### PR TITLE
Add metadata information to generated .abi.json file (master-2.x)

### DIFF
--- a/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_metadata.cs
+++ b/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_metadata.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel;
+using System.Numerics;
+
+[assembly: Neo.SmartContract.Framework.ContractDescription("contract description")]
+[assembly: Neo.SmartContract.Framework.ContractTitle("contract title")]
+[assembly: Neo.SmartContract.Framework.ContractVersion("contract version")]
+[assembly: Neo.SmartContract.Framework.ContractAuthor("contract author")]
+[assembly: Neo.SmartContract.Framework.ContractEmail("contract email")]
+[assembly: Neo.SmartContract.Framework.ContractHasDynamicInvoke]
+[assembly: Neo.SmartContract.Framework.ContractHasStorage]
+[assembly: Neo.SmartContract.Framework.ContractIsPayable]
+
+namespace Neo.Compiler.MSIL.TestClasses
+{
+    public class Contract_Metadata : SmartContract.Framework.SmartContract
+    {
+        public static void Main(string method, object[] args) { }
+    }
+}

--- a/Neo.Compiler.MSIL.UnitTests/UnitTest_Metadata.cs
+++ b/Neo.Compiler.MSIL.UnitTests/UnitTest_Metadata.cs
@@ -1,0 +1,48 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.MSIL.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Neo.Compiler.MSIL
+{
+    [TestClass]
+    public class UnitTest_Metadata
+    {
+        [TestMethod]
+        public void Test_default_Metadata()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_Event.cs");
+            var abi = testengine.ScriptEntry.finialABI;
+            var metadata = abi["metadata"].asDict();
+
+            Assert.AreEqual(metadata["title"].AsString(), "TestContract");
+            Assert.AreEqual(metadata["version"].AsString(), "0.0.0.0");
+            Assert.AreEqual(metadata["description"].AsString(), null);
+            Assert.AreEqual(metadata["author"].AsString(), null);
+            Assert.AreEqual(metadata["email"].AsString(), null);
+            Assert.AreEqual(metadata["has-storage"].AsBool(), false);
+            Assert.AreEqual(metadata["has-dynamic-invoke"].AsBool(), false);
+            Assert.AreEqual(metadata["is-payable"].AsBool(), false);
+        }
+
+        [TestMethod]
+        public void Test_Metadata()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_metadata.cs");
+            var abi = testengine.ScriptEntry.finialABI;
+            var metadata = abi["metadata"].asDict();
+
+            Assert.AreEqual(metadata["title"].AsString(), "contract title");
+            Assert.AreEqual(metadata["version"].AsString(), "contract version");
+            Assert.AreEqual(metadata["description"].AsString(), "contract description");
+            Assert.AreEqual(metadata["author"].AsString(), "contract author");
+            Assert.AreEqual(metadata["email"].AsString(), "contract email");
+            Assert.AreEqual(metadata["has-storage"].AsBool(), true);
+            Assert.AreEqual(metadata["has-dynamic-invoke"].AsBool(), true);
+            Assert.AreEqual(metadata["is-payable"].AsBool(), true);
+        }
+    }
+}

--- a/Neo.Compiler.MSIL/FuncExport.cs
+++ b/Neo.Compiler.MSIL/FuncExport.cs
@@ -62,6 +62,7 @@ namespace vmtool
 
             return "Unknown:" + _type;
         }
+
         public static MyJson.JsonNode_Object Export(NeoModule module, byte[] script)
         {
             var sha256 = System.Security.Cryptography.SHA256.Create();
@@ -79,6 +80,18 @@ namespace vmtool
                 sb.Append(b.ToString("x02"));
             }
             outjson.SetDictValue("hash", sb.ToString());
+
+            //metadata
+            var metadataJson = new MyJson.JsonNode_Object();
+            metadataJson.SetDictValue("title", module.Title);
+            metadataJson.SetDictValue("description", module.Description);
+            metadataJson.SetDictValue("version", module.Version);
+            metadataJson.SetDictValue("author", module.Author);
+            metadataJson.SetDictValue("email", module.Email);
+            metadataJson.SetDictValue("has-storage", module.HasStorage);
+            metadataJson.SetDictValue("has-dynamic-invoke", module.HasDynamicInvoke);
+            metadataJson.SetDictValue("is-payable", module.IsPayable);
+            outjson.SetDictValue("metadata", metadataJson);
 
             //entrypoint
             outjson.SetDictValue("entrypoint", "Main");

--- a/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -73,6 +73,9 @@ namespace Neo.Compiler.MSIL
             {
                 option = option ?? ConvOption.Default
             };
+
+            ParseMetadata(this.inModule, this.outModule);
+
             foreach (var t in _in.mapType)
             {
                 if (t.Key.Contains("<"))
@@ -300,6 +303,56 @@ namespace Neo.Compiler.MSIL
                         throw new Exception("not have right fill bytes");
                     }
                     c.needfixfunc = false;
