### PR TITLE
change the way how unittest execute contract

### DIFF
--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
@@ -320,8 +320,29 @@ namespace Neo.Compiler.MSIL
                 _Insert1(VM.OpCode.SETITEM, null, to);
             }
         }
+        private void _insertBeginCodeEntry(NeoMethod to)
+        {
+            _InsertPush(2, "begincode", to);
+            _Insert1(VM.OpCode.NEWARRAY, "", to);
+            _Insert1(VM.OpCode.TOALTSTACK, "", to);
+            //移动参数槽位
+            for (var i = 0; i < 2; i++)
+            {
+                //getarray
+                _Insert1(VM.OpCode.FROMALTSTACK, "set param:" + i, to);
+                _Insert1(VM.OpCode.DUP, null, to);
+                _Insert1(VM.OpCode.TOALTSTACK, null, to);
 
-        private void _insertEndCode(ILMethod from, NeoMethod to, OpCode src)
+                _InsertPush(i, "", to); //Array pos
+
+                _InsertPush(2, "", to); //Array item
+                _Insert1(VM.OpCode.ROLL, null, to);
+
+                _Insert1(VM.OpCode.SETITEM, null, to);
+            }
+        }
+
+        private void _insertEndCode(NeoMethod to, OpCode src)
         {
             ////占位不谢
             _Convert1by1(VM.OpCode.NOP, src, to);

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
@@ -81,7 +81,6 @@ namespace Neo.Compiler.MSIL
                 _code.debugILCode = src.code.ToString();
             }
 
-
             addr++;
 
             _code.code = code;
@@ -170,7 +169,8 @@ namespace Neo.Compiler.MSIL
             {
                 var call = from.body_Codes[next];
                 if (call.tokenMethod == "System.Numerics.BigInteger System.Numerics.BigInteger::op_Implicit(System.UInt64)")
-                {//如果是ulong转型到biginteger，需要注意
+                {
+                    //如果是ulong转型到biginteger，需要注意
                     ulong v = (ulong)i;
                     outv = v;
                     _ConvertPush(outv.ToByteArray(), src, to);
@@ -178,13 +178,10 @@ namespace Neo.Compiler.MSIL
                 }
             }
 
-
-            {
-                _ConvertPush(i, src, to);
-                return 0;
-            }
-
+            _ConvertPush(i, src, to);
+            return 0;
         }
+
         private int _ConvertPushI4WithConv(ILMethod from, int i, OpCode src, NeoMethod to)
         {
             var next = from.GetNextCodeAddr(src.addr);
@@ -227,8 +224,8 @@ namespace Neo.Compiler.MSIL
                 _ConvertPush(i, src, to);
                 return 0;
             }
-
         }
+
         private void _insertSharedStaticVarCode(NeoMethod to)
         {
             _InsertPush(this.outModule.mapFields.Count, "static var", to);
@@ -284,7 +281,6 @@ namespace Neo.Compiler.MSIL
                     _Insert1(VM.OpCode.SETITEM, "", to);
                 }
             }
-
         }
 
         private void _insertBeginCode(ILMethod from, NeoMethod to)

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -230,7 +230,8 @@ namespace Neo.Compiler.MSIL
             }
             if (mainmethod == "")
             {
-                throw new Exception("Can't find EntryPoint,Check it.");
+                mainmethod = InsertAutoEntry();
+                logger.Log("Auto Insert entrypoint.");
             }
             else
             {
@@ -247,6 +248,28 @@ namespace Neo.Compiler.MSIL
             //this.outModule.Build();
             return outModule;
         }
