### PR TITLE
Mix attributes (OpCall/Syscall)

### DIFF
--- a/Neo.SmartContract.Framework/Helper.cs
+++ b/Neo.SmartContract.Framework/Helper.cs
@@ -9,32 +9,32 @@ namespace Neo.SmartContract.Framework
         /// <summary>
         /// Converts byte to byte[].
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static byte[] AsByteArray(this byte source);
 
         /// <summary>
         /// Converts sbyte to byte[].
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static byte[] AsByteArray(this sbyte source);
 
         /// <summary>
         /// Converts sbyte[] to byte[].
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static byte[] AsByteArray(this sbyte[] source);
 
         /// <summary>
         /// Converts byte[] to sbyte[].
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static sbyte[] AsSbyteArray(this byte[] source);
 
         /// <summary>
         /// Converts byte[] to BigInteger. No guarantees are assumed regarding BigInteger working range.
         /// Examples: [0x0a] -> 10; [0x80] -> -128; [] -> 0; [0xff00] -> 255
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static BigInteger AsBigInteger(this byte[] source);
 
         /// <summary>
@@ -51,19 +51,19 @@ namespace Neo.SmartContract.Framework
         /// Converts BigInteger to byte[]. No guarantees are assumed regarding BigInteger working range.
         /// Examples: 10 -> [0x0a]; 10 -> [0x0a00]; -128 -> [0x80]; -128 -> [0x80ff]; 0 -> []; 0 -> [0x00]; 255 -> [0xff00]
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static byte[] AsByteArray(this BigInteger source);
 
         /// <summary>
         /// Converts string to byte[]. Examples: "hello" -> [0x68656c6c6f]; "" -> []; "Neo" -> [0x4e656f]
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static byte[] AsByteArray(this string source);
 
         /// <summary>
         /// Converts byte[] to string. Examples: [0x68656c6c6f] -> "hello"; [] -> ""; [0x4e656f] -> "Neo"
         /// </summary>
-        [OpCode]
+        [Nonemit]
         public extern static string AsString(this byte[] source);
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Neo.SmartContract.Framework
             return source;
         }
 
-        [OpCode]
+        [Nonemit]
         public extern static Delegate ToDelegate(this byte[] source);
 
         /// <summary>

--- a/Neo.SmartContract.Framework/Helper.cs
+++ b/Neo.SmartContract.Framework/Helper.cs
@@ -88,7 +88,11 @@ namespace Neo.SmartContract.Framework
         /// Converts and ensures parameter source is sbyte (range 0x00 to 0xff); faults otherwise.
         /// Examples: 255 -> fault; -128 -> [0x80]; 0 -> [0x00]; 10 -> [0x0a]; 127 -> [0x7f]; 128 -> fault
         /// </summary>
-        [OpCode(OpCode.DUP, OpCode.ARRAYSIZE, OpCode.PUSH1, OpCode.NUMEQUAL, OpCode.THROWIFNOT)]
+        [OpCode(OpCode.DUP)]
+        [OpCode(OpCode.ARRAYSIZE)]
+        [OpCode(OpCode.PUSH1)]
+        [OpCode(OpCode.NUMEQUAL)]
+        [OpCode(OpCode.THROWIFNOT)]
         public extern static sbyte AsSbyte(this BigInteger source);
         //{
         //    Assert(source.AsByteArray().Length == 1);
@@ -99,7 +103,11 @@ namespace Neo.SmartContract.Framework
         /// Converts and ensures parameter source is sbyte (range 0x00 to 0xff); faults otherwise.
         /// Examples: 255 -> fault; -128 -> [0x80]; 0 -> [0x00]; 10 -> [0x0a]; 127 -> [0x7f]; 128 -> fault
         /// </summary>
-        [OpCode(OpCode.DUP, OpCode.ARRAYSIZE, OpCode.PUSH1, OpCode.NUMEQUAL, OpCode.THROWIFNOT)]
+        [OpCode(OpCode.DUP)]
+        [OpCode(OpCode.ARRAYSIZE)]
+        [OpCode(OpCode.PUSH1)]
+        [OpCode(OpCode.NUMEQUAL)]
+        [OpCode(OpCode.THROWIFNOT)]
         public extern static sbyte AsSbyte(this int source);
         //{
         //    Assert(((BigInteger)source).AsByteArray().Length == 1);
@@ -110,7 +118,11 @@ namespace Neo.SmartContract.Framework
         /// Converts and ensures parameter source is byte (range 0x00 to 0xff); faults otherwise.
         /// Examples: 255 -> fault; -128 -> [0x80]; 0 -> [0x00]; 10 -> [0x0a]; 127 -> [0x7f]; 128 -> fault
         /// </summary>
-        [OpCode(OpCode.DUP, OpCode.ARRAYSIZE, OpCode.PUSH1, OpCode.NUMEQUAL, OpCode.THROWIFNOT)]
+        [OpCode(OpCode.DUP)]
+        [OpCode(OpCode.ARRAYSIZE)]
+        [OpCode(OpCode.PUSH1)]
+        [OpCode(OpCode.NUMEQUAL)]
+        [OpCode(OpCode.THROWIFNOT)]
         public extern static byte AsByte(this BigInteger source);
         //{
         //    Assert(source.AsByteArray().Length == 1);
