### PR TITLE
Update NEON to emit debug information 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Add package coverlet.msbuild
       run: find Neo.Compiler.MSIL.UnitTests -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
     - name: Test Neo.Compiler.MSIL.UnitTests
-      run: dotnet test Neo.Compiler.MSIL.UnitTests /p:CollectCoverage=true /p:CoverletOutput=${GITHUB_WORKSPACE}/coverage/ /p:Exclude="[Neo.SmartContract.*]*"
+      run: dotnet test Neo.Compiler.MSIL.UnitTests /p:CollectCoverage=true /p:CoverletOutput=${GITHUB_WORKSPACE}/coverage/lcov /p:Exclude="[Neo.SmartContract.*]*" /p:CoverletOutputFormat=lcov
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         dotnet tool install --tool-path ./ dotnet-format
         ./dotnet-format --check --dry-run -v diagnostic
     - name: Add package coverlet.msbuild
-      run: find tests -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
+      run: find Neo.Compiler.MSIL.UnitTests -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
     - name: Test Neo.Compiler.MSIL.UnitTests
       run: dotnet test Neo.Compiler.MSIL.UnitTests /p:CollectCoverage=true /p:CoverletOutput=${GITHUB_WORKSPACE}/coverage/ /p:Exclude="[Neo.SmartContract.*]*"
     - name: Coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: .NET Core Test and Publish
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+env:
+  DOTNET_VERSION: 3.1.100
+
+jobs:
+
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Check format
+      run: |
+        dotnet tool install --tool-path ./ dotnet-format
+        ./dotnet-format --check --dry-run -v diagnostic
+    - name: Add package coverlet.msbuild
+      run: find tests -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
+    - name: Test Neo.Compiler.MSIL.UnitTests
+      run: dotnet test Neo.Compiler.MSIL.UnitTests /p:CollectCoverage=true /p:CoverletOutput=${GITHUB_WORKSPACE}/coverage/ /p:Exclude="[Neo.SmartContract.*]*"
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Neo.Compiler.MSIL.UnitTests/Neo.Compiler.MSIL.UnitTests.csproj
+++ b/Neo.Compiler.MSIL.UnitTests/Neo.Compiler.MSIL.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Neo.Compiler.MSIL</RootNamespace>
   </PropertyGroup>

--- a/Neo.Compiler.MSIL.UnitTests/UnitTest_DebugInfo.cs
+++ b/Neo.Compiler.MSIL.UnitTests/UnitTest_DebugInfo.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.MSIL.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Neo.Compiler.MSIL
+{
+    [TestClass]
+    public class UnitTest_DebugInfo
+    {
+        [TestMethod]
+        public void Test_DebugInfo()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_Event.cs");
+            var debugInfo = testengine.ScriptEntry.debugInfo;
+            Assert.IsTrue(debugInfo.HaveDictItem("entrypoint"));
+            Assert.AreEqual(debugInfo["entrypoint"].type, MyJson.JsonType.Value_String);
+            Assert.IsTrue(debugInfo.HaveDictItem("documents"));
+            Assert.AreEqual(debugInfo["documents"].type, MyJson.JsonType.Array);
+            Assert.IsTrue(debugInfo["documents"].AsList().Count == 1);
+            Assert.IsTrue(debugInfo["documents"].AsList().All(n => n.type == MyJson.JsonType.Value_String));
+            Assert.IsTrue(debugInfo.HaveDictItem("methods"));
+            Assert.AreEqual(debugInfo["methods"].type, MyJson.JsonType.Array);
+            Assert.AreEqual(debugInfo["methods"].AsList().Count, 1);
+            Assert.AreEqual(debugInfo["methods"].AsList()[0].asDict()["name"].AsString(), "Neo.Compiler.MSIL.TestClasses.Contract_Event,Main");
+            Assert.IsTrue(debugInfo.HaveDictItem("events"));
+            Assert.AreEqual(debugInfo["events"].type, MyJson.JsonType.Array);
+            Assert.AreEqual(debugInfo["events"].AsList().Count, 1);
+            Assert.AreEqual(debugInfo["events"].AsList()[0].asDict()["name"].AsString(), "Neo.Compiler.MSIL.TestClasses.Contract_Event,transfer");
+        }
+    }
+}

