### PR TITLE
Fix OOM abusing large arrays (3x)

### DIFF
--- a/src/Neo.Compiler.MSIL/Helper.cs
+++ b/src/Neo.Compiler.MSIL/Helper.cs
@@ -1,11 +1,26 @@
+using Mono.Cecil;
 using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Neo.Compiler
 {
     public static class Helper
     {
+        private readonly static Regex _regex_cctor = new Regex(@".*\:\:\.cctor\(\)");
+        private readonly static Regex _regex_ctor = new Regex(@".*\:\:\.ctor\(\)");
+
+        public static bool Is_cctor(this MethodDefinition method)
+        {
+            return method.IsConstructor && _regex_cctor.IsMatch(method.FullName);
+        }
+
+        public static bool Is_ctor(this MethodDefinition method)
+        {
+            return method.IsConstructor && _regex_ctor.IsMatch(method.FullName);
+        }
+
         public static uint ToInteropMethodHash(this string method)
         {
             return ToInteropMethodHash(Encoding.ASCII.GetBytes(method));

--- a/src/Neo.Compiler.MSIL/Helper.cs
+++ b/src/Neo.Compiler.MSIL/Helper.cs
@@ -8,8 +8,10 @@ namespace Neo.Compiler
 {
     public static class Helper
     {
+        // System.Void Neo.Compiler.MSIL.TestClasses.Contract_syscall::.cctor()
         private readonly static Regex _regex_cctor = new Regex(@".*\:\:\.cctor\(\)");
-        private readonly static Regex _regex_ctor = new Regex(@".*\:\:\.ctor\(\)");
+        // System.Void Neo.Compiler.MSIL.TestClasses.Contract_syscall::.ctor(System.Int32)
+        private readonly static Regex _regex_ctor = new Regex(@".*\:\:\.ctor\(.*\)");
 
         public static bool Is_cctor(this MethodDefinition method)
         {

--- a/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
@@ -6,7 +6,9 @@ namespace Neo.Compiler.MSIL
 {
     class CctorSubVM
     {
-        static Stack<object> calcStack;
+        private const ushort MaxArraySize = ushort.MaxValue;
+        private static Stack<object> calcStack;
+
         public static object Dup(object src)
         {
             if (src.GetType() == typeof(byte[]))
@@ -35,6 +37,7 @@ namespace Neo.Compiler.MSIL
                 return null;
             }
         }
+
         public static byte[] HexString2Bytes(string str)
         {
             byte[] outd = new byte[str.Length / 2];
@@ -44,6 +47,7 @@ namespace Neo.Compiler.MSIL
             }
             return outd;
         }
+
         public static void Parse(ILMethod from, NeoModule to)
         {
             calcStack = new Stack<object>();
@@ -100,6 +104,7 @@ namespace Neo.Compiler.MSIL
                             if ((src.tokenType == "System.Byte") || (src.tokenType == "System.SByte"))
                             {
                                 var count = (int)calcStack.Pop();
+                                if (count > MaxArraySize) throw new ArgumentException("MaxArraySize found");
                                 byte[] data = new byte[count];
                                 calcStack.Push(data);
                             }

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
@@ -985,16 +985,11 @@ namespace Neo.Compiler.MSIL
             try
             {
                 NeoMethod nm = new NeoMethod();
-                if (method.FullName.Contains(".cctor"))
+                if (method.IsConstructor)
                 {
                     CctorSubVM.Parse(_method, this.outModule);
                     //continue;
                     return false;
-                }
-                if (method.IsConstructor)
-                {
-                    return false;
-                    //continue;
                 }
                 nm._namespace = method.DeclaringType.FullName;
                 nm.name = method.FullName;

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
@@ -985,11 +985,16 @@ namespace Neo.Compiler.MSIL
             try
             {
                 NeoMethod nm = new NeoMethod();
-                if (method.IsConstructor)
+                if (method.Is_cctor())
                 {
                     CctorSubVM.Parse(_method, this.outModule);
                     //continue;
                     return false;
+                }
+                if (method.Is_ctor())
+                {
+                    return false;
+                    //continue;
                 }
                 nm._namespace = method.DeclaringType.FullName;
                 nm.name = method.FullName;

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -86,12 +86,11 @@ namespace Neo.Compiler.MSIL
                     if (m.Value.method.IsAddOn || m.Value.method.IsRemoveOn)
                         continue;//event 自动生成的代码，不要
                     NeoMethod nm = new NeoMethod();
-                    if (m.Key.Contains(".cctor"))
+                    if (m.Value.method.IsConstructor)
                     {
                         CctorSubVM.Parse(m.Value, this.outModule);
                         continue;
                     }
-                    if (m.Value.method.IsConstructor) continue;
                     nm._namespace = m.Value.method.DeclaringType.FullName;
                     nm.name = m.Value.method.FullName;
                     nm.displayName = m.Value.method.Name;
@@ -145,9 +144,8 @@ namespace Neo.Compiler.MSIL
 
                 foreach (var m in value.methods)
                 {
-
                     if (m.Value.method == null) continue;
-                    if (m.Key.Contains(".cctor"))
+                    if (m.Value.method.IsConstructor)
                     {
                         continue;
                     }

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -86,11 +86,12 @@ namespace Neo.Compiler.MSIL
                     if (m.Value.method.IsAddOn || m.Value.method.IsRemoveOn)
                         continue;//event 自动生成的代码，不要
                     NeoMethod nm = new NeoMethod();
-                    if (m.Value.method.IsConstructor)
+                    if (m.Value.method.Is_cctor())
                     {
                         CctorSubVM.Parse(m.Value, this.outModule);
                         continue;
                     }
+                    if (m.Value.method.Is_ctor()) continue;
                     nm._namespace = m.Value.method.DeclaringType.FullName;
                     nm.name = m.Value.method.FullName;
                     nm.displayName = m.Value.method.Name;
@@ -145,7 +146,7 @@ namespace Neo.Compiler.MSIL
                 foreach (var m in value.methods)
                 {
                     if (m.Value.method == null) continue;
-                    if (m.Value.method.IsConstructor)
+                    if (m.Value.method.Is_cctor())
                     {
                         continue;
                     }


### PR DESCRIPTION
Close https://github.com/neo-project/neo-devpack-dotnet/issues/112

Fixes:

- `MaxArraySize` was added in order to prevent big arrays that the VM can't handle
- Constructor detection was improved because is bypaseable using `cctor` as class name