@@ -121,7 +133,11 @@ namespace Neo.SmartContract.Framework
         /// Converts and ensures parameter source is byte (range 0x00 to 0xff); faults otherwise.
         /// Examples: 255 -> fault; -128 -> [0x80]; 0 -> [0x00]; 10 -> [0x0a]; 127 -> [0x7f]; 128 -> fault
         /// </summary>
-        [OpCode(OpCode.DUP, OpCode.ARRAYSIZE, OpCode.PUSH1, OpCode.NUMEQUAL, OpCode.THROWIFNOT)]
+        [OpCode(OpCode.DUP)]
+        [OpCode(OpCode.ARRAYSIZE)]
+        [OpCode(OpCode.PUSH1)]
+        [OpCode(OpCode.NUMEQUAL)]
+        [OpCode(OpCode.THROWIFNOT)]
         public extern static byte AsByte(this int source);
         //{
         //    Assert(((BigInteger)source).AsByteArray().Length == 1);

--- a/Neo.SmartContract.Framework/Helper.cs
+++ b/Neo.SmartContract.Framework/Helper.cs
@@ -41,7 +41,8 @@ namespace Neo.SmartContract.Framework
         /// Converts byte[] to BigInteger and ensures output is within BigInteger range (32-bytes) in standard format; faults otherwise.
         /// Examples: -128 [0x80ff] -> -128 [0x80]; 0 [0x000000] -> 0 [0x00]; 0 [] -> 0 [0x00]; 255 [0xff00000000000000] -> 255 [0xff00]
         /// </summary>
-        [OpCode(OpCode.PUSH0, OpCode.ADD)]
+        [OpCode(OpCode.PUSH0)]
+        [OpCode(OpCode.ADD)]
         public extern static BigInteger ToBigInteger(this byte[] source);
         //{
         //    return source.AsBigInteger() + 0;

--- a/Neo.SmartContract.Framework/NonemitAttribute.cs
+++ b/Neo.SmartContract.Framework/NonemitAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+namespace Neo.SmartContract.Framework
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor)]
+    public class NonemitAttribute : Attribute
+    {
+    }
+}

--- a/Neo.SmartContract.Framework/OpCodeAttribute.cs
+++ b/Neo.SmartContract.Framework/OpCodeAttribute.cs
@@ -1,16 +1,31 @@
-﻿using Neo.VM;
+using Neo.VM;
 using System;
 
 namespace Neo.SmartContract.Framework
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, AllowMultiple = true)]
     public class OpCodeAttribute : Attribute
     {
-        public OpCode[] OpCodes { get; }
+        /// <summary>
+        /// opcode
+        /// </summary>
+        public OpCode OpCode { get; }
 
-        public OpCodeAttribute(params OpCode[] opcodes)
+        /// <summary>
+        /// opcode data (can be hex "ab01ab" or ascii "Runtime.Notify")
+        /// </summary>
+        public string OpData { get; }
+
+        /// <summary>
+        /// if opcode data is Hex or ascii
+        /// </summary>
+        public bool IsHex { get; }
+
+        public OpCodeAttribute(OpCode opCode, string opData = "", bool isHex = false)
         {
-            this.OpCodes = opcodes;
+            OpCode = opCode;
+            OpData = opData;
+            IsHex = isHex;
         }
     }
 }

--- a/Neo.SmartContract.Framework/Services/Neo/Storage.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Storage.cs
@@ -88,97 +88,85 @@ namespace Neo.SmartContract.Framework.Services.Neo
         /// <summary>
         /// Returns the byte[] value corresponding to given byte[] key for current Storage context
         /// </summary>