+        private string InsertAutoEntry()
+        {
+
+            string name = "::autoentrypoint";
+            NeoMethod autoEntry = new NeoMethod();
+            autoEntry._namespace = "";
+            autoEntry.name = "Main";
+            autoEntry.displayName = "Main";
+            autoEntry.paramtypes.Add(new NeoParam(name, "string"));
+            autoEntry.paramtypes.Add(new NeoParam(name, "array"));
+            autoEntry.returntype = "object";
+            autoEntry.body_Codes[0] = new NeoCode();
+            autoEntry.body_Codes[0].addr = 0;
+            autoEntry.body_Codes[0].code = VM.OpCode.NOP;
+            autoEntry.funcaddr = 0;
+
+            outModule.mapMethods[name] = autoEntry;
+
+            return name;
+
+        }
+
         private void LinkCode(string main)
         {
             if (this.outModule.mapMethods.ContainsKey(main) == false)
@@ -1040,7 +1063,7 @@ namespace Neo.Compiler.MSIL
                             _Convert1by1(VM.OpCode.DUPFROMALTSTACKBOTTOM, null, to);
                             _ConvertPush(field.index, null, to);
 
-                            _Insert1(VM.OpCode.PICKITEM,"",to);
+                            _Insert1(VM.OpCode.PICKITEM, "", to);
 
                             //throw new Exception("Just allow defined a static variable with readonly." + d.FullName);
                         }
@@ -1071,7 +1094,7 @@ namespace Neo.Compiler.MSIL
                         //_Insert1(VM.OpCode.RET, "", to);
                     }
                     break;
-               
+
                 default:
 #if WITHPDB
                     logger.Log("unsupported instruction " + src.code + "\r\n   in: " + to.name + "\r\n");

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -108,8 +108,8 @@ namespace Neo.Compiler.MSIL
                     nm.isPublic = m.Value.method.IsPublic;
                     this.methodLink[m.Value] = nm;
                     outModule.mapMethods[nm.name] = nm;
-
                 }
+
                 foreach (var e in t.Value.fields)
                 {
                     if (e.Value.isEvent)
@@ -130,7 +130,6 @@ namespace Neo.Compiler.MSIL
                         var field = new NeoField(e.Key, e.Value.type, _fieldindex);
                         outModule.mapFields[e.Value.field.FullName] = field;
                     }
-
                 }
             }
 
@@ -156,7 +155,6 @@ namespace Neo.Compiler.MSIL
                         continue;//event 自动生成的代码，不要
 
                     var nm = this.methodLink[m.Value];
-
 
                     //try
                     {
@@ -248,9 +246,9 @@ namespace Neo.Compiler.MSIL
             //this.outModule.Build();
             return outModule;
         }
+
         private string InsertAutoEntry()
         {
-
             string name = "::autoentrypoint";
             NeoMethod autoEntry = new NeoMethod();
             autoEntry._namespace = "";
@@ -264,14 +262,16 @@ namespace Neo.Compiler.MSIL
             outModule.mapMethods[name] = autoEntry;
 
             return name;
-
         }
+
         private void FillEntryMethod(NeoMethod to)
         {
             this.addr = 0;
             this.addrconv.Clear();
 
+#if DEBUG
             _Insert1(VM.OpCode.NOP, "this is a debug code.", to);
+#endif
             _insertSharedStaticVarCode(to);
 
             _insertBeginCodeEntry(to);
@@ -332,10 +332,12 @@ namespace Neo.Compiler.MSIL
                 Int16 addroff = (Int16)(nextaddr - addr);
                 op.bytes = BitConverter.GetBytes(addroff);
             }
-
+#if DEBUG
             _Insert1(VM.OpCode.NOP, "this is a end debug code.", to);
+#endif
             ConvertAddrInMethod(to);
         }
+
         private void LinkCode(string main)
         {
             if (this.outModule.mapMethods.ContainsKey(main) == false)
@@ -419,8 +421,6 @@ namespace Neo.Compiler.MSIL
 
         private void ConvertMethod(ILMethod from, NeoMethod to)
         {
-
-
             this.addr = 0;
             this.addrconv.Clear();
 
@@ -513,6 +513,7 @@ namespace Neo.Compiler.MSIL
             var n = BitConverter.ToInt32(target, 0);
             return n;
         }
+
         private void ConvertAddrInMethod(NeoMethod to)
         {
             foreach (var c in to.body_Codes.Values)
@@ -531,12 +532,10 @@ namespace Neo.Compiler.MSIL
                     {
                         throw new Exception("cannot convert addr in: " + to.name + "\r\n");
                     }
-
-
-
                 }
             }
         }
