### PR TITLE
Safe attribution for byte[] element

### DIFF
--- a/Neo.SmartContract.Framework/Helper.cs
+++ b/Neo.SmartContract.Framework/Helper.cs
@@ -7,6 +7,18 @@ namespace Neo.SmartContract.Framework
     public static class Helper
     {
         /// <summary>
+        /// Converts byte to byte[].
+        /// </summary>
+        [Nonemit]
+        public extern static byte[] AsByteArray(this byte source);
+
+        /// <summary>
+        /// Converts sbyte to byte[].
+        /// </summary>
+        [Nonemit]
+        public extern static byte[] AsByteArray(this sbyte source);
+       
+        /// <summary>
         /// Converts sbyte[] to byte[].
         /// </summary>
         [Nonemit]
@@ -158,6 +170,14 @@ namespace Neo.SmartContract.Framework
                 source = source - 256;
             return (byte) (source + 0);
         }
+        
+        /// <summary>
+        /// Safely performs attribution v[x] = b. Faults if x < 0 or x >= v.Length
+        /// </summary>
+        public static byte[] Set(this byte[] v, int x, sbyte b)
+        {
+            return v.Take(x).Concat(b.AsByteArray()).Concat(v.Last(v.Length - x - 1));
+        }
 
         [OpCode(OpCode.CAT)]
         public extern static byte[] Concat(this byte[] first, byte[] second);
@@ -168,8 +188,17 @@ namespace Neo.SmartContract.Framework
         [OpCode(OpCode.SUBSTR)]
         public extern static byte[] Range(this byte[] source, int index, int count);
 
+        /// <summary>
+        /// Returns byte[] with first 'count' elements from 'source'. Faults if count < 0
+        /// </summary>
         [OpCode(OpCode.LEFT)]
         public extern static byte[] Take(this byte[] source, int count);
+        
+        /// <summary>
+        /// Returns byte[] with last 'count' elements from 'source'. Faults if count < 0
+        /// </summary>
+        [OpCode(OpCode.RIGHT)]
+        public extern static byte[] Last(this byte[] source, int count);
 
         [Nonemit]
         public extern static Delegate ToDelegate(this byte[] source);


### PR DESCRIPTION
Proposed attribution for byte[] elements. Current byte[] v attribution v[ index ] = b will fail, because compiler considers byte[] a reference type (just like object[]), but neo-vm treats it as a value type.
This PR allows the following attribution to work:
```cs
   byte[] v = // ... initialization
   v[ index ] = b; // compiles, but fails on practice (value is not stored)
   v = v.Set(index, b); // works
```