-        public static byte[] Get(byte[] key)
-        {
-            return Get(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Get")]
+        public static byte[] Get(byte[] key);
 
         /// <summary>
         /// Returns the byte[] value corresponding to given string key for current Storage context
         /// </summary>
-        public static byte[] Get(string key)
-        {
-            return Get(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Get")]
+        public static byte[] Get(string key);
 
         /// <summary>
         /// Writes byte[] value on byte[] key for current Storage context
         /// </summary>
-        public static void Put(byte[] key, byte[] value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Put")]
+        public static void Put(byte[] key, byte[] value);
 
         /// <summary>
-        /// Writes BignInteger value on byte[] key for current Storage context
+        /// Writes BigInteger value on byte[] key for current Storage context
         /// </summary>
-        public static void Put(byte[] key, BigInteger value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Put")]
+        public static void Put(byte[] key, BigInteger value);
 
         /// <summary>
         /// Writes string value on byte[] key for current Storage context
         /// </summary>
-        public static void Put(byte[] key, string value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Put")]
+        public static void Put(byte[] key, string value);
 
         /// <summary>
         /// Writes byte[] value on string key for current Storage context
         /// </summary>
-        public static void Put(string key, byte[] value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Put")]
+        public static void Put(string key, byte[] value);
 
         /// <summary>
         /// Writes BigInteger value on string key for current Storage context
         /// </summary>
-        public static void Put(string key, BigInteger value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Put")]
+        public static void Put(string key, BigInteger value);
 
         /// <summary>
         /// Writes string value on string key for current Storage context
         /// </summary>
-        public static void Put(string key, string value)
-        {
-            Put(CurrentContext, key, value);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Put")]
+        public static void Put(string key, string value);
 
         /// <summary>
         /// Deletes byte[] key from current Storage context
         /// </summary>
-        public static void Delete(byte[] key)
-        {
-            Delete(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Delete")]
+        public static void Delete(byte[] key);
 
         /// <summary>
         /// Deletes string key from given Storage context
         /// </summary>
-        public static void Delete(string key)
-        {
-            Delete(CurrentContext, key);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Delete")]
+        public static void Delete(string key);
 
         /// <summary>
         /// Returns a byte[] to byte[] iterator for a byte[] prefix on current Storage context
         /// </summary>
-        public static Iterator<byte[], byte[]> Find(byte[] prefix)
-        {
-            return Find(CurrentContext, prefix);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Find")]
+        public static Iterator<byte[], byte[]> Find(byte[] prefix);
 
         /// <summary>
         /// Returns a string to byte[] iterator for a string prefix on current Storage context
         /// </summary>
-        public static Iterator<string, byte[]> Find(string prefix)
-        {
-            return Find(CurrentContext, prefix);
-        }
+        [Syscall("Neo.Storage.GetContext")]
+        [Syscall("Neo.Storage.Find")]
+        public static Iterator<string, byte[]> Find(string prefix);
     }
 }

--- a/Neo.SmartContract.Framework/Services/Neo/Storage.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Storage.cs
@@ -90,83 +90,83 @@ namespace Neo.SmartContract.Framework.Services.Neo
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Get")]
-        public static byte[] Get(byte[] key);
+        public static extern byte[] Get(byte[] key);
 
         /// <summary>
         /// Returns the byte[] value corresponding to given string key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Get")]
-        public static byte[] Get(string key);
+        public static extern byte[] Get(string key);
 
         /// <summary>
         /// Writes byte[] value on byte[] key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Put")]
-        public static void Put(byte[] key, byte[] value);
+        public static extern void Put(byte[] key, byte[] value);
 
         /// <summary>
         /// Writes BigInteger value on byte[] key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Put")]
-        public static void Put(byte[] key, BigInteger value);
+        public static extern void Put(byte[] key, BigInteger value);
 
         /// <summary>
         /// Writes string value on byte[] key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Put")]
-        public static void Put(byte[] key, string value);
+        public static extern void Put(byte[] key, string value);
 
         /// <summary>
         /// Writes byte[] value on string key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Put")]
-        public static void Put(string key, byte[] value);
+        public static extern void Put(string key, byte[] value);
 
         /// <summary>
         /// Writes BigInteger value on string key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Put")]
-        public static void Put(string key, BigInteger value);
+        public static extern void Put(string key, BigInteger value);
 
         /// <summary>
         /// Writes string value on string key for current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Put")]
-        public static void Put(string key, string value);
+        public static extern void Put(string key, string value);
 
         /// <summary>
         /// Deletes byte[] key from current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Delete")]
-        public static void Delete(byte[] key);
+        public static extern void Delete(byte[] key);
 
         /// <summary>
         /// Deletes string key from given Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Delete")]
-        public static void Delete(string key);
+        public static extern void Delete(string key);
 
         /// <summary>
         /// Returns a byte[] to byte[] iterator for a byte[] prefix on current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Find")]
-        public static Iterator<byte[], byte[]> Find(byte[] prefix);
+        public static extern Iterator<byte[], byte[]> Find(byte[] prefix);
 
         /// <summary>
         /// Returns a string to byte[] iterator for a string prefix on current Storage context
         /// </summary>
         [Syscall("Neo.Storage.GetContext")]
         [Syscall("Neo.Storage.Find")]
-        public static Iterator<string, byte[]> Find(string prefix);
+        public static extern Iterator<string, byte[]> Find(string prefix);
     }
 }

--- a/Neo.SmartContract.Framework/SyscallAttribute.cs
+++ b/Neo.SmartContract.Framework/SyscallAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Neo.SmartContract.Framework
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, AllowMultiple = true)]
     public class SyscallAttribute : Attribute
     {
         public string Method { get; }


### PR DESCRIPTION
This change allows to mix OpCode attribute with Syscall attribute: https://github.com/neo-project/neo-compiler/pull/144

Example (prints Height and Height+1):
```cs
        [Syscall("Neo.Blockchain.GetHeight")]
        [OpCode(OpCode.INC)]
        public extern static int NextHeight();
        
        public static void Main()
        {
            uint x = Blockchain.GetHeight();
            Runtime.Notify(x);
            Runtime.Notify(NextHeight());
        }
```