### PR TITLE
Allowing multiple syscalls

### DIFF
--- a/Neo.SmartContract.Framework/Services/Neo/Storage.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Storage.cs
@@ -88,97 +88,73 @@ namespace Neo.SmartContract.Framework.Services.Neo
         /// <summary>
         /// Returns the byte[] value corresponding to given byte[] key for current Storage context
         /// </summary>
-        public static byte[] Get(byte[] key)
-        {
-            return Get(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Get")]
+        public static extern byte[] Get(byte[] key);
 
         /// <summary>
         /// Returns the byte[] value corresponding to given string key for current Storage context
         /// </summary>
-        public static byte[] Get(string key)
-        {
-            return Get(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Get")]
+        public static extern byte[] Get(string key);
 
         /// <summary>
         /// Writes byte[] value on byte[] key for current Storage context
         /// </summary>
-        public static void Put(byte[] key, byte[] value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
+        public static extern void Put(byte[] key, byte[] value);
 
         /// <summary>
         /// Writes BignInteger value on byte[] key for current Storage context
         /// </summary>
-        public static void Put(byte[] key, BigInteger value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
+        public static extern void Put(byte[] key, BigInteger value);
 
         /// <summary>
         /// Writes string value on byte[] key for current Storage context
         /// </summary>
-        public static void Put(byte[] key, string value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
+        public static extern void Put(byte[] key, string value);
 
         /// <summary>
         /// Writes byte[] value on string key for current Storage context
         /// </summary>
-        public static void Put(string key, byte[] value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
+        public static extern void Put(string key, byte[] value);
 
         /// <summary>
         /// Writes BigInteger value on string key for current Storage context
         /// </summary>
-        public static void Put(string key, BigInteger value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
+        public static extern void Put(string key, BigInteger value);
 
         /// <summary>
         /// Writes string value on string key for current Storage context
         /// </summary>
-        public static void Put(string key, string value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
+        public static extern void Put(string key, string value);
 
         /// <summary>
         /// Deletes byte[] key from current Storage context
         /// </summary>
-        public static void Delete(byte[] key)
-        {
-            Delete(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Delete")]
+        public static extern void Delete(byte[] key);
 
         /// <summary>
         /// Deletes string key from given Storage context
         /// </summary>
-        public static void Delete(string key)
-        {
-            Delete(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Delete")]
+        public static extern void Delete(string key);
 
         /// <summary>
         /// Returns a byte[] to byte[] iterator for a byte[] prefix on current Storage context
         /// </summary>
-        public static Iterator<byte[], byte[]> Find(byte[] prefix)
-        {
-            return Find(CurrentContext, prefix);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Find")]
+        public static extern Iterator<byte[], byte[]> Find(byte[] prefix);
 
         /// <summary>
         /// Returns a string to byte[] iterator for a string prefix on current Storage context
         /// </summary>
-        public static Iterator<string, byte[]> Find(string prefix)
-        {
-            return Find(CurrentContext, prefix);
-        }
+        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Find")]
+        public static extern Iterator<string, byte[]> Find(string prefix);
     }
 }

--- a/Neo.SmartContract.Framework/SyscallAttribute.cs
+++ b/Neo.SmartContract.Framework/SyscallAttribute.cs
@@ -5,11 +5,11 @@ namespace Neo.SmartContract.Framework
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor)]
     public class SyscallAttribute : Attribute
     {
-        public string Method { get; }
+        public string[] Methods { get; }
 
-        public SyscallAttribute(string method)
+        public SyscallAttribute(params string[] methods)
         {
-            this.Method = method;
+            this.Methods = methods;
         }
     }
 }


### PR DESCRIPTION
This allows multiple syscalls, example:
```cs
        [Syscall("Neo.Storage.GetContext", "Neo.Storage.Put")]
        Put(string key, string value);
```

Now, Storage Put for hello world will be simple and efficient :)