--- a/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
@@ -12,7 +12,7 @@ namespace Neo.Compiler.MSIL.Utils
         public ModuleConverter converterIL { get; private set; }
         public byte[] finalAVM { get; private set; }
         public MyJson.JsonNode_Object finialABI { get; private set; }
-        public MyJson.JsonNode_Object debugInfo {get; private set; }
+        public MyJson.JsonNode_Object debugInfo { get; private set; }
 
         public BuildScript() { }
 

--- a/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
@@ -12,6 +12,7 @@ namespace Neo.Compiler.MSIL.Utils
         public ModuleConverter converterIL { get; private set; }
         public byte[] finalAVM { get; private set; }
         public MyJson.JsonNode_Object finialABI { get; private set; }
+        public MyJson.JsonNode_Object debugInfo {get; private set; }
 
         public BuildScript() { }
 
@@ -50,6 +51,7 @@ namespace Neo.Compiler.MSIL.Utils
             try
             {
                 finialABI = vmtool.FuncExport.Export(converterIL.outModule, finalAVM);
+                debugInfo = DebugExport.Export(converterIL.outModule);
             }
             catch { }
         }

--- a/Neo.Compiler.MSIL/DebugExport.cs
+++ b/Neo.Compiler.MSIL/DebugExport.cs
@@ -8,7 +8,7 @@ using vmtool;
 
 namespace Neo.Compiler
 {
-    static class DebugExport
+    public static class DebugExport
     {
         private static MyJson.JsonNode_Array GetSequencePoints(IEnumerable<NeoCode> codes, IDictionary<string, int> docMap)
         {

--- a/Neo.Compiler.MSIL/DebugExport.cs
+++ b/Neo.Compiler.MSIL/DebugExport.cs
@@ -1,0 +1,147 @@
+using Mono.Cecil.Cil;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using vmtool;
+
+namespace Neo.Compiler
+{
+    static class DebugExport
+    {
+        private static MyJson.JsonNode_Array GetSequencePoints(IEnumerable<NeoCode> codes, IDictionary<string, int> docMap)
+        {
+            var points = codes
+                .Where(code => code.sequencePoint != null)
+                .Select(code => (code.addr, code.sequencePoint));
+
+            var outjson = new MyJson.JsonNode_Array();
+
+            foreach (var (address, sequencePoint) in points)
+            {
+                var range = string.Format("{0}:{1}-{2}:{3}",
+                    sequencePoint.StartLine,
+                    sequencePoint.StartColumn,
+                    sequencePoint.EndLine,
+                    sequencePoint.EndColumn);
+
+                var spjson = new MyJson.JsonNode_Object();
+                spjson.SetDictValue("addr", address);
+                spjson.SetDictValue("doc", docMap[sequencePoint.Document.Url]);
+                spjson.SetDictValue("range", range);
+
+                outjson.Add(spjson);
+            }
+
+            return outjson;
+        }
+
+        static string ConvertType(string type)
+        {
+            if (type == "System.Object")
+                return string.Empty;
+
+            return FuncExport.ConvType(type);
+        }
+
+        static MyJson.JsonNode_Array GetParameters(IList<NeoParam> @params)
+        {
+            var paramsJson = new MyJson.JsonNode_Array();
+            foreach (var param in @params)
+            {
+                var paramJson = new MyJson.JsonNode_Object();
+                paramJson.SetDictValue("name", param.name);
+                paramJson.SetDictValue("type", ConvertType(param.type));
+                paramsJson.Add(paramJson);
+            }
+
+            return paramsJson;
+        }
+
+        static MyJson.JsonNode_Array GetMethods(NeoModule module, IDictionary<string, int> docMap)
+        {
+
+            var outjson = new MyJson.JsonNode_Array();
+
+            foreach (var method in module.mapMethods.Values)
+            {
+                var range = string.Format("{0}-{1}",
+                    method.body_Codes.Values.First().addr,
+                    method.body_Codes.Values.Last().addr);
+
+
+                var methodJson = new MyJson.JsonNode_Object();
+                methodJson.SetDictValue("id", method.name);
+                methodJson.SetDictValue("namespace", method._namespace);
+                methodJson.SetDictValue("name", method.displayName);
+                methodJson.SetDictValue("range", range);
+                methodJson.SetDictValue("params", GetParameters(method.paramtypes));
+                methodJson.SetDictValue("return", ConvertType(method.returntype));
+
+                var varaiablesJson = new MyJson.JsonNode_Array();
+                foreach (var variable in method.body_Variables)
+                {
+                    var variableJson = new MyJson.JsonNode_Object();
+                    variableJson.SetDictValue("name", variable.name);
+                    variableJson.SetDictValue("type", ConvertType(variable.type));
+                    varaiablesJson.Add(variableJson);
+                }
+                methodJson.SetDictValue("variables", varaiablesJson);
+
+                methodJson.SetDictValue("sequence-points", GetSequencePoints(method.body_Codes.Values, docMap));
+                outjson.Add(methodJson);
+            }
+            return outjson;
+        }
+
+        static MyJson.JsonNode_Array GetEvents(NeoModule module)
+        {
+            var outjson = new MyJson.JsonNode_Array();
+            foreach (var @event in module.mapEvents.Values)
+            {
+                var eventJson = new MyJson.JsonNode_Object();
+                eventJson.SetDictValue("id", @event.name);
+                eventJson.SetDictValue("namespace", @event._namespace);
+                eventJson.SetDictValue("name", @event.displayName);
+                eventJson.SetDictValue("params", GetParameters(@event.paramtypes));
+                outjson.Add(eventJson);
+            }
+            return outjson;
+        }
+
+        static IDictionary<string, int> GetDocumentMap(NeoModule module)
+        {
+            return module.mapMethods.Values
+                .SelectMany(m => m.body_Codes.Values)
+                .Where(code => code.sequencePoint != null)
+                .Select(code => code.sequencePoint.Document.Url)
+                .Distinct()
+                .Select((d, i) => (d, i))
+                .ToDictionary(t => t.d, t => t.i);
+        }
+
+        static MyJson.JsonNode_Array GetDocuments(IDictionary<string, int> docMap)
+        {
+            var outjson = new MyJson.JsonNode_Array();
+            foreach (var doc in docMap.OrderBy(kvp => kvp.Value))
+            {
+                Debug.Assert(outjson.Count == doc.Value);
+                outjson.Add(new MyJson.JsonNode_ValueString(doc.Key));
+            }
+            return outjson;
+        }
+
+        public static MyJson.JsonNode_Object Export(NeoModule am)
+        {
+            var docMap = GetDocumentMap(am);
+
+            var outjson = new MyJson.JsonNode_Object();
+            outjson.SetDictValue("entrypoint", am.mainMethod);
+            outjson.SetDictValue("documents", GetDocuments(docMap));
+            outjson.SetDictValue("methods", GetMethods(am, docMap));
+            outjson.SetDictValue("events", GetEvents(am));
+            return outjson;
+        }
+    }
+}

--- a/Neo.Compiler.MSIL/FuncExport.cs
+++ b/Neo.Compiler.MSIL/FuncExport.cs
@@ -1,4 +1,4 @@
-using Neo.Compiler;
+﻿using Neo.Compiler;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,9 +43,6 @@ namespace vmtool
 
                 case "System.String":
                     return "String";
-
-                case "System.Object[]":
-                    return "Array";
 
                 case "__InteropInterface":
                 case "IInteropInterface":

--- a/Neo.Compiler.MSIL/FuncExport.cs
+++ b/Neo.Compiler.MSIL/FuncExport.cs
@@ -1,4 +1,4 @@
-﻿using Neo.Compiler;
+using Neo.Compiler;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +8,7 @@ namespace vmtool
 {
     public class FuncExport
     {
-        static string ConvType(string _type)
+        public static string ConvType(string _type)
         {
             switch (_type)
             {
@@ -57,7 +57,7 @@ namespace vmtool
                 case "System.Object":
                     return "ByteArray";
             }
-            if (_type.Contains("[]"))
+            if (_type != null && _type.Contains("[]"))
                 return "Array";
 
             return "Unknown:" + _type;

--- a/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
+++ b/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 
 namespace Neo.Compiler.MSIL
@@ -78,6 +78,7 @@ namespace Neo.Compiler.MSIL
                 _code.debugline = src.debugline;
                 _code.debugILAddr = src.addr;
                 _code.debugILCode = src.code.ToString();
+                _code.sequencePoint = src.sequencePoint;
             }
 
 

--- a/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
@@ -166,6 +166,11 @@ namespace Neo.Compiler.MSIL
                         foreach (var src in m.Value.paramtypes)
                         {
                             nm.paramtypes.Add(new NeoParam(src.name, src.type));
+                        }
+
+                        foreach (var @var in m.Value.body_Variables)
+                        {
+                            nm.body_Variables.Add(@var);
                         }
 
                         if (IsAppCall(m.Value.method, out byte[] outcall))

--- a/Neo.Compiler.MSIL/MSIL/ILModule.cs
+++ b/Neo.Compiler.MSIL/MSIL/ILModule.cs
@@ -233,7 +233,9 @@ namespace Neo.Compiler.MSIL
                     {
                         foreach (var v in bodyNative.Variables)
                         {
-                            var indexname = v.VariableType.Name + ":" + v.Index;
+                            var indexname = method.DebugInformation.TryGetName(v, out var varname)
+                                ? varname
+                                : v.VariableType.Name + ":" + v.Index;
                             this.body_Variables.Add(new NeoParam(indexname, v.VariableType.FullName));
                         }
                     }
@@ -247,10 +249,11 @@ namespace Neo.Compiler.MSIL
                         };
 
                         var sp = method.DebugInformation.GetSequencePoint(code);
-                        if (sp != null)
+                        if (sp != null && !sp.IsHidden)
                         {
                             c.debugcode = sp.Document.Url;
                             c.debugline = sp.StartLine;
+                            c.sequencePoint = sp;
                         }
                         c.InitToken(code.Operand);
                         this.body_Codes.Add(c.addr, c);
@@ -543,6 +546,7 @@ namespace Neo.Compiler.MSIL
         public CodeEx code;
         public int debugline = -1;
         public string debugcode;
+        public Mono.Cecil.Cil.SequencePoint sequencePoint;
         public object tokenUnknown;
         public int tokenAddr_Index;
         //public int tokenAddr;

--- a/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
+++ b/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Neo.Compiler.MSIL</AssemblyTitle>
     <Version>2.4.1.1</Version>
     <Authors>The Neo Project</Authors>
-    <TargetFrameworks>netcoreapp2.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>neon</AssemblyName>
     <PackageId>Neo.Compiler.MSIL</PackageId>

--- a/Neo.Compiler.MSIL/NeoModule.cs
+++ b/Neo.Compiler.MSIL/NeoModule.cs
@@ -187,6 +187,8 @@ namespace Neo.Compiler
         public int srcaddr;
         public int[] srcaddrswitch;
         public string srcfunc;
+        public Mono.Cecil.Cil.SequencePoint sequencePoint;
+
         public override string ToString()
         {
             //string info = "AL_" + addr.ToString("X04") + " " + code.ToString();

--- a/Neo.Compiler.MSIL/Program.cs
+++ b/Neo.Compiler.MSIL/Program.cs
@@ -134,7 +134,7 @@ namespace Neo.Compiler
                 {
                     var outjson = DebugExport.Export(am);
                     StringBuilder sb = new StringBuilder();
-                    outjson.ConvertToStringWithFormat(sb, 0);
+                    outjson.ConvertToString(sb);
                     debugstr = sb.ToString();
                     log.Log("gen debug succ");
                 }
@@ -183,12 +183,11 @@ namespace Neo.Compiler
             try
             {
                 string debugname = onlyname + ".debug.json";
-                string debugzip = onlyname + ".debug.zip";
+                string debugzip = onlyname + ".avmdbgnfo";
 
                 var tempName = Path.GetTempFileName();
                 File.Delete(tempName);
                 File.WriteAllText(tempName, debugstr);
-
 
                 File.Delete(debugzip);
                 using (var archive = ZipFile.Open(debugzip, ZipArchiveMode.Create))

--- a/Neo.Compiler.MSIL/Program.cs
+++ b/Neo.Compiler.MSIL/Program.cs
@@ -1,6 +1,7 @@
 using Neo.Compiler.MSIL;
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 
@@ -101,6 +102,7 @@ namespace Neo.Compiler
             byte[] bytes;
             bool bSucc;
             string jsonstr = null;
+            string debugstr = null;
             //convert and build
             try
             {
@@ -128,6 +130,18 @@ namespace Neo.Compiler
                     log.Log("gen abi Error:" + err.ToString());
                 }
 
+                try
+                {
+                    var outjson = DebugExport.Export(am);
+                    StringBuilder sb = new StringBuilder();
+                    outjson.ConvertToStringWithFormat(sb, 0);
+                    debugstr = sb.ToString();
+                    log.Log("gen debug succ");
+                }
+                catch (Exception err)
+                {
+                    log.Log("gen debug Error:" + err.ToString());
+                }
             }
             catch (Exception err)
             {
@@ -150,9 +164,9 @@ namespace Neo.Compiler
                 log.Log("Write Bytes Error:" + err.ToString());
                 return;
             }
+
             try
             {
-
                 string abiname = onlyname + ".abi.json";
 
                 System.IO.File.Delete(abiname);
@@ -165,6 +179,32 @@ namespace Neo.Compiler
                 log.Log("Write abi Error:" + err.ToString());
                 return;
             }
+
+            try
+            {
+                string debugname = onlyname + ".debug.json";
+                string debugzip = onlyname + ".debug.zip";
+
+                var tempName = Path.GetTempFileName();
+                File.Delete(tempName);
+                File.WriteAllText(tempName, debugstr);
+
+
+                File.Delete(debugzip);
+                using (var archive = ZipFile.Open(debugzip, ZipArchiveMode.Create))
+                {
+                    archive.CreateEntryFromFile(tempName, Path.GetFileName(debugname));
+                }
+                File.Delete(tempName);
+                log.Log("write:" + debugzip);
+                bSucc = true;
+            }
+            catch (Exception err)
+            {
+                log.Log("Write debug Error:" + err.ToString());
+                return;
+            }
+
             try
             {
                 fs.Dispose();


### PR DESCRIPTION
The [Neo Smart Contract Debugger](https://marketplace.visualstudio.com/items?itemName=ngd-seattle.neo-contract-debug) requires additional information beyond the current NEON output in order to drive the debugging experience. The [NEON-DE fork](https://github.com/ngdseattle/neo-devpack-dotnet) emits the required information, however the [format NEON-DE uses](https://github.com/ngdseattle/design-notes/blob/master/NDX-DN11%20-%20NEO%20Debug%20Info%20Specification.md#original-format) is not very efficient. This PR updates the official NEON compiler to emit an [updated format](https://github.com/ngdseattle/design-notes/blob/master/NDX-DN11%20-%20NEO%20Debug%20Info%20Specification.md#v010-format) that is dramatically more space efficient than the original format.

To measure debug info size improvement, we used the [Moonlight ICO template](https://github.com/Moonlight-io/moonlight-ico-template). The debug information information emitted by NEON-DE was 636.6 kb. By removing redundant and unneeded data from the file as well as encoding information in a more compact fashion, we were able to get the json encoded debug information down to about 55kb - about 8.6% of the original file size! Additionally, we compress the file further via zip compression, getting the file size down to around 13.5kb, about 2.1% of the original file size. 

~Note, this PR is currently in draft while I update the debugger to read the new format. Once I've confirmed that no additional format changes are needed, I will update this PR to be ready to merge. In the meantime, feedback is welcome.~

Fixes #149 