+
         private int ConvertCode(ILMethod method, OpCode src, NeoMethod to)
         {
             int skipcount = 0;
@@ -1054,7 +1053,6 @@ namespace Neo.Compiler.MSIL
                     break;
 
                 case CodeEx.Ldsfld:
-
                     {
                         _Convert1by1(VM.OpCode.NOP, src, to);
                         var d = src.tokenUnknown as Mono.Cecil.FieldDefinition;
@@ -1100,7 +1098,6 @@ namespace Neo.Compiler.MSIL
                             break;
                         }
 
-
                         //如果是调用event导致的这个代码，只找出他的名字
                         if (d.DeclaringType.HasEvents)
                         {
@@ -1123,7 +1120,8 @@ namespace Neo.Compiler.MSIL
                             }
                         }
                         else
-                        {//如果走到这里，是一个静态成员，但是没有添加readonly 表示
+                        {
+                            //如果走到这里，是一个静态成员，但是没有添加readonly 表示
                             //lights add,need static var load function
                             var field = this.outModule.mapFields[d.FullName];
                             _Convert1by1(VM.OpCode.DUPFROMALTSTACKBOTTOM, null, to);
@@ -1143,14 +1141,11 @@ namespace Neo.Compiler.MSIL
                         _Convert1by1(VM.OpCode.DUPFROMALTSTACKBOTTOM, null, to);
                         _ConvertPush(field.index, null, to);
 
-
                         //got v to top
                         _ConvertPush(2, null, to);
                         _Convert1by1(VM.OpCode.ROLL, null, to);
 
-
                         _Insert1(VM.OpCode.SETITEM, "", to);
-
                     }
                     break;
                 case CodeEx.Throw:
@@ -1172,6 +1167,5 @@ namespace Neo.Compiler.MSIL
 
             return skipcount;
         }
-
     }
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_autoentrypoint.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_autoentrypoint.cs
@@ -20,12 +20,18 @@ namespace Neo.Compiler.MSIL.TestClasses
         //        return null;
         //    }
         //}
+
+        private static bool privateMethod()
+        {
+            return true;
+        }
+
         public static byte[] call01()
         {
             var nb = new byte[] { 1, 2, 3, 4 };
             return nb;
         }
-        public static void call02(string a,int b)
+        public static void call02(string a, int b)
         {
             Neo.SmartContract.Framework.Services.Neo.Runtime.Log(a);
         }

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_autoentrypoint.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_autoentrypoint.cs
@@ -1,0 +1,33 @@
+﻿using Neo.SmartContract.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Neo.Compiler.MSIL.TestClasses
+{
+    class Contract_autoentrypoint : SmartContract.Framework.SmartContract
+    {
+        //there is no main here, it can be auto generation.
+        //object Main(string name,object[])
+        //{
+        //    if(name=="call01")
+        //    {
+        //        return call01();
+        //    }
+        //    if(name=="call02")
+        //    {
+        //        call02(_params[0],params[1]);
+        //        return null;
+        //    }
+        //}
+        public static byte[] call01()
+        {
+            var nb = new byte[] { 1, 2, 3, 4 };
+            return nb;
+        }
+        public static void call02(string a,int b)
+        {
+            Neo.SmartContract.Framework.Services.Neo.Runtime.Log(a);
+        }
+    }
+}

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest1.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest1.cs
@@ -56,11 +56,10 @@ namespace Neo.Compiler.MSIL
             testengine.AddEntryScript("./TestClasses/Contract1.cs");
 
 
-            StackItem[] _params = new StackItem[] { "testfunc", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("testfunc").Run();
             StackItem wantresult = new byte[] { 1, 2, 3, 4 };
 
-            var bequal = wantresult.Equals(result.Pop());
+            var bequal = wantresult.Equals(result);
             Assert.IsTrue(bequal);
         }
         [TestMethod]