+                }
+            }
+        }
+
+        private static void ParseMetadata(ILModule inModule, NeoModule outModule)
+        {
+            var assemblyDef = inModule.module.Assembly;
+            outModule.Title = assemblyDef.Name.Name;
+            outModule.Version = assemblyDef.Name.Version.ToString();
+
+            foreach (var attrib in assemblyDef.CustomAttributes)
+            {
+                switch (attrib.AttributeType.FullName)
+                {
+                    case "System.Reflection.AssemblyTitleAttribute":
+                        if (outModule.Title == assemblyDef.Name.Name)
+                        {
+                            outModule.Title = attrib.ConstructorArguments[0].Value.ToString();
+                        }
+                        break;
+                    case "System.Reflection.AssemblyDescriptionAttribute":
+                        if (string.IsNullOrEmpty(outModule.Description))
+                        {
+                            outModule.Description = attrib.ConstructorArguments[0].Value.ToString();
+                        }
+                        break;
+                    case "Neo.SmartContract.Framework.ContractAuthor":
+                        outModule.Author = attrib.ConstructorArguments[0].Value.ToString();
+                        break;
+                    case "Neo.SmartContract.Framework.ContractDescription":
+                        outModule.Description = attrib.ConstructorArguments[0].Value.ToString();
+                        break;
+                    case "Neo.SmartContract.Framework.ContractEmail":
+                        outModule.Email = attrib.ConstructorArguments[0].Value.ToString();
+                        break;
+                    case "Neo.SmartContract.Framework.ContractHasDynamicInvoke":
+                        outModule.HasDynamicInvoke = true;
+                        break;
+                    case "Neo.SmartContract.Framework.ContractHasStorage":
+                        outModule.HasStorage = true;
+                        break;
+                    case "Neo.SmartContract.Framework.ContractIsPayable":
+                        outModule.IsPayable = true;
+                        break;
+                    case "Neo.SmartContract.Framework.ContractTitle":
+                        outModule.Title = attrib.ConstructorArguments[0].Value.ToString();
+                        break;
+                    case "Neo.SmartContract.Framework.ContractVersion":
+                        outModule.Version = attrib.ConstructorArguments[0].Value.ToString();
+                        break;
                 }
             }
         }

--- a/Neo.Compiler.MSIL/NeoModule.cs
+++ b/Neo.Compiler.MSIL/NeoModule.cs
@@ -7,6 +7,15 @@ namespace Neo.Compiler
 {
     public class NeoModule
     {
+        public string Title;
+        public string Description;
+        public string Version;
+        public string Author;
+        public string Email;
+        public bool HasStorage;
+        public bool HasDynamicInvoke;
+        public bool IsPayable;
+
         public NeoModule(ILogger logger)
         {
         }

--- a/Neo.SmartContract.Framework/ContractMetadata.cs
+++ b/Neo.SmartContract.Framework/ContractMetadata.cs
@@ -37,7 +37,7 @@ namespace Neo.SmartContract.Framework
     }
 
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
-    public sealed class ContractHasDynamicInvoke: Attribute
+    public sealed class ContractHasDynamicInvoke : Attribute
     {
     }
 

--- a/Neo.SmartContract.Framework/ContractMetadata.cs
+++ b/Neo.SmartContract.Framework/ContractMetadata.cs
@@ -1,0 +1,75 @@
+using Neo.VM;
+using System;
+
+namespace Neo.SmartContract.Framework
+{
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractAuthor : Attribute
+    {
+        public ContractAuthor(string author)
+        {
+            Author = author;
+        }
+
+        public string Author { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractDescription : Attribute
+    {
+        public ContractDescription(string description)
+        {
+            Description = description;
+        }
+
+        public string Description { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractEmail : Attribute
+    {
+        public ContractEmail(string email)
+        {
+            Email = email;
+        }
+
+        public string Email { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractHasDynamicInvoke: Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractHasStorage : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractIsPayable : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractTitle : Attribute
+    {
+        public ContractTitle(string title)
+        {
+            Title = title;
+        }
+
+        public string Title { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class ContractVersion : Attribute
+    {
+        public ContractVersion(string version)
+        {
+            Version = version;
+        }
+
+        public string Version { get; }
+    }
+}


### PR DESCRIPTION
Fixes #144 

This PR adds a new "metadata" property to the .abi.json file generated by NEON (2.x branch). It contains the metadata needed by [Neo.Contract.Create](https://github.com/neo-project/neo/blob/master-2.x/neo/SmartContract/NeoService.cs#L682) to deploy contracts that can't be obtained from the AVM or existing .abi.json file. 

Having this information included in the abi.json file enables tools like [neo-express](https://github.com/neo-project/neo-express) and [neo-visual-devtracker](https://github.com/neo-project/neo-visual-tracker) to deploy contracts w/o collecting this information from the developer at contract deployment time. Additionally, by specifying these values in source (as per below), we also reduce the potential for errors at contract deployment time.

The contract metadata can be included in the contract C# source code via a set of new custom attributes that this PR adds to the Neo.SmartContract.Framework package. 

``` csharp
using Neo.SmartContract.Framework;

[assembly: ContractTitle("MyTestContract")]
[assembly: ContractDescription("This is the description of my contract")]
[assembly: ContractVersion("2.0")]
[assembly: ContractAuthor("DevHawk")]
[assembly: ContractEmail("devhawk@outlook.com")]
[assembly: ContractHasStorage]

// can also specify a contract can be dynamically invoked or is payable
// [assembly: ContractHasDynamicInvoke]
// [assembly: ContractIsPayable]
```

The resulting metadata node looks in the contract.abi.json file looks like this:

```json
"metadata":
{
    "title":"MyTestContract",
    "description":"This is a description of my contract",
    "version":"2.0",
    "author":"DevHawk",
    "email":"devhawk@outlook.com",
    "has-storage":true,
    "has-dynamic-invoke":false,
    "is-payable":false
},
```

NEON uses the following defaults if metadata is not specified via custom attributes:

* Contract title defaults to the AssemblyDef.Name.Name field defined in metadata.
* Contract version defaults to the AssemblyDef.Name.Version field defined in metadata
* Remaining string properties default to empty string
* Boolean properties default to false

The .NET library already has [`AssemblyTitleAttribute`](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblytitleattribute) and [`AssemblyDescriptionAttribute`](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblydescriptionattribute) custom attributes. If these attributes are specified, NEON will use them for contract title and description respectively. However, if both standard and Neo contract attributes are used to specify the same metadata, NEON will use the value from the Neo contract attribute.