### PR TITLE
为了解决使用 hexstring 和 address 不方便的问题做准备

### DIFF
--- a/Neo.SmartContract.Framework/Helper.cs
+++ b/Neo.SmartContract.Framework/Helper.cs
@@ -20,16 +20,16 @@ namespace Neo.SmartContract.Framework
         [OpCode(OpCode.CAT)]
         public extern static byte[] Concat(this byte[] first, byte[] second);
 
+        [NonemitWithConvert(ConvertMethod.HexToBytes)]
+        public extern static byte[] HexToBytes(this string hex);
+
         [OpCode(OpCode.SUBSTR)]
         public extern static byte[] Range(this byte[] source, int index, int count);
 
         [OpCode(OpCode.LEFT)]
         public extern static byte[] Take(this byte[] source, int count);
 
-        [NonemitWithConvert(ConvertMethod.HexString2Bytes)]
-        public extern static byte[] HexString2Bytes(string hex);
-
-        [NonemitWithConvert(ConvertMethod.AddressString2ScriptHashBytes)]
-        public extern static byte[] AddressString2ScriptHashBytes(string address);
+        [NonemitWithConvert(ConvertMethod.ToScriptHash)]
+        public extern static byte[] ToScriptHash(this string address);
     }
 }

--- a/Neo.SmartContract.Framework/Helper.cs
+++ b/Neo.SmartContract.Framework/Helper.cs
@@ -25,5 +25,11 @@ namespace Neo.SmartContract.Framework
 
         [OpCode(OpCode.LEFT)]
         public extern static byte[] Take(this byte[] source, int count);
+
+        [NonemitWithConvert(ConvertMethod.HexString2Bytes)]
+        public extern static byte[] HexString2Bytes(string hex);
+
+        [NonemitWithConvert(ConvertMethod.AddressString2ScriptHashBytes)]
+        public extern static byte[] AddressString2ScriptHashBytes(string address);
     }
 }

--- a/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
+++ b/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Globalization;
+
+namespace Neo.SmartContract.Framework
+{
+    public enum ConvertMethod
+    {
+        HexString2Bytes,
+        AddressString2ScriptHashBytes,
+    }
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+    public class NonemitWithConvertAttribute : Attribute
+    {
+        public ConvertMethod method { get; }
+
+        public NonemitWithConvertAttribute(ConvertMethod method)
+        {
+            this.method = method;
+        }
+    }
+}

--- a/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
+++ b/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Globalization;
 
 namespace Neo.SmartContract.Framework
 {
     public enum ConvertMethod
     {
-        HexString2Bytes,
-        AddressString2ScriptHashBytes,
+        HexToBytes,
+        ToScriptHash,
     }
+
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
     public class NonemitWithConvertAttribute : Attribute
     {

--- a/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
+++ b/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
@@ -11,11 +11,11 @@ namespace Neo.SmartContract.Framework
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
     public class NonemitWithConvertAttribute : Attribute
     {
-        public ConvertMethod method { get; }
+        public ConvertMethod Method { get; }
 
         public NonemitWithConvertAttribute(ConvertMethod method)
         {
-            this.method = method;
+            this.Method = method;
         }
     }
 }


### PR DESCRIPTION
将在编译器增加两种语法:

public static byte[] address = Helper.AddressString2ScriptHashBytes("ALjSnMZidJqd18iQaoCgFun6iqWRm2cVtj");
public static byte[] data = Helper.HexString2Bytes("a1b1a2b2");