@@ -70,11 +69,10 @@ namespace Neo.Compiler.MSIL
             testengine.AddEntryScript("./TestClasses/Contract2.cs");
 
 
-            StackItem[] _params = new StackItem[] { "testfunc", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("testfunc").Run();
             StackItem wantresult = 3;
 
-            var bequal = wantresult.Equals(result.Pop());
+            var bequal = wantresult.Equals(result);
             Assert.IsTrue(bequal);
         }
     }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_Appcall.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_Appcall.cs
@@ -16,11 +16,10 @@ namespace Neo.Compiler.MSIL
             //will appcall 0102030405060708090A0102030405060708090A
             testengine.AddEntryScript("./TestClasses/Contract_appcall.cs");
 
-            StackItem[] _params = new StackItem[] { "testfunc", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("testfunc").Run();
             StackItem wantresult = new byte[] { 1, 2, 3, 4 };
 
-            var bequal = wantresult.Equals(result.Pop());
+            var bequal = wantresult.Equals(result);
             Assert.IsTrue(bequal);
 
         }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
@@ -18,11 +18,10 @@ namespace Neo.Compiler.MSIL
 
             testengine.scriptEntry.DumpAVM();
 
-            StackItem[] _params = new StackItem[] { "call01", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("call01").Run();
             StackItem wantresult = new byte[] { 1, 2, 3, 4 };
 
-            var bequal = wantresult.Equals(result.Pop());
+            var bequal = wantresult.Equals(result);
             Assert.IsTrue(bequal);
         }
         [TestMethod]
@@ -33,10 +32,9 @@ namespace Neo.Compiler.MSIL
 
             testengine.scriptEntry.DumpAVM();
 
-            StackItem[] _params = new StackItem[] { "call02", new StackItem[] { "hello", 33 } };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("call02").Run("hello", 33);
             StackItem wantresult = new byte[0];
-            var bequal = wantresult.Equals(result.Pop());
+            var bequal = wantresult.Equals(result);
 
             //if your function return is void,when auto generate a entry point,it always return new byte[0];
             // object Main(string,object[]) must be return sth.

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
@@ -30,8 +30,7 @@ namespace Neo.Compiler.MSIL
 
             testengine.scriptEntry.DumpAVM();
 
-            StackItem[] _params = new StackItem[] { "privateMethod", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.ExecuteContract("privateMethod", new StackItem[0]);
 
             Assert.AreEqual(0, result.Count);
         }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.MSIL.Utils;
 using Neo.VM;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Neo.Compiler.MSIL
 {
@@ -24,6 +21,21 @@ namespace Neo.Compiler.MSIL
             var bequal = wantresult.Equals(result);
             Assert.IsTrue(bequal);
         }
+
+        [TestMethod]
+        public void Test_AutoEntry_private()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_autoentrypoint.cs");
+
+            testengine.scriptEntry.DumpAVM();
+
+            StackItem[] _params = new StackItem[] { "privateMethod", new StackItem[0] };
+            var result = testengine.ExecuteTestCase(_params);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
         [TestMethod]
         public void Test_AutoEntry_call02()
         {
@@ -40,7 +52,5 @@ namespace Neo.Compiler.MSIL
             // object Main(string,object[]) must be return sth.
             Assert.IsTrue(bequal);
         }
-
     }
