### PR TITLE
Fix publish updating the nuget

### DIFF
--- a/src/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
+++ b/src/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.3" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
     <PackageReference Include="Neo" Version="3.0.0-CI00172" />
   </ItemGroup>
 


### PR DESCRIPTION
Close #85 (@lock9 we should provide releases like other projects)

Using this command:

`dotnet publish -c Release /p:PublishSingleFile=true -r win-x64 -f netcoreapp2.0`

Before this change:

![image](https://user-images.githubusercontent.com/3167973/64675995-d23cb700-d474-11e9-9e80-7af42cc23655.png)

After this change, it works as expected

![image](https://user-images.githubusercontent.com/3167973/64676034-e54f8700-d474-11e9-9ed9-97581e18651b.png)
