### PR TITLE
Added Account.IsStandard method

### DIFF
--- a/Neo.SmartContract.Framework/Services/Neo/Account.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Account.cs
@@ -16,5 +16,8 @@
 
         [Syscall("Neo.Account.GetBalance")]
         public extern long GetBalance(byte[] asset_id);
+        
+        [Syscall("Neo.Account.IsStandard")]
+        public static extern bool IsStandard(byte[] scripthash);
     }
 }


### PR DESCRIPTION
This method is currently missing in C# API. I decided to create it static because it does not depend on Account object itself, only a scripthash.