-
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_AutoEntrypoint.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.MSIL.Utils;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Neo.Compiler.MSIL
+{
+    [TestClass]
+    public class UnitTest_AutoEntryPoint
+    {
+        [TestMethod]
+        public void Test_AutoEntry()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_autoentrypoint.cs");
+
+            testengine.scriptEntry.DumpAVM();
+
+            StackItem[] _params = new StackItem[] { "call01", new StackItem[0] };
+            var result = testengine.ExecuteTestCase(_params);
+            StackItem wantresult = new byte[] { 1, 2, 3, 4 };
+
+            var bequal = wantresult.Equals(result.Pop());
+            Assert.IsTrue(bequal);
+        }
+        [TestMethod]
+        public void Test_AutoEntry_call02()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_autoentrypoint.cs");
+
+            testengine.scriptEntry.DumpAVM();
+
+            StackItem[] _params = new StackItem[] { "call02", new StackItem[] { "hello", 33 } };
+            var result = testengine.ExecuteTestCase(_params);
+            StackItem wantresult = new byte[0];
+            var bequal = wantresult.Equals(result.Pop());
+
+            //if your function return is void,when auto generate a entry point,it always return new byte[0];
+            // object Main(string,object[]) must be return sth.
+            Assert.IsTrue(bequal);
+        }
+
+    }
+
+}

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_Shift.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_Shift.cs
@@ -18,8 +18,7 @@ namespace Neo.Compiler.MSIL
 
             testengine.scriptEntry.DumpAVM();
 
-            StackItem[] _params = new StackItem[] { "testfunc", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("testfunc").Run();
         }
         [TestMethod]
         public void Test_Shift_BigInteger()
@@ -29,8 +28,7 @@ namespace Neo.Compiler.MSIL
 
             testengine.scriptEntry.DumpAVM();
 
-            StackItem[] _params = new StackItem[] { "testfunc", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("testfunc").Run();
         }
     }
 

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
@@ -12,12 +12,11 @@ namespace Neo.Compiler.MSIL
         {
             var testengine = new TestEngine();
             testengine.AddEntryScript("./TestClasses/Contract_StaticVar.cs");
-            StackItem[] _params = new StackItem[] { "testfunc", new StackItem[0] };
-            var result = testengine.ExecuteTestCase(_params);
+            var result = testengine.GetMethod("testfunc").Run();
 
             //test (1+5)*7 == 42
             StackItem wantresult = 42;
-            var bequal = wantresult.Equals(result.Pop());
+            var bequal = wantresult.Equals(result);
             Assert.IsTrue(bequal);
         }
 

--- a/tests/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
@@ -145,10 +145,9 @@ namespace Neo.Compiler.MSIL.Utils
 
         public void DumpAVM()
         {
-            foreach(var method in GetAllNEOVMMethod())
             {
-                Console.WriteLine("dump:" + method.displayName + " addr in avm:" + method.funcaddr);
-                foreach (var c in method.body_Codes)
+                Console.WriteLine("dump:");
+                foreach (var c in this.converterIL.outModule.total_Codes)
                 {
                     var line = c.Key.ToString("X04") + "=>" + c.Value.ToString();
                     if(c.Value.bytes!=null&&c.Value.bytes.Length>0)

--- a/tests/Neo.Compiler.MSIL.UnitTests/Utils/TestEngine.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/Utils/TestEngine.cs
@@ -52,14 +52,14 @@ namespace Neo.Compiler.MSIL.Utils
             }
             public StackItem Run(params StackItem[] _params)
             {
-                return this.engine.ExecuteContract(methodname, _params);
+                return this.engine.ExecuteContract(methodname, _params).Pop();
             }
         }
         public ContractMethod GetMethod(string methodname)
         {
             return new ContractMethod(this, methodname);
         }
-        private StackItem ExecuteContract(string methodname, params StackItem[] _params)
+        public RandomAccessStack<StackItem> ExecuteContract(string methodname, params StackItem[] _params)
         {
             this.LoadScript(scriptEntry.finalAVM);
             this.InvocationStack.Peek().InstructionPointer = 0;
@@ -81,7 +81,7 @@ namespace Neo.Compiler.MSIL.Utils
             if (stack.Count != 1)
                 throw new Exception("should have 1 result in stack.");
 
-            return stack.Pop();
+            return stack;
         }
         //public RandomAccessStack<StackItem> ExecuteTestCase(StackItem[] _params)
         //{


### PR DESCRIPTION
because all contract entrypoint is:  
Main(string methodname, params object[] params);

change unittest call method from

```
ExecuteTestCase(new stackitem[]{methodname,new stackitem[]{param1,param2,...});
```

to

```
GetMethod(methodname).Run(param1,param2,...);
```