### PR TITLE
FeaturesAttribute instead of individual feature attributes to match 3.x

### DIFF
--- a/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_metadata.cs
+++ b/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_metadata.cs
@@ -7,9 +7,10 @@ using System.Numerics;
 [assembly: Neo.SmartContract.Framework.ContractVersion("contract version")]
 [assembly: Neo.SmartContract.Framework.ContractAuthor("contract author")]
 [assembly: Neo.SmartContract.Framework.ContractEmail("contract email")]
-[assembly: Neo.SmartContract.Framework.ContractHasDynamicInvoke]
-[assembly: Neo.SmartContract.Framework.ContractHasStorage]
-[assembly: Neo.SmartContract.Framework.ContractIsPayable]
+[assembly: Neo.SmartContract.Framework.Features(
+    Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.HasStorage |
+    Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.HasDynamicInvoke |
+    Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.Payable )]
 
 namespace Neo.Compiler.MSIL.TestClasses
 {

--- a/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_metadata.cs
+++ b/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_metadata.cs
@@ -10,7 +10,7 @@ using System.Numerics;
 [assembly: Neo.SmartContract.Framework.Features(
     Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.HasStorage |
     Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.HasDynamicInvoke |
-    Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.Payable )]
+    Neo.SmartContract.Framework.Services.Neo.ContractPropertyState.Payable)]
 
 namespace Neo.Compiler.MSIL.TestClasses
 {

--- a/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -343,14 +343,18 @@ namespace Neo.Compiler.MSIL
                     case "Neo.SmartContract.Framework.ContractEmail":
                         outModule.Email = attrib.ConstructorArguments[0].Value.ToString();
                         break;
-                    case "Neo.SmartContract.Framework.ContractHasDynamicInvoke":
-                        outModule.HasDynamicInvoke = true;
-                        break;
-                    case "Neo.SmartContract.Framework.ContractHasStorage":
-                        outModule.HasStorage = true;
-                        break;
-                    case "Neo.SmartContract.Framework.ContractIsPayable":
-                        outModule.IsPayable = true;
+                    case "Neo.SmartContract.Framework.FeaturesAttribute":
+                        {
+                            // define constants to mirror ContractPropertyState values
+                            const byte HAS_STORAGE = 1 << 0;
+                            const byte HAS_DYNAMIC_INVOKE = 1 << 1;
+                            const byte PAYABLE = 1 << 2;
+
+                            var features = (byte)attrib.ConstructorArguments[0].Value;
+                            outModule.HasDynamicInvoke = (features & HAS_DYNAMIC_INVOKE) != 0;
+                            outModule.HasStorage = (features & HAS_STORAGE) != 0;
+                            outModule.IsPayable = (features & PAYABLE) != 0;
+                        }
                         break;
                     case "Neo.SmartContract.Framework.ContractTitle":
                         outModule.Title = attrib.ConstructorArguments[0].Value.ToString();

--- a/Neo.SmartContract.Framework/ContractMetadata.cs
+++ b/Neo.SmartContract.Framework/ContractMetadata.cs
@@ -1,8 +1,27 @@
+using Neo.SmartContract.Framework.Services.Neo;
 using Neo.VM;
 using System;
 
 namespace Neo.SmartContract.Framework
 {
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class FeaturesAttribute : Attribute
+    {
+        /// <summary>
+        /// Smart contract features
+        /// </summary>
+        public ContractPropertyState Features { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="features">Specify the smart contract features</param>
+        public FeaturesAttribute(ContractPropertyState features)
+        {
+            Features = features;
+        }
+    }
+
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class ContractAuthor : Attribute
     {
@@ -34,21 +53,6 @@ namespace Neo.SmartContract.Framework
         }
 
         public string Email { get; }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
-    public sealed class ContractHasDynamicInvoke : Attribute
-    {
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
-    public sealed class ContractHasStorage : Attribute
-    {
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
-    public sealed class ContractIsPayable : Attribute
-    {
     }
 
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]


### PR DESCRIPTION
Fixes #158 

When I did #148, I forgot that the master branch has already created a FeaturesAttribute in #129. This PR updates the master-2.x branch NEON + smart contract framework to us a FeaturesAttribute like master branch.

~Note, this PR is in draft waiting for #154 to be merged ~