### PR TITLE
remove dependecny on neo from neo.compiler.msil

### DIFF
--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
@@ -1,7 +1,7 @@
-using Neo.SmartContract;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Neo.Compiler.MSIL
@@ -11,6 +11,15 @@ namespace Neo.Compiler.MSIL
     /// </summary>
     public partial class ModuleConverter
     {
+        static Lazy<SHA256> sha265 = new Lazy<SHA256>();
+
+        private static byte[] GenerateInteropMethodHash(string method)
+        {
+            var bytes = Encoding.ASCII.GetBytes(method);
+            var hash = sha265.Value.ComputeHash(bytes);
+            return BitConverter.GetBytes(BitConverter.ToUInt32(hash, 0));
+        }
+
         private void _ConvertStLoc(ILMethod method, OpCode src, NeoMethod to, int pos)
         {
 
@@ -935,7 +944,7 @@ namespace Neo.Compiler.MSIL
             else if (calltype == 4)
             {
                 _ConvertPush(callhash, src, to);
-                _Insert1(VM.OpCode.SYSCALL, "", to, BitConverter.GetBytes(InteropService.System_Contract_Call));
+                _Insert1(VM.OpCode.SYSCALL, "", to, GenerateInteropMethodHash("System.Contract.Call"));
             }
             else if (calltype == 5)
             {
@@ -950,7 +959,7 @@ namespace Neo.Compiler.MSIL
 
                 //a syscall
                 {
-                    var bytes = BitConverter.GetBytes(InteropService.System_Runtime_Notify);
+                    var bytes = GenerateInteropMethodHash("System.Runtime.Notify");
                     //byte[] outbytes = new byte[bytes.Length + 1];
                     //outbytes[0] = (byte)bytes.Length;
                     //Array.Copy(bytes, 0, outbytes, 1, bytes.Length);
@@ -962,7 +971,7 @@ namespace Neo.Compiler.MSIL
             {
                 _ConvertPush(callpcount, src, to);
                 _Convert1by1(VM.OpCode.ROLL, null, to);
-                _Convert1by1(VM.OpCode.SYSCALL, null, to, BitConverter.GetBytes(InteropService.System_Contract_Call));
+                _Convert1by1(VM.OpCode.SYSCALL, null, to, GenerateInteropMethodHash("System.Contract.Call"));
             }
             return 0;
         }

--- a/src/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
+++ b/src/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
-    <PackageReference Include="Neo" Version="3.0.0-CI00172" />
   </ItemGroup>
 
 </Project>

--- a/src/Neo.Compiler.MSIL/OpCode.cs
+++ b/src/Neo.Compiler.MSIL/OpCode.cs
@@ -1,0 +1,717 @@
+namespace Neo.VM
+{
+    public enum OpCode : byte
+    {
+        // Constants
+        /// <summary>
+        /// An empty array of bytes is pushed onto the stack. 
+        /// This is equivalent to pushing Integer zero to the stack.
+        /// This is equivalent to pushing Boolean false to the stack.
+        /// </summary>
+        PUSH0 = 0x00,
+        PUSHF = PUSH0,
+        /// <summary>
+        /// Push 1 byte on the evaluation stack.
+        /// </summary>
+        PUSHBYTES1 = 0x01,
+        /// <summary>
+        /// Push 2 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES2 = 0x02,
+        /// <summary>
+        /// Push 3 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES3 = 0x03,
+        /// <summary>
+        /// Push 4 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES4 = 0x04,
+        /// <summary>
+        /// Push 5 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES5 = 0x05,
+        /// <summary>
+        /// Push 6 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES6 = 0x06,
+        /// <summary>
+        /// Push 7 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES7 = 0x07,
+        /// <summary>
+        /// Push 8 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES8 = 0x08,
+        /// <summary>
+        /// Push 9 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES9 = 0x09,
+        /// <summary>
+        /// Push 10 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES10 = 0x0A,
+        /// <summary>
+        /// Push 11 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES11 = 0x0B,
+        /// <summary>
+        /// Push 12 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES12 = 0x0C,
+        /// <summary>
+        /// Push 13 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES13 = 0x0D,
+        /// <summary>
+        /// Push 14 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES14 = 0x0E,
+        /// <summary>
+        /// Push 15 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES15 = 0x0F,
+        /// <summary>
+        /// Push 16 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES16 = 0x10,
+        /// <summary>
+        /// Push 17 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES17 = 0x11,
+        /// <summary>
+        /// Push 18 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES18 = 0x12,
+        /// <summary>
+        /// Push 19 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES19 = 0x13,
+        /// <summary>
+        /// Push 20 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES20 = 0x14,
+        /// <summary>
+        /// Push 21 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES21 = 0x15,
+        /// <summary>
+        /// Push 22 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES22 = 0x16,
+        /// <summary>
+        /// Push 23 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES23 = 0x17,
+        /// <summary>
+        /// Push 24 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES24 = 0x18,
+        /// <summary>
+        /// Push 25 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES25 = 0x19,
+        /// <summary>
+        /// Push 26 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES26 = 0x1A,
+        /// <summary>
+        /// Push 27 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES27 = 0x1B,
+        /// <summary>
+        /// Push 28 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES28 = 0x1C,
+        /// <summary>
+        /// Push 29 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES29 = 0x1D,
+        /// <summary>
+        /// Push 30 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES30 = 0x1E,
+        /// <summary>
+        /// Push 31 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES31 = 0x1F,
+        /// <summary>
+        /// Push 32 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES32 = 0x20,
+        /// <summary>
+        /// Push 33 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES33 = 0x21,
+        /// <summary>
+        /// Push 34 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES34 = 0x22,
+        /// <summary>
+        /// Push 35 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES35 = 0x23,
+        /// <summary>
+        /// Push 36 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES36 = 0x24,
+        /// <summary>
+        /// Push 37 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES37 = 0x25,
+        /// <summary>
+        /// Push 38 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES38 = 0x26,
+        /// <summary>
+        /// Push 39 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES39 = 0x27,
+        /// <summary>
+        /// Push 40 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES40 = 0x28,
+        /// <summary>
+        /// Push 41 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES41 = 0x29,
+        /// <summary>
+        /// Push 42 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES42 = 0x2A,
+        /// <summary>
+        /// Push 43 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES43 = 0x2B,
+        /// <summary>
+        /// Push 44 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES44 = 0x2C,
+        /// <summary>
+        /// Push 45 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES45 = 0x2D,
+        /// <summary>
+        /// Push 46 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES46 = 0x2E,
+        /// <summary>
+        /// Push 47 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES47 = 0x2F,
+        /// <summary>
+        /// Push 48 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES48 = 0x30,
+        /// <summary>
+        /// Push 49 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES49 = 0x31,
+        /// <summary>
+        /// Push 50 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES50 = 0x32,
+        /// <summary>
+        /// Push 51 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES51 = 0x33,
+        /// <summary>
+        /// Push 52 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES52 = 0x34,
+        /// <summary>
+        /// Push 53 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES53 = 0x35,
+        /// <summary>
+        /// Push 54 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES54 = 0x36,
+        /// <summary>
+        /// Push 55 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES55 = 0x37,
+        /// <summary>
+        /// Push 56 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES56 = 0x38,
+        /// <summary>
+        /// Push 57 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES57 = 0x39,
+        /// <summary>
+        /// Push 58 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES58 = 0x3A,
+        /// <summary>
+        /// Push 59 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES59 = 0x3B,
+        /// <summary>
+        /// Push 60 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES60 = 0x3C,
+        /// <summary>
+        /// Push 61 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES61 = 0x3D,
+        /// <summary>
+        /// Push 62 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES62 = 0x3E,
+        /// <summary>
+        /// Push 63 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES63 = 0x3F,
+        /// <summary>
+        /// Push 64 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES64 = 0x40,
+        /// <summary>
+        /// Push 65 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES65 = 0x41,
+        /// <summary>
+        /// Push 66 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES66 = 0x42,
+        /// <summary>
+        /// Push 67 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES67 = 0x43,
+        /// <summary>
+        /// Push 68 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES68 = 0x44,
+        /// <summary>
+        /// Push 69 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES69 = 0x45,
+        /// <summary>
+        /// Push 70 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES70 = 0x46,
+        /// <summary>
+        /// Push 71 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES71 = 0x47,
+        /// <summary>
+        /// Push 72 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES72 = 0x48,
+        /// <summary>
+        /// Push 73 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES73 = 0x49,
+        /// <summary>
+        /// Push 74 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES74 = 0x4A,
+        /// <summary>
+        /// Push 75 bytes on the evaluation stack.
+        /// </summary>
+        PUSHBYTES75 = 0x4B,
+        /// <summary>
+        /// The next byte contains the number of bytes to be pushed onto the stack.
+        /// </summary>
+        PUSHDATA1 = 0x4C,
+        /// <summary>
+        /// The next two bytes contain the number of bytes to be pushed onto the stack.
+        /// </summary>
+        PUSHDATA2 = 0x4D,
+        /// <summary>
+        /// The next four bytes contain the number of bytes to be pushed onto the stack.
+        /// </summary>
+        PUSHDATA4 = 0x4E,
+        /// <summary>
+        /// The number -1 is pushed onto the stack.
+        /// </summary>
+        PUSHM1 = 0x4F,
+        /// <summary>
+        /// The number 1 is pushed onto the stack.
+        /// </summary>
+        PUSH1 = 0x51,
+        PUSHT = PUSH1,
+        /// <summary>
+        /// The number 2 is pushed onto the stack.
+        /// </summary>
+        PUSH2 = 0x52,
+        /// <summary>
+        /// The number 3 is pushed onto the stack.
+        /// </summary>
+        PUSH3 = 0x53,
+        /// <summary>
+        /// The number 4 is pushed onto the stack.
+        /// </summary>
+        PUSH4 = 0x54,
+        /// <summary>
+        /// The number 5 is pushed onto the stack.
+        /// </summary>
+        PUSH5 = 0x55,
+        /// <summary>
+        /// The number 6 is pushed onto the stack.
+        /// </summary>
+        PUSH6 = 0x56,
+        /// <summary>
+        /// The number 7 is pushed onto the stack.
+        /// </summary>
+        PUSH7 = 0x57,
+        /// <summary>
+        /// The number 8 is pushed onto the stack.
+        /// </summary>
+        PUSH8 = 0x58,
+        /// <summary>
+        /// The number 9 is pushed onto the stack.
+        /// </summary>
+        PUSH9 = 0x59,
+        /// <summary>
+        /// The number 10 is pushed onto the stack.
+        /// </summary>
+        PUSH10 = 0x5A,
+        /// <summary>
+        /// The number 11 is pushed onto the stack.
+        /// </summary>
+        PUSH11 = 0x5B,
+        /// <summary>
+        /// The number 12 is pushed onto the stack.
+        /// </summary>
+        PUSH12 = 0x5C,
+        /// <summary>
+        /// The number 13 is pushed onto the stack.
+        /// </summary>
+        PUSH13 = 0x5D,
+        /// <summary>
+        /// The number 14 is pushed onto the stack.
+        /// </summary>
+        PUSH14 = 0x5E,
+        /// <summary>
+        /// The number 15 is pushed onto the stack.
+        /// </summary>
+        PUSH15 = 0x5F,
+        /// <summary>
+        /// The number 16 is pushed onto the stack.
+        /// </summary>
+        PUSH16 = 0x60,
+
+        // Flow control
+        /// <summary>
+        ///  Does nothing.
+        /// </summary>
+        NOP = 0x61,
+        /// <summary>
+        /// Reads a 2-byte value n and a jump is performed to relative position n (counting from opcode JMP address).
+        /// </summary>
+        JMP = 0x62,
+        /// <summary>
+        /// A boolean value b is taken from main stack and reads a 2-byte value n, if b is True then a jump is performed to relative position n (counting from opcode JMPIF address).
+        /// </summary>
+        JMPIF = 0x63,
+        /// <summary>
+        /// A boolean value b is taken from main stack and reads a 2-byte value n, if b is False then a jump is performed to relative position n (counting from opcode JMPIFNOT address).
+        /// </summary>
+        JMPIFNOT = 0x64,
+        /// <summary>
+        /// Current context is copied to the invocation stack. Reads a 2-byte value n and a jump is performed to relative position n.
+        /// </summary>
+        CALL = 0x65,
+        /// <summary>
+        /// Stops the execution if invocation stack is empty.
+        /// </summary>
+        RET = 0x66,
+        /// <summary>
+        /// Reads a string and executes the corresponding operation.
+        /// </summary>
+        SYSCALL = 0x68,
+
+
+        // Stack
+        /// <summary>
+        /// Copies the bottom of alt stack and put it on top of main stack.
+        /// </summary> 
+        DUPFROMALTSTACKBOTTOM = 0x69,
+        /// <summary>
+        /// Duplicates the item on top of alt stack and put it on top of main stack.
+        /// </summary>
+        DUPFROMALTSTACK = 0x6A,
+        /// <summary>
+        /// Puts the input onto the top of the alt stack. Removes it from the main stack.
+        /// </summary>
+        TOALTSTACK = 0x6B,
+        /// <summary>
+        /// Puts the input onto the top of the main stack. Removes it from the alt stack.
+        /// </summary>
+        FROMALTSTACK = 0x6C,
+        /// <summary>
+        /// The item n back in the main stack is removed.
+        /// </summary>
+        XDROP = 0x6D,
+        /// <summary>
+        /// The item n back in the main stack in swapped with top stack item.
+        /// </summary>
+        XSWAP = 0x72,
+        /// <summary>
+        /// The item on top of the main stack is copied and inserted to the position n in the main stack.
+        /// </summary>
+        XTUCK = 0x73,
+        /// <summary>
+        /// Puts the number of stack items onto the stack.
+        /// </summary>
+        DEPTH = 0x74,
+        /// <summary>
+        /// Removes the top stack item.
+        /// </summary>
+        DROP = 0x75,
+        /// <summary>
+        /// Duplicates the top stack item.
+        /// </summary>
+        DUP = 0x76,
+        /// <summary>
+        /// Removes the second-to-top stack item.
+        /// </summary>
+        NIP = 0x77,
+        /// <summary>
+        /// Copies the second-to-top stack item to the top.
+        /// </summary>
+        OVER = 0x78,
+        /// <summary>
+        /// The item n back in the stack is copied to the top.
+        /// </summary>
+        PICK = 0x79,
+        /// <summary>
+        /// The item n back in the stack is moved to the top.
+        /// </summary>
+        ROLL = 0x7A,
+        /// <summary>
+        /// The top three items on the stack are rotated to the left.
+        /// </summary>
+        ROT = 0x7B,
+        /// <summary>
+        /// The top two items on the stack are swapped.
+        /// </summary>
+        SWAP = 0x7C,
+        /// <summary>
+        /// The item at the top of the stack is copied and inserted before the second-to-top item.
+        /// </summary>
+        TUCK = 0x7D,
+
+
+        // Splice
+        /// <summary>
+        /// Concatenates two strings.
+        /// </summary>
+        CAT = 0x7E,
+        /// <summary>
+        /// Returns a section of a string.
+        /// </summary>
+        SUBSTR = 0x7F,
+        /// <summary>
+        /// Keeps only characters left of the specified point in a string.
+        /// </summary>
+        LEFT = 0x80,
+        /// <summary>
+        /// Keeps only characters right of the specified point in a string.
+        /// </summary>
+        RIGHT = 0x81,
+        /// <summary>
+        /// Returns the length of the input string.
+        /// </summary>
+        SIZE = 0x82,
+
+
+        // Bitwise logic
+        /// <summary>
+        /// Flips all of the bits in the input.
+        /// </summary>
+        INVERT = 0x83,
+        /// <summary>
+        /// Boolean and between each bit in the inputs.
+        /// </summary>
+        AND = 0x84,
+        /// <summary>
+        /// Boolean or between each bit in the inputs.
+        /// </summary>
+        OR = 0x85,
+        /// <summary>
+        /// Boolean exclusive or between each bit in the inputs.
+        /// </summary>
+        XOR = 0x86,
+        /// <summary>
+        /// Returns 1 if the inputs are exactly equal, 0 otherwise.
+        /// </summary>
+        EQUAL = 0x87,
+
+
+        // Arithmetic
+        /// <summary>
+        /// 1 is added to the input.
+        /// </summary>
+        INC = 0x8B,
+        /// <summary>
+        /// 1 is subtracted from the input.
+        /// </summary>
+        DEC = 0x8C,
+        /// <summary>
+        /// Puts the sign of top stack item on top of the main stack. If value is negative, put -1; if positive, put 1; if value is zero, put 0.
+        /// </summary>
+        SIGN = 0x8D,
+        /// <summary>
+        /// The sign of the input is flipped.
+        /// </summary>
+        NEGATE = 0x8F,
+        /// <summary>
+        /// The input is made positive.
+        /// </summary>
+        ABS = 0x90,
+        /// <summary>
+        /// If the input is 0 or 1, it is flipped. Otherwise the output will be 0.
+        /// </summary>
+        NOT = 0x91,
+        /// <summary>
+        /// Returns 0 if the input is 0. 1 otherwise.
+        /// </summary>
+        NZ = 0x92,
+        /// <summary>
+        /// a is added to b.
+        /// </summary>
+        ADD = 0x93,
+        /// <summary>
+        /// b is subtracted from a.
+        /// </summary>
+        SUB = 0x94,
+        /// <summary>
+        /// a is multiplied by b.
+        /// </summary>
+        MUL = 0x95,
+        /// <summary>
+        /// a is divided by b.
+        /// </summary>
+        DIV = 0x96,
+        /// <summary>
+        /// Returns the remainder after dividing a by b.
+        /// </summary>
+        MOD = 0x97,
+        /// <summary>
+        /// Shifts a left b bits, preserving sign.
+        /// </summary>
+        SHL = 0x98,
+        /// <summary>
+        /// Shifts a right b bits, preserving sign.
+        /// </summary>
+        SHR = 0x99,
+        /// <summary>
+        /// If both a and b are not 0, the output is 1. Otherwise 0.
+        /// </summary>
+        BOOLAND = 0x9A,
+        /// <summary>
+        /// If a or b is not 0, the output is 1. Otherwise 0.
+        /// </summary>
+        BOOLOR = 0x9B,
+        /// <summary>
+        /// Returns 1 if the numbers are equal, 0 otherwise.
+        /// </summary>
+        NUMEQUAL = 0x9C,
+        /// <summary>
+        /// Returns 1 if the numbers are not equal, 0 otherwise.
+        /// </summary>
+        NUMNOTEQUAL = 0x9E,
+        /// <summary>
+        /// Returns 1 if a is less than b, 0 otherwise.
+        /// </summary>
+        LT = 0x9F,
+        /// <summary>
+        /// Returns 1 if a is greater than b, 0 otherwise.
+        /// </summary>
+        GT = 0xA0,
+        /// <summary>
+        /// Returns 1 if a is less than or equal to b, 0 otherwise.
+        /// </summary>
+        LTE = 0xA1,
+        /// <summary>
+        /// Returns 1 if a is greater than or equal to b, 0 otherwise.
+        /// </summary>
+        GTE = 0xA2,
+        /// <summary>
+        /// Returns the smaller of a and b.
+        /// </summary>
+        MIN = 0xA3,
+        /// <summary>
+        /// Returns the larger of a and b.
+        /// </summary>
+        MAX = 0xA4,
+        /// <summary>
+        /// Returns 1 if x is within the specified range (left-inclusive), 0 otherwise.
+        /// </summary>
+        WITHIN = 0xA5,
+
+        //Reserved = 0xAC,
+        //Reserved = 0xAE,
+
+        // Array
+        /// <summary>
+        /// An array is removed from top of the main stack. Its size is put on top of the main stack.
+        /// </summary>
+        ARRAYSIZE = 0xC0,
+        /// <summary>
+        /// A value n is taken from top of main stack. The next n items on main stack are removed, put inside n-sized array and this array is put on top of the main stack.
+        /// </summary>
+        PACK = 0xC1,
+        /// <summary>
+        /// An array is removed from top of the main stack. Its elements are put on top of the main stack (in reverse order) and the array size is also put on main stack.
+        /// </summary>
+        UNPACK = 0xC2,
+        /// <summary>
+        /// An input index n (or key) and an array (or map) are taken from main stack. Element array[n] (or map[n]) is put on top of the main stack.
+        /// </summary>
+        PICKITEM = 0xC3,
+        /// <summary>
+        /// A value v, index n (or key) and an array (or map) are taken from main stack. Attribution array[n]=v (or map[n]=v) is performed.
+        /// </summary>
+        SETITEM = 0xC4,
+        /// <summary>
+        /// A value n is taken from top of main stack. A zero-filled array type with size n is put on top of the main stack.
+        /// </summary>
+        NEWARRAY = 0xC5,
+        /// <summary>
+        /// A value n is taken from top of main stack. A zero-filled struct type with size n is put on top of the main stack.
+        /// </summary>
+        NEWSTRUCT = 0xC6,
+        /// <summary>
+        /// A Map is created and put on top of the main stack.
+        /// </summary>
+        NEWMAP = 0xC7,
+        /// <summary>
+        /// The item on top of main stack is removed and appended to the second item on top of the main stack.
+        /// </summary>
+        APPEND = 0xC8,
+        /// <summary>
+        /// An array is removed from the top of the main stack and its elements are reversed.
+        /// </summary>
+        REVERSE = 0xC9,
+        /// <summary>
+        /// An input index n (or key) and an array (or map) are removed from the top of the main stack. Element array[n] (or map[n]) is removed.
+        /// </summary>
+        REMOVE = 0xCA,
+        /// <summary>
+        /// An input index n (or key) and an array (or map) are removed from the top of the main stack. Puts True on top of main stack if array[n] (or map[n]) exist, and False otherwise.
+        /// </summary>
+        HASKEY = 0xCB,
+        /// <summary>
+        /// A map is taken from top of the main stack. The keys of this map are put on top of the main stack.
+        /// </summary>
+        KEYS = 0xCC,
+        /// <summary>
+        /// A map is taken from top of the main stack. The values of this map are put on top of the main stack.
+        /// </summary>
+        VALUES = 0xCD,
+
+
+        // Exceptions
+        /// <summary>
+        /// Halts the execution of the vm by setting VMState.FAULT.
+        /// </summary>
+        THROW = 0xF0,
+        /// <summary>
+        /// Removes top stack item n, and halts the execution of the vm by setting VMState.FAULT only if n is False.
+        /// </summary>
+        THROWIFNOT = 0xF1
+    }
+}

--- a/src/Neo.Compiler.MSIL/RIPEMD160.cs
+++ b/src/Neo.Compiler.MSIL/RIPEMD160.cs
@@ -1,0 +1,1054 @@
+#if !NET47
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Cryptography;
+
+namespace Neo.Cryptography
+{
+    [ComVisible(true)]
+    public class RIPEMD160Managed : HashAlgorithm
+    {
+        private byte[] _buffer;
+        private long _count; // Number of bytes in the hashed message
+        private uint[] _stateMD160;
+        private uint[] _blockDWords;
+
+        public override int HashSize => 160;
+
+        //
+        // public constructors
+        //
+
+        public RIPEMD160Managed()
+        {
+            _stateMD160 = new uint[5];
+            _blockDWords = new uint[16];
+            _buffer = new byte[64];
+
+            InitializeState();
+        }
+
+        //
+        // public methods
+        //
+
+        public override void Initialize()
+        {
+            InitializeState();
+
+            // Zeroize potentially sensitive information.
+            Array.Clear(_blockDWords, 0, _blockDWords.Length);
+            Array.Clear(_buffer, 0, _buffer.Length);
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        protected override void HashCore(byte[] rgb, int ibStart, int cbSize)
+        {
+            _HashData(rgb, ibStart, cbSize);
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        protected override byte[] HashFinal()
+        {
+            return _EndHash();
+        }
+
+        //
+        // private methods
+        //
+
+        private void InitializeState()
+        {
+            _count = 0;
+
+            // Use the same chaining values (IVs) as in SHA1, 
+            // The convention is little endian however (same as MD4)
+            _stateMD160[0] = 0x67452301;
+            _stateMD160[1] = 0xefcdab89;
+            _stateMD160[2] = 0x98badcfe;
+            _stateMD160[3] = 0x10325476;
+            _stateMD160[4] = 0xc3d2e1f0;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private unsafe void _HashData(byte[] partIn, int ibStart, int cbSize)
+        {
+            int bufferLen;
+            int partInLen = cbSize;
+            int partInBase = ibStart;
+
+            /* Compute length of buffer */
+            bufferLen = (int)(_count & 0x3f);
+
+            /* Update number of bytes */
+            _count += partInLen;
+
+            fixed (uint* stateMD160 = _stateMD160)
+            {
+                fixed (byte* buffer = _buffer)
+                {
+                    fixed (uint* blockDWords = _blockDWords)
+                    {
+                        if ((bufferLen > 0) && (bufferLen + partInLen >= 64))
+                        {
+                            Buffer.BlockCopy(partIn, partInBase, _buffer, bufferLen, 64 - bufferLen);
+                            partInBase += (64 - bufferLen);
+                            partInLen -= (64 - bufferLen);
+                            MDTransform(blockDWords, stateMD160, buffer);
+                            bufferLen = 0;
+                        }
+
+                        /* Copy input to temporary buffer and hash */
+                        while (partInLen >= 64)
+                        {
+                            Buffer.BlockCopy(partIn, partInBase, _buffer, 0, 64);
+                            partInBase += 64;
+                            partInLen -= 64;
+                            MDTransform(blockDWords, stateMD160, buffer);
+                        }
+
+                        if (partInLen > 0)
+                        {
+                            Buffer.BlockCopy(partIn, partInBase, _buffer, bufferLen, partInLen);
+                        }
+                    }
+                }
+            }
+        }
+
+        [SecurityCritical]  // auto-generated
+        private byte[] _EndHash()
+        {
+            byte[] pad;
+            int padLen;
+            long bitCount;
+            byte[] hash = new byte[20];
+
+            /* Compute padding: 80 00 00 ... 00 00 <bit count>
+             */
+
+            padLen = 64 - (int)(_count & 0x3f);
+            if (padLen <= 8)
+                padLen += 64;
+
+            pad = new byte[padLen];
+            pad[0] = 0x80;
+
+            //  Convert count to bit count
+            bitCount = _count * 8;
+
+            // The convention for RIPEMD is little endian (the same as MD4)
+            pad[padLen - 1] = (byte)((bitCount >> 56) & 0xff);
+            pad[padLen - 2] = (byte)((bitCount >> 48) & 0xff);
+            pad[padLen - 3] = (byte)((bitCount >> 40) & 0xff);
+            pad[padLen - 4] = (byte)((bitCount >> 32) & 0xff);
+            pad[padLen - 5] = (byte)((bitCount >> 24) & 0xff);
+            pad[padLen - 6] = (byte)((bitCount >> 16) & 0xff);
+            pad[padLen - 7] = (byte)((bitCount >> 8) & 0xff);
+            pad[padLen - 8] = (byte)((bitCount >> 0) & 0xff);
+
+            /* Digest padding */
+            _HashData(pad, 0, pad.Length);
+
+            /* Store digest */
+            DWORDToLittleEndian(hash, _stateMD160, 5);
+
+            return hash;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated
+        private static unsafe void MDTransform(uint* blockDWords, uint* state, byte* block)
+        {
+            uint aa = state[0];
+            uint bb = state[1];
+            uint cc = state[2];
+            uint dd = state[3];
+            uint ee = state[4];
+
+            uint aaa = aa;
+            uint bbb = bb;
+            uint ccc = cc;
+            uint ddd = dd;
+            uint eee = ee;
+
+            DWORDFromLittleEndian(blockDWords, 16, block);
+
+            /*
+                As we don't have macros in C# and we don't want to pay the cost of a function call
+                (which BTW is quite important here as we would have to pass 5 args by ref in 
+                16 * 10 = 160 function calls)
+                we'll prefer a less compact code to a less performant code
+            */
+
+            // Left Round 1 
+            // FF(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[0], 11);
+            aa += blockDWords[0] + F(bb, cc, dd);
+            aa = (aa << 11 | aa >> (32 - 11)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // FF(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[1], 14);
+            ee += blockDWords[1] + F(aa, bb, cc);
+            ee = (ee << 14 | ee >> (32 - 14)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // FF(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[2], 15);
+            dd += blockDWords[2] + F(ee, aa, bb);
+            dd = (dd << 15 | dd >> (32 - 15)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // FF(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[3], 12);
+            cc += blockDWords[3] + F(dd, ee, aa);
+            cc = (cc << 12 | cc >> (32 - 12)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // FF(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[4], 5);
+            bb += blockDWords[4] + F(cc, dd, ee);
+            bb = (bb << 5 | bb >> (32 - 5)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // FF(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[5], 8);
+            aa += blockDWords[5] + F(bb, cc, dd);
+            aa = (aa << 8 | aa >> (32 - 8)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // FF(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[6], 7);
+            ee += blockDWords[6] + F(aa, bb, cc);
+            ee = (ee << 7 | ee >> (32 - 7)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // FF(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[7], 9);
+            dd += blockDWords[7] + F(ee, aa, bb);
+            dd = (dd << 9 | dd >> (32 - 9)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // FF(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[8], 11);
+            cc += blockDWords[8] + F(dd, ee, aa);
+            cc = (cc << 11 | cc >> (32 - 11)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // FF(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[9], 13);
+            bb += blockDWords[9] + F(cc, dd, ee);
+            bb = (bb << 13 | bb >> (32 - 13)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // FF(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[10], 14);
+            aa += blockDWords[10] + F(bb, cc, dd);
+            aa = (aa << 14 | aa >> (32 - 14)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // FF(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[11], 15);
+            ee += blockDWords[11] + F(aa, bb, cc);
+            ee = (ee << 15 | ee >> (32 - 15)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // FF(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[12], 6);
+            dd += blockDWords[12] + F(ee, aa, bb);
+            dd = (dd << 6 | dd >> (32 - 6)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // FF(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[13], 7);
+            cc += blockDWords[13] + F(dd, ee, aa);
+            cc = (cc << 7 | cc >> (32 - 7)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // FF(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[14], 9);
+            bb += blockDWords[14] + F(cc, dd, ee);
+            bb = (bb << 9 | bb >> (32 - 9)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // FF(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[15], 8);
+            aa += blockDWords[15] + F(bb, cc, dd);
+            aa = (aa << 8 | aa >> (32 - 8)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // Left Round 2 
+            // GG(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[7], 7);
+            ee += G(aa, bb, cc) + blockDWords[7] + 0x5a827999;
+            ee = (ee << 7 | ee >> (32 - 7)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // GG(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[4], 6);
+            dd += G(ee, aa, bb) + blockDWords[4] + 0x5a827999;
+            dd = (dd << 6 | dd >> (32 - 6)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // GG(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[13], 8);
+            cc += G(dd, ee, aa) + blockDWords[13] + 0x5a827999;
+            cc = (cc << 8 | cc >> (32 - 8)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // GG(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[1], 13);
+            bb += G(cc, dd, ee) + blockDWords[1] + 0x5a827999;
+            bb = (bb << 13 | bb >> (32 - 13)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // GG(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[10], 11);
+            aa += G(bb, cc, dd) + blockDWords[10] + 0x5a827999;
+            aa = (aa << 11 | aa >> (32 - 11)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // GG(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[6], 9);
+            ee += G(aa, bb, cc) + blockDWords[6] + 0x5a827999;
+            ee = (ee << 9 | ee >> (32 - 9)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // GG(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[15], 7);
+            dd += G(ee, aa, bb) + blockDWords[15] + 0x5a827999;
+            dd = (dd << 7 | dd >> (32 - 7)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // GG(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[3], 15);
+            cc += G(dd, ee, aa) + blockDWords[3] + 0x5a827999;
+            cc = (cc << 15 | cc >> (32 - 15)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // GG(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[12], 7);
+            bb += G(cc, dd, ee) + blockDWords[12] + 0x5a827999;
+            bb = (bb << 7 | bb >> (32 - 7)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // GG(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[0], 12);
+            aa += G(bb, cc, dd) + blockDWords[0] + 0x5a827999;
+            aa = (aa << 12 | aa >> (32 - 12)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // GG(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[9], 15);
+            ee += G(aa, bb, cc) + blockDWords[9] + 0x5a827999;
+            ee = (ee << 15 | ee >> (32 - 15)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // GG(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[5], 9);
+            dd += G(ee, aa, bb) + blockDWords[5] + 0x5a827999;
+            dd = (dd << 9 | dd >> (32 - 9)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // GG(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[2], 11);
+            cc += G(dd, ee, aa) + blockDWords[2] + 0x5a827999;
+            cc = (cc << 11 | cc >> (32 - 11)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // GG(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[14], 7);
+            bb += G(cc, dd, ee) + blockDWords[14] + 0x5a827999;
+            bb = (bb << 7 | bb >> (32 - 7)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // GG(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[11], 13);
+            aa += G(bb, cc, dd) + blockDWords[11] + 0x5a827999;
+            aa = (aa << 13 | aa >> (32 - 13)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // GG(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[8], 12);
+            ee += G(aa, bb, cc) + blockDWords[8] + 0x5a827999;
+            ee = (ee << 12 | ee >> (32 - 12)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // Left Round 3 
+            // HH(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[3], 11);
+            dd += H(ee, aa, bb) + blockDWords[3] + 0x6ed9eba1;
+            dd = (dd << 11 | dd >> (32 - 11)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // HH(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[10], 13);
+            cc += H(dd, ee, aa) + blockDWords[10] + 0x6ed9eba1;
+            cc = (cc << 13 | cc >> (32 - 13)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // HH(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[14], 6);
+            bb += H(cc, dd, ee) + blockDWords[14] + 0x6ed9eba1;
+            bb = (bb << 6 | bb >> (32 - 6)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // HH(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[4], 7);
+            aa += H(bb, cc, dd) + blockDWords[4] + 0x6ed9eba1;
+            aa = (aa << 7 | aa >> (32 - 7)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // HH(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[9], 14);
+            ee += H(aa, bb, cc) + blockDWords[9] + 0x6ed9eba1;
+            ee = (ee << 14 | ee >> (32 - 14)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // HH(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[15], 9);
+            dd += H(ee, aa, bb) + blockDWords[15] + 0x6ed9eba1;
+            dd = (dd << 9 | dd >> (32 - 9)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // HH(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[8], 13);
+            cc += H(dd, ee, aa) + blockDWords[8] + 0x6ed9eba1;
+            cc = (cc << 13 | cc >> (32 - 13)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // HH(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[1], 15);
+            bb += H(cc, dd, ee) + blockDWords[1] + 0x6ed9eba1;
+            bb = (bb << 15 | bb >> (32 - 15)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // HH(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[2], 14);
+            aa += H(bb, cc, dd) + blockDWords[2] + 0x6ed9eba1;
+            aa = (aa << 14 | aa >> (32 - 14)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // HH(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[7], 8);
+            ee += H(aa, bb, cc) + blockDWords[7] + 0x6ed9eba1;
+            ee = (ee << 8 | ee >> (32 - 8)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // HH(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[0], 13);
+            dd += H(ee, aa, bb) + blockDWords[0] + 0x6ed9eba1;
+            dd = (dd << 13 | dd >> (32 - 13)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // HH(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[6], 6);
+            cc += H(dd, ee, aa) + blockDWords[6] + 0x6ed9eba1;
+            cc = (cc << 6 | cc >> (32 - 6)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // HH(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[13], 5);
+            bb += H(cc, dd, ee) + blockDWords[13] + 0x6ed9eba1;
+            bb = (bb << 5 | bb >> (32 - 5)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // HH(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[11], 12);
+            aa += H(bb, cc, dd) + blockDWords[11] + 0x6ed9eba1;
+            aa = (aa << 12 | aa >> (32 - 12)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // HH(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[5], 7);
+            ee += H(aa, bb, cc) + blockDWords[5] + 0x6ed9eba1;
+            ee = (ee << 7 | ee >> (32 - 7)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // HH(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[12], 5);
+            dd += H(ee, aa, bb) + blockDWords[12] + 0x6ed9eba1;
+            dd = (dd << 5 | dd >> (32 - 5)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // Left Round 4 
+            // II(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[1], 11);
+            cc += I(dd, ee, aa) + blockDWords[1] + 0x8f1bbcdc;
+            cc = (cc << 11 | cc >> (32 - 11)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // II(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[9], 12);
+            bb += I(cc, dd, ee) + blockDWords[9] + 0x8f1bbcdc;
+            bb = (bb << 12 | bb >> (32 - 12)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // II(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[11], 14);
+            aa += I(bb, cc, dd) + blockDWords[11] + 0x8f1bbcdc;
+            aa = (aa << 14 | aa >> (32 - 14)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // II(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[10], 15);
+            ee += I(aa, bb, cc) + blockDWords[10] + 0x8f1bbcdc;
+            ee = (ee << 15 | ee >> (32 - 15)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // II(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[0], 14);
+            dd += I(ee, aa, bb) + blockDWords[0] + 0x8f1bbcdc;
+            dd = (dd << 14 | dd >> (32 - 14)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // II(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[8], 15);
+            cc += I(dd, ee, aa) + blockDWords[8] + 0x8f1bbcdc;
+            cc = (cc << 15 | cc >> (32 - 15)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // II(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[12], 9);
+            bb += I(cc, dd, ee) + blockDWords[12] + 0x8f1bbcdc;
+            bb = (bb << 9 | bb >> (32 - 9)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // II(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[4], 8);
+            aa += I(bb, cc, dd) + blockDWords[4] + 0x8f1bbcdc;
+            aa = (aa << 8 | aa >> (32 - 8)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // II(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[13], 9);
+            ee += I(aa, bb, cc) + blockDWords[13] + 0x8f1bbcdc;
+            ee = (ee << 9 | ee >> (32 - 9)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // II(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[3], 14);
+            dd += I(ee, aa, bb) + blockDWords[3] + 0x8f1bbcdc;
+            dd = (dd << 14 | dd >> (32 - 14)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // II(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[7], 5);
+            cc += I(dd, ee, aa) + blockDWords[7] + 0x8f1bbcdc;
+            cc = (cc << 5 | cc >> (32 - 5)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // II(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[15], 6);
+            bb += I(cc, dd, ee) + blockDWords[15] + 0x8f1bbcdc;
+            bb = (bb << 6 | bb >> (32 - 6)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // II(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[14], 8);
+            aa += I(bb, cc, dd) + blockDWords[14] + 0x8f1bbcdc;
+            aa = (aa << 8 | aa >> (32 - 8)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // II(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[5], 6);
+            ee += I(aa, bb, cc) + blockDWords[5] + 0x8f1bbcdc;
+            ee = (ee << 6 | ee >> (32 - 6)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // II(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[6], 5);
+            dd += I(ee, aa, bb) + blockDWords[6] + 0x8f1bbcdc;
+            dd = (dd << 5 | dd >> (32 - 5)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // II(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[2], 12);
+            cc += I(dd, ee, aa) + blockDWords[2] + 0x8f1bbcdc;
+            cc = (cc << 12 | cc >> (32 - 12)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // Left Round 5 
+            // JJ(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[4], 9);
+            bb += J(cc, dd, ee) + blockDWords[4] + 0xa953fd4e;
+            bb = (bb << 9 | bb >> (32 - 9)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // JJ(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[0], 15);
+            aa += J(bb, cc, dd) + blockDWords[0] + 0xa953fd4e;
+            aa = (aa << 15 | aa >> (32 - 15)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // JJ(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[5], 5);
+            ee += J(aa, bb, cc) + blockDWords[5] + 0xa953fd4e;
+            ee = (ee << 5 | ee >> (32 - 5)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // JJ(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[9], 11);
+            dd += J(ee, aa, bb) + blockDWords[9] + 0xa953fd4e;
+            dd = (dd << 11 | dd >> (32 - 11)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // JJ(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[7], 6);
+            cc += J(dd, ee, aa) + blockDWords[7] + 0xa953fd4e;
+            cc = (cc << 6 | cc >> (32 - 6)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // JJ(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[12], 8);
+            bb += J(cc, dd, ee) + blockDWords[12] + 0xa953fd4e;
+            bb = (bb << 8 | bb >> (32 - 8)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // JJ(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[2], 13);
+            aa += J(bb, cc, dd) + blockDWords[2] + 0xa953fd4e;
+            aa = (aa << 13 | aa >> (32 - 13)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // JJ(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[10], 12);
+            ee += J(aa, bb, cc) + blockDWords[10] + 0xa953fd4e;
+            ee = (ee << 12 | ee >> (32 - 12)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // JJ(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[14], 5);
+            dd += J(ee, aa, bb) + blockDWords[14] + 0xa953fd4e;
+            dd = (dd << 5 | dd >> (32 - 5)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // JJ(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[1], 12);
+            cc += J(dd, ee, aa) + blockDWords[1] + 0xa953fd4e;
+            cc = (cc << 12 | cc >> (32 - 12)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // JJ(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[3], 13);
+            bb += J(cc, dd, ee) + blockDWords[3] + 0xa953fd4e;
+            bb = (bb << 13 | bb >> (32 - 13)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // JJ(ref aa, ref bb, ref cc, ref dd, ref ee, blockDWords[8], 14);
+            aa += J(bb, cc, dd) + blockDWords[8] + 0xa953fd4e;
+            aa = (aa << 14 | aa >> (32 - 14)) + ee;
+            cc = (cc << 10 | cc >> (32 - 10));
+
+            // JJ(ref ee, ref aa, ref bb, ref cc, ref dd, blockDWords[11], 11);
+            ee += J(aa, bb, cc) + blockDWords[11] + 0xa953fd4e;
+            ee = (ee << 11 | ee >> (32 - 11)) + dd;
+            bb = (bb << 10 | bb >> (32 - 10));
+
+            // JJ(ref dd, ref ee, ref aa, ref bb, ref cc, blockDWords[6], 8);
+            dd += J(ee, aa, bb) + blockDWords[6] + 0xa953fd4e;
+            dd = (dd << 8 | dd >> (32 - 8)) + cc;
+            aa = (aa << 10 | aa >> (32 - 10));
+
+            // JJ(ref cc, ref dd, ref ee, ref aa, ref bb, blockDWords[15], 5);
+            cc += J(dd, ee, aa) + blockDWords[15] + 0xa953fd4e;
+            cc = (cc << 5 | cc >> (32 - 5)) + bb;
+            ee = (ee << 10 | ee >> (32 - 10));
+
+            // JJ(ref bb, ref cc, ref dd, ref ee, ref aa, blockDWords[13], 6);
+            bb += J(cc, dd, ee) + blockDWords[13] + 0xa953fd4e;
+            bb = (bb << 6 | bb >> (32 - 6)) + aa;
+            dd = (dd << 10 | dd >> (32 - 10));
+
+            // Parallel Right Round 1 
+            // JJJ(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[5], 8);
+            aaa += J(bbb, ccc, ddd) + blockDWords[5] + 0x50a28be6;
+            aaa = (aaa << 8 | aaa >> (32 - 8)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // JJJ(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[14], 9);
+            eee += J(aaa, bbb, ccc) + blockDWords[14] + 0x50a28be6;
+            eee = (eee << 9 | eee >> (32 - 9)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // JJJ(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[7], 9);
+            ddd += J(eee, aaa, bbb) + blockDWords[7] + 0x50a28be6;
+            ddd = (ddd << 9 | ddd >> (32 - 9)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // JJJ(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[0], 11);
+            ccc += J(ddd, eee, aaa) + blockDWords[0] + 0x50a28be6;
+            ccc = (ccc << 11 | ccc >> (32 - 11)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // JJJ(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[9], 13);
+            bbb += J(ccc, ddd, eee) + blockDWords[9] + 0x50a28be6;
+            bbb = (bbb << 13 | bbb >> (32 - 13)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // JJJ(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[2], 15);
+            aaa += J(bbb, ccc, ddd) + blockDWords[2] + 0x50a28be6;
+            aaa = (aaa << 15 | aaa >> (32 - 15)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // JJJ(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[11], 15);
+            eee += J(aaa, bbb, ccc) + blockDWords[11] + 0x50a28be6;
+            eee = (eee << 15 | eee >> (32 - 15)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // JJJ(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[4], 5);
+            ddd += J(eee, aaa, bbb) + blockDWords[4] + 0x50a28be6;
+            ddd = (ddd << 5 | ddd >> (32 - 5)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // JJJ(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[13], 7);
+            ccc += J(ddd, eee, aaa) + blockDWords[13] + 0x50a28be6;
+            ccc = (ccc << 7 | ccc >> (32 - 7)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // JJJ(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[6], 7);
+            bbb += J(ccc, ddd, eee) + blockDWords[6] + 0x50a28be6;
+            bbb = (bbb << 7 | bbb >> (32 - 7)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // JJJ(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[15], 8);
+            aaa += J(bbb, ccc, ddd) + blockDWords[15] + 0x50a28be6;
+            aaa = (aaa << 8 | aaa >> (32 - 8)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // JJJ(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[8], 11);
+            eee += J(aaa, bbb, ccc) + blockDWords[8] + 0x50a28be6;
+            eee = (eee << 11 | eee >> (32 - 11)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // JJJ(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[1], 14);
+            ddd += J(eee, aaa, bbb) + blockDWords[1] + 0x50a28be6;
+            ddd = (ddd << 14 | ddd >> (32 - 14)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // JJJ(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[10], 14);
+            ccc += J(ddd, eee, aaa) + blockDWords[10] + 0x50a28be6;
+            ccc = (ccc << 14 | ccc >> (32 - 14)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // JJJ(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[3], 12);
+            bbb += J(ccc, ddd, eee) + blockDWords[3] + 0x50a28be6;
+            bbb = (bbb << 12 | bbb >> (32 - 12)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // JJJ(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[12], 6);
+            aaa += J(bbb, ccc, ddd) + blockDWords[12] + 0x50a28be6;
+            aaa = (aaa << 6 | aaa >> (32 - 6)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // Parallel Right Round 2 
+            // III(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[6], 9); 
+            eee += I(aaa, bbb, ccc) + blockDWords[6] + 0x5c4dd124;
+            eee = (eee << 9 | eee >> (32 - 9)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // III(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[11], 13);
+            ddd += I(eee, aaa, bbb) + blockDWords[11] + 0x5c4dd124;
+            ddd = (ddd << 13 | ddd >> (32 - 13)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // III(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[3], 15);
+            ccc += I(ddd, eee, aaa) + blockDWords[3] + 0x5c4dd124;
+            ccc = (ccc << 15 | ccc >> (32 - 15)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // III(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[7], 7);
+            bbb += I(ccc, ddd, eee) + blockDWords[7] + 0x5c4dd124;
+            bbb = (bbb << 7 | bbb >> (32 - 7)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // III(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[0], 12);
+            aaa += I(bbb, ccc, ddd) + blockDWords[0] + 0x5c4dd124;
+            aaa = (aaa << 12 | aaa >> (32 - 12)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // III(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[13], 8);
+            eee += I(aaa, bbb, ccc) + blockDWords[13] + 0x5c4dd124;
+            eee = (eee << 8 | eee >> (32 - 8)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // III(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[5], 9);
+            ddd += I(eee, aaa, bbb) + blockDWords[5] + 0x5c4dd124;
+            ddd = (ddd << 9 | ddd >> (32 - 9)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // III(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[10], 11);
+            ccc += I(ddd, eee, aaa) + blockDWords[10] + 0x5c4dd124;
+            ccc = (ccc << 11 | ccc >> (32 - 11)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // III(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[14], 7);
+            bbb += I(ccc, ddd, eee) + blockDWords[14] + 0x5c4dd124;
+            bbb = (bbb << 7 | bbb >> (32 - 7)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // III(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[15], 7);
+            aaa += I(bbb, ccc, ddd) + blockDWords[15] + 0x5c4dd124;
+            aaa = (aaa << 7 | aaa >> (32 - 7)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // III(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[8], 12);
+            eee += I(aaa, bbb, ccc) + blockDWords[8] + 0x5c4dd124;
+            eee = (eee << 12 | eee >> (32 - 12)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // III(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[12], 7);
+            ddd += I(eee, aaa, bbb) + blockDWords[12] + 0x5c4dd124;
+            ddd = (ddd << 7 | ddd >> (32 - 7)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // III(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[4], 6);
+            ccc += I(ddd, eee, aaa) + blockDWords[4] + 0x5c4dd124;
+            ccc = (ccc << 6 | ccc >> (32 - 6)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // III(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[9], 15);
+            bbb += I(ccc, ddd, eee) + blockDWords[9] + 0x5c4dd124;
+            bbb = (bbb << 15 | bbb >> (32 - 15)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // III(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[1], 13);
+            aaa += I(bbb, ccc, ddd) + blockDWords[1] + 0x5c4dd124;
+            aaa = (aaa << 13 | aaa >> (32 - 13)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // III(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[2], 11);
+            eee += I(aaa, bbb, ccc) + blockDWords[2] + 0x5c4dd124;
+            eee = (eee << 11 | eee >> (32 - 11)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // Parallel Right Round 3
+            // HHH(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[15], 9);
+            ddd += H(eee, aaa, bbb) + blockDWords[15] + 0x6d703ef3;
+            ddd = (ddd << 9 | ddd >> (32 - 9)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // HHH(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[5], 7);
+            ccc += H(ddd, eee, aaa) + blockDWords[5] + 0x6d703ef3;
+            ccc = (ccc << 7 | ccc >> (32 - 7)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // HHH(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[1], 15);
+            bbb += H(ccc, ddd, eee) + blockDWords[1] + 0x6d703ef3;
+            bbb = (bbb << 15 | bbb >> (32 - 15)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // HHH(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[3], 11);
+            aaa += H(bbb, ccc, ddd) + blockDWords[3] + 0x6d703ef3;
+            aaa = (aaa << 11 | aaa >> (32 - 11)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // HHH(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[7], 8);
+            eee += H(aaa, bbb, ccc) + blockDWords[7] + 0x6d703ef3;
+            eee = (eee << 8 | eee >> (32 - 8)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // HHH(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[14], 6);
+            ddd += H(eee, aaa, bbb) + blockDWords[14] + 0x6d703ef3;
+            ddd = (ddd << 6 | ddd >> (32 - 6)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // HHH(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[6], 6);
+            ccc += H(ddd, eee, aaa) + blockDWords[6] + 0x6d703ef3;
+            ccc = (ccc << 6 | ccc >> (32 - 6)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // HHH(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[9], 14);
+            bbb += H(ccc, ddd, eee) + blockDWords[9] + 0x6d703ef3;
+            bbb = (bbb << 14 | bbb >> (32 - 14)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // HHH(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[11], 12);
+            aaa += H(bbb, ccc, ddd) + blockDWords[11] + 0x6d703ef3;
+            aaa = (aaa << 12 | aaa >> (32 - 12)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // HHH(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[8], 13);
+            eee += H(aaa, bbb, ccc) + blockDWords[8] + 0x6d703ef3;
+            eee = (eee << 13 | eee >> (32 - 13)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // HHH(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[12], 5);
+            ddd += H(eee, aaa, bbb) + blockDWords[12] + 0x6d703ef3;
+            ddd = (ddd << 5 | ddd >> (32 - 5)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // HHH(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[2], 14);
+            ccc += H(ddd, eee, aaa) + blockDWords[2] + 0x6d703ef3;
+            ccc = (ccc << 14 | ccc >> (32 - 14)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // HHH(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[10], 13);
+            bbb += H(ccc, ddd, eee) + blockDWords[10] + 0x6d703ef3;
+            bbb = (bbb << 13 | bbb >> (32 - 13)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // HHH(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[0], 13);
+            aaa += H(bbb, ccc, ddd) + blockDWords[0] + 0x6d703ef3;
+            aaa = (aaa << 13 | aaa >> (32 - 13)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // HHH(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[4], 7);
+            eee += H(aaa, bbb, ccc) + blockDWords[4] + 0x6d703ef3;
+            eee = (eee << 7 | eee >> (32 - 7)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // HHH(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[13], 5);
+            ddd += H(eee, aaa, bbb) + blockDWords[13] + 0x6d703ef3;
+            ddd = (ddd << 5 | ddd >> (32 - 5)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // Parallel Right Round 4
+            // GGG(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[8], 15);
+            ccc += G(ddd, eee, aaa) + blockDWords[8] + 0x7a6d76e9;
+            ccc = (ccc << 15 | ccc >> (32 - 15)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // GGG(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[6], 5);
+            bbb += G(ccc, ddd, eee) + blockDWords[6] + 0x7a6d76e9;
+            bbb = (bbb << 5 | bbb >> (32 - 5)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // GGG(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[4], 8);
+            aaa += G(bbb, ccc, ddd) + blockDWords[4] + 0x7a6d76e9;
+            aaa = (aaa << 8 | aaa >> (32 - 8)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // GGG(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[1], 11);
+            eee += G(aaa, bbb, ccc) + blockDWords[1] + 0x7a6d76e9;
+            eee = (eee << 11 | eee >> (32 - 11)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // GGG(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[3], 14);
+            ddd += G(eee, aaa, bbb) + blockDWords[3] + 0x7a6d76e9;
+            ddd = (ddd << 14 | ddd >> (32 - 14)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // GGG(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[11], 14);
+            ccc += G(ddd, eee, aaa) + blockDWords[11] + 0x7a6d76e9;
+            ccc = (ccc << 14 | ccc >> (32 - 14)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // GGG(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[15], 6);
+            bbb += G(ccc, ddd, eee) + blockDWords[15] + 0x7a6d76e9;
+            bbb = (bbb << 6 | bbb >> (32 - 6)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // GGG(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[0], 14);
+            aaa += G(bbb, ccc, ddd) + blockDWords[0] + 0x7a6d76e9;
+            aaa = (aaa << 14 | aaa >> (32 - 14)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // GGG(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[5], 6);
+            eee += G(aaa, bbb, ccc) + blockDWords[5] + 0x7a6d76e9;
+            eee = (eee << 6 | eee >> (32 - 6)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // GGG(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[12], 9);
+            ddd += G(eee, aaa, bbb) + blockDWords[12] + 0x7a6d76e9;
+            ddd = (ddd << 9 | ddd >> (32 - 9)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // GGG(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[2], 12);
+            ccc += G(ddd, eee, aaa) + blockDWords[2] + 0x7a6d76e9;
+            ccc = (ccc << 12 | ccc >> (32 - 12)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // GGG(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[13], 9);
+            bbb += G(ccc, ddd, eee) + blockDWords[13] + 0x7a6d76e9;
+            bbb = (bbb << 9 | bbb >> (32 - 9)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // GGG(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[9], 12);
+            aaa += G(bbb, ccc, ddd) + blockDWords[9] + 0x7a6d76e9;
+            aaa = (aaa << 12 | aaa >> (32 - 12)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // GGG(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[7], 5);
+            eee += G(aaa, bbb, ccc) + blockDWords[7] + 0x7a6d76e9;
+            eee = (eee << 5 | eee >> (32 - 5)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // GGG(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[10], 15);
+            ddd += G(eee, aaa, bbb) + blockDWords[10] + 0x7a6d76e9;
+            ddd = (ddd << 15 | ddd >> (32 - 15)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // GGG(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[14], 8);
+            ccc += G(ddd, eee, aaa) + blockDWords[14] + 0x7a6d76e9;
+            ccc = (ccc << 8 | ccc >> (32 - 8)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // Parallel Right Round 5 
+            // FFF(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[12], 8);
+            bbb += F(ccc, ddd, eee) + blockDWords[12];
+            bbb = (bbb << 8 | bbb >> (32 - 8)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // FFF(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[15], 5);
+            aaa += F(bbb, ccc, ddd) + blockDWords[15];
+            aaa = (aaa << 5 | aaa >> (32 - 5)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // FFF(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[10], 12);
+            eee += F(aaa, bbb, ccc) + blockDWords[10];
+            eee = (eee << 12 | eee >> (32 - 12)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // FFF(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[4], 9);
+            ddd += F(eee, aaa, bbb) + blockDWords[4];
+            ddd = (ddd << 9 | ddd >> (32 - 9)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // FFF(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[1], 12);
+            ccc += F(ddd, eee, aaa) + blockDWords[1];
+            ccc = (ccc << 12 | ccc >> (32 - 12)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // FFF(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[5], 5);
+            bbb += F(ccc, ddd, eee) + blockDWords[5];
+            bbb = (bbb << 5 | bbb >> (32 - 5)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // FFF(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[8], 14);
+            aaa += F(bbb, ccc, ddd) + blockDWords[8];
+            aaa = (aaa << 14 | aaa >> (32 - 14)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // FFF(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[7], 6);
+            eee += F(aaa, bbb, ccc) + blockDWords[7];
+            eee = (eee << 6 | eee >> (32 - 6)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // FFF(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[6], 8);
+            ddd += F(eee, aaa, bbb) + blockDWords[6];
+            ddd = (ddd << 8 | ddd >> (32 - 8)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // FFF(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[2], 13);
+            ccc += F(ddd, eee, aaa) + blockDWords[2];
+            ccc = (ccc << 13 | ccc >> (32 - 13)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // FFF(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[13], 6);
+            bbb += F(ccc, ddd, eee) + blockDWords[13];
+            bbb = (bbb << 6 | bbb >> (32 - 6)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // FFF(ref aaa, ref bbb, ref ccc, ref ddd, ref eee, blockDWords[14], 5);
+            aaa += F(bbb, ccc, ddd) + blockDWords[14];
+            aaa = (aaa << 5 | aaa >> (32 - 5)) + eee;
+            ccc = (ccc << 10 | ccc >> (32 - 10));
+
+            // FFF(ref eee, ref aaa, ref bbb, ref ccc, ref ddd, blockDWords[0], 15);
+            eee += F(aaa, bbb, ccc) + blockDWords[0];
+            eee = (eee << 15 | eee >> (32 - 15)) + ddd;
+            bbb = (bbb << 10 | bbb >> (32 - 10));
+
+            // FFF(ref ddd, ref eee, ref aaa, ref bbb, ref ccc, blockDWords[3], 13);
+            ddd += F(eee, aaa, bbb) + blockDWords[3];
+            ddd = (ddd << 13 | ddd >> (32 - 13)) + ccc;
+            aaa = (aaa << 10 | aaa >> (32 - 10));
+
+            // FFF(ref ccc, ref ddd, ref eee, ref aaa, ref bbb, blockDWords[9], 11);
+            ccc += F(ddd, eee, aaa) + blockDWords[9];
+            ccc = (ccc << 11 | ccc >> (32 - 11)) + bbb;
+            eee = (eee << 10 | eee >> (32 - 10));
+
+            // FFF(ref bbb, ref ccc, ref ddd, ref eee, ref aaa, blockDWords[11], 11);
+            bbb += F(ccc, ddd, eee) + blockDWords[11];
+            bbb = (bbb << 11 | bbb >> (32 - 11)) + aaa;
+            ddd = (ddd << 10 | ddd >> (32 - 10));
+
+            // Update the state of the hash object
+            ddd += cc + state[1];
+            state[1] = state[2] + dd + eee;
+            state[2] = state[3] + ee + aaa;
+            state[3] = state[4] + aa + bbb;
+            state[4] = state[0] + bb + ccc;
+            state[0] = ddd;
+        }
+
+        // The five basic functions
+        private static uint F(uint x, uint y, uint z)
+        {
+            return (x ^ y ^ z);
+        }
+
+        private static uint G(uint x, uint y, uint z)
+        {
+            return ((x & y) | (~x & z));
+        }
+
+        private static uint H(uint x, uint y, uint z)
+        {
+            return ((x | ~y) ^ z);
+        }
+
+        private static uint I(uint x, uint y, uint z)
+        {
+            return ((x & z) | (y & ~z));
+        }
+
+        private static uint J(uint x, uint y, uint z)
+        {
+            return (x ^ (y | ~z));
+        }
+
+        [SecurityCritical]  // auto-generated
+        private unsafe static void DWORDFromLittleEndian(uint* x, int digits, byte* block)
+        {
+            int i;
+            int j;
+
+            for (i = 0, j = 0; i < digits; i++, j += 4)
+                x[i] = (uint)(block[j] | (block[j + 1] << 8) | (block[j + 2] << 16) | (block[j + 3] << 24));
+        }
+
+        private static void DWORDToLittleEndian(byte[] block, uint[] x, int digits)
+        {
+            int i;
+            int j;
+
+            for (i = 0, j = 0; i < digits; i++, j += 4)
+            {
+                block[j] = (byte)(x[i] & 0xff);
+                block[j + 1] = (byte)((x[i] >> 8) & 0xff);
+                block[j + 2] = (byte)((x[i] >> 16) & 0xff);
+                block[j + 3] = (byte)((x[i] >> 24) & 0xff);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
these changes remove the dependency on NEO.dll and NEO.VM.dll from NEON. This is the first step towards having a single NEON tool that targets NEO 2 and 3.

Note, this is PR is not ready to merge. I'm opening it as a draft PR in order to facilitate discussion.