### PR TITLE
Change support to dotnet 2.0

### DIFF
--- a/Neo.SmartContract.Framework/Neo.SmartContract.Framework.csproj
+++ b/Neo.SmartContract.Framework/Neo.SmartContract.Framework.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Neo.SmartContract.Framework</AssemblyTitle>
     <Version>2.9.3</Version>
     <Authors>The Neo Project</Authors>
-    <TargetFrameworks>netstandard1.6;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Neo.SmartContract.Framework</AssemblyName>
     <PackageId>Neo.SmartContract.Framework</PackageId>
     <PackageTags>NEO;AntShares;Blockchain;Smart Contract;VM</PackageTags>


### PR DESCRIPTION
dotnet 2.0 is the only official support we have for linux (not 4.0), could we adopt this as the standard?