### PR TITLE
support code in cctor

### DIFF
--- a/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
@@ -101,9 +101,9 @@ namespace Neo.Compiler.MSIL
                             }
                             else
                             {
+                                //other type mean is not a constValue
                                 constValue = false;
                                 continue;
-                                //throw new Exception("only byte[] can be defined in here.");
                             }
                         }
                         break;

--- a/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
@@ -183,7 +183,6 @@ namespace Neo.Compiler.MSIL
                                             var bytes = NEO.AllianceOfThinWallet.Cryptography.Base58.Decode(text);
                                             var hash = bytes.Skip(1).Take(20).ToArray();
                                             calcStack.Push(hash);
-
                                         }
                                         else if (attrname == "HexToBytes")//HexString2Bytes to bytes[]
                                         {
@@ -204,7 +203,7 @@ namespace Neo.Compiler.MSIL
                         {
                             var field = src.tokenUnknown as Mono.Cecil.FieldReference;
                             var fname = field.FullName;
-                            if(calcStack.Count==0)
+                            if (calcStack.Count == 0)
                             {
                                 constValue = false;
                                 to.staticfieldsWithConstValue[fname] = null;
@@ -228,7 +227,7 @@ namespace Neo.Compiler.MSIL
                         break;
                 }
             }
-            if(constValue==false)
+            if (constValue == false)
             {
                 if (to.staticfieldsCctor.Contains(from) == false)
                     to.staticfieldsCctor.Add(from);

--- a/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
@@ -38,8 +38,9 @@ namespace Neo.Compiler.MSIL
             }
         }
 
-        public static void Parse(ILMethod from, NeoModule to)
+        public static bool Parse(ILMethod from, NeoModule to)
         {
+            bool constValue = true;
             calcStack = new Stack<object>();
             bool bEnd = false;
             foreach (var src in from.body_Codes.Values)
@@ -100,7 +101,9 @@ namespace Neo.Compiler.MSIL
                             }
                             else
                             {
-                                throw new Exception("only byte[] can be defined in here.");
+                                constValue = false;
+                                continue;
+                                //throw new Exception("only byte[] can be defined in here.");
                             }
                         }
                         break;
@@ -180,6 +183,7 @@ namespace Neo.Compiler.MSIL
                                             var bytes = NEO.AllianceOfThinWallet.Cryptography.Base58.Decode(text);
                                             var hash = bytes.Skip(1).Take(20).ToArray();
                                             calcStack.Push(hash);
+
                                         }
                                         else if (attrname == "HexToBytes")//HexString2Bytes to bytes[]
                                         {
@@ -200,8 +204,16 @@ namespace Neo.Compiler.MSIL
                         {
                             var field = src.tokenUnknown as Mono.Cecil.FieldReference;
                             var fname = field.FullName;
+                            if(calcStack.Count==0)
+                            {
+                                constValue = false;
+                                to.staticfieldsWithConstValue[fname] = null;
+                            }
+                            else
+                            {
+                                to.staticfieldsWithConstValue[fname] = calcStack.Pop();
+                            }
                             // field.DeclaringType.FullName + "::" + field.Name;
-                            to.staticfields[fname] = calcStack.Pop();
                         }
                         break;
                     case CodeEx.Stelem_I1:
@@ -212,8 +224,17 @@ namespace Neo.Compiler.MSIL
                             array[index] = v;
                         }
                         break;
+                    default:
+                        break;
                 }
             }
+            if(constValue==false)
+            {
+                if (to.staticfieldsCctor.Contains(from) == false)
+                    to.staticfieldsCctor.Add(from);
+            }
+
+            return constValue;
         }
     }
 }

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
@@ -232,7 +232,7 @@ namespace Neo.Compiler.MSIL
             _Insert1(VM.OpCode.NEWARRAY, "", to);
             _Insert1(VM.OpCode.TOALTSTACK, "", to);
 
-            foreach (var defvar in this.outModule.staticfields)
+            foreach (var defvar in this.outModule.staticfieldsWithConstValue)
             {
                 if (this.outModule.mapFields.TryGetValue(defvar.Key, out NeoField field))
                 {
@@ -275,7 +275,8 @@ namespace Neo.Compiler.MSIL
                     }
                     else
                     {
-                        throw new Exception("not support type _insertSharedStaticVarCode\r\n   in: " + to.name + "\r\n");
+                        _Convert1by1(VM.OpCode.PUSHNULL, null, to);
+                        //throw new Exception("not support type _insertSharedStaticVarCode\r\n   in: " + to.name + "\r\n");
                     }
                     #endregion
                     _Insert1(VM.OpCode.SETITEM, "", to);

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
@@ -276,10 +276,8 @@ namespace Neo.Compiler.MSIL
                     }
                     else
                     {
-                        //continue;
                         //no need to init null
                         _Convert1by1(VM.OpCode.PUSHNULL, null, to);
-                        //throw new Exception("not support type _insertSharedStaticVarCode\r\n   in: " + to.name + "\r\n");
                     }
                     #endregion
                     _Insert1(VM.OpCode.SETITEM, "", to);
@@ -287,9 +285,9 @@ namespace Neo.Compiler.MSIL
             }
 
             //insert code part
-            foreach(var cctor in this.outModule.staticfieldsCctor)
+            foreach (var cctor in this.outModule.staticfieldsCctor)
             {
-                FillMethod(cctor, to,false);
+                FillMethod(cctor, to, false);
             }
         }
 

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Common.cs
@@ -228,6 +228,7 @@ namespace Neo.Compiler.MSIL
 
         private void _insertSharedStaticVarCode(NeoMethod to)
         {
+            //insert init constvalue part
             _InsertPush(this.outModule.mapFields.Count, "static var", to);
             _Insert1(VM.OpCode.NEWARRAY, "", to);
             _Insert1(VM.OpCode.TOALTSTACK, "", to);
@@ -275,12 +276,20 @@ namespace Neo.Compiler.MSIL
                     }
                     else
                     {
+                        //continue;
+                        //no need to init null
                         _Convert1by1(VM.OpCode.PUSHNULL, null, to);
                         //throw new Exception("not support type _insertSharedStaticVarCode\r\n   in: " + to.name + "\r\n");
                     }
                     #endregion
                     _Insert1(VM.OpCode.SETITEM, "", to);
                 }
+            }
+
+            //insert code part
+            foreach(var cctor in this.outModule.staticfieldsCctor)
+            {
+                FillMethod(cctor, to,false);
             }
         }
 

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -88,6 +88,9 @@ namespace Neo.Compiler.MSIL
                         continue;//event 自动生成的代码，不要
                     if (m.Value.method.Is_cctor())
                     {
+                        //if cctor contains sth can not be as a const value.
+                        //  then need 1.record these cctor's code.
+                        //            2.insert them to main function
                         CctorSubVM.Parse(m.Value, this.outModule);
                         continue;
                     }
@@ -1058,7 +1061,7 @@ namespace Neo.Compiler.MSIL
                             )
                         {
                             var fname = d.FullName;// d.DeclaringType.FullName + "::" + d.Name;
-                            var _src = outModule.staticfields[fname];
+                            var _src = outModule.staticfieldsWithConstValue[fname];
                             if (_src is byte[])
                             {
                                 var bytesrc = (byte[])_src;

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -406,6 +406,7 @@ namespace Neo.Compiler.MSIL
                 }
             }
         }
+
         private void FillMethod(ILMethod from, NeoMethod to, bool withReturn)
         {
             int skipcount = 0;
@@ -421,13 +422,10 @@ namespace Neo.Compiler.MSIL
                     if (src.code == CodeEx.Ret)//before return
                     {
                         if (!withReturn) break;
-
                         _insertEndCode(to, src);
-
                     }
                     try
                     {
-
                         skipcount = ConvertCode(from, src, to);
                     }
                     catch (Exception err)

--- a/src/Neo.Compiler.MSIL/NeoModule.cs
+++ b/src/Neo.Compiler.MSIL/NeoModule.cs
@@ -17,7 +17,8 @@ namespace Neo.Compiler
         public Dictionary<string, NeoMethod> mapMethods = new Dictionary<string, NeoMethod>();
         public Dictionary<string, NeoEvent> mapEvents = new Dictionary<string, NeoEvent>();
         public Dictionary<string, NeoField> mapFields = new Dictionary<string, NeoField>();
-        public Dictionary<string, object> staticfields = new Dictionary<string, object>();
+        public Dictionary<string, object> staticfieldsWithConstValue = new Dictionary<string, object>();
+        public List<ILMethod> staticfieldsCctor = new List<ILMethod>();
         //小蚁没类型，只有方法
         public SortedDictionary<int, NeoCode> total_Codes = new SortedDictionary<int, NeoCode>();
 

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVar.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVar.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Neo.Compiler.MSIL.TestClasses
 {
-
     class Contract_staticvar : SmartContract.Framework.SmartContract
     {
         static int a1 = 1;
@@ -25,5 +20,4 @@ namespace Neo.Compiler.MSIL.TestClasses
             a1 *= 7;
         }
     }
-
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVarInit.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVarInit.cs
@@ -1,0 +1,29 @@
+using Neo.SmartContract.Framework.Services.System;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Neo.Compiler.MSIL.TestClasses
+{
+
+    class Contract_staticvar : SmartContract.Framework.SmartContract
+    {
+        //define and staticvar and initit with a runtime code.
+        static byte[] callscript = ExecutionEngine.CallingScriptHash;
+
+        public static object Main(string method, object[] args)
+        {
+            if (method == "staticinit")
+                return testStaticInit();
+            return null;
+        }
+
+        static byte[] testStaticInit()
+        {
+            return callscript;
+
+        }
+
+    }
+
+}

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVarInit.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVarInit.cs
@@ -9,19 +9,20 @@ namespace Neo.Compiler.MSIL.TestClasses
     class Contract_staticvar : SmartContract.Framework.SmartContract
     {
         //define and staticvar and initit with a runtime code.
-        static byte[] callscript = ExecutionEngine.CallingScriptHash;
+        static byte[] callscript = ExecutionEngine.EntryScriptHash;
 
         public static object Main(string method, object[] args)
         {
             if (method == "staticinit")
                 return testStaticInit();
+            if (method == "directget")
+                return ExecutionEngine.EntryScriptHash;
             return null;
         }
 
         static byte[] testStaticInit()
         {
             return callscript;
-
         }
 
     }

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVarInit.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_StaticVarInit.cs
@@ -1,11 +1,7 @@
 using Neo.SmartContract.Framework.Services.System;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Neo.Compiler.MSIL.TestClasses
 {
-
     class Contract_staticvar : SmartContract.Framework.SmartContract
     {
         //define and staticvar and initit with a runtime code.
@@ -24,7 +20,5 @@ namespace Neo.Compiler.MSIL.TestClasses
         {
             return callscript;
         }
-
     }
-
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
@@ -29,14 +29,16 @@ namespace Neo.Compiler.MSIL
                 var testengine = new TestEngine();
                 testengine.AddEntryScript("./TestClasses/Contract_StaticVarInit.cs");
                 var result = testengine.ExecuteTestCaseStandard("staticinit");
-                //test (1+5)*7 == 42
+                // static byte[] callscript = ExecutionEngine.EntryScriptHash;
+                // ...
+                // return callscript
                 var1 = (result.Pop() as ByteArray);
             }
             {
                 var testengine = new TestEngine();
                 testengine.AddEntryScript("./TestClasses/Contract_StaticVarInit.cs");
                 var result = testengine.ExecuteTestCaseStandard("directget");
-                //test (1+5)*7 == 42
+                // return ExecutionEngine.EntryScriptHash
                 var2 = (result.Pop() as ByteArray);
             }
             Assert.IsNotNull(var1);

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
@@ -44,6 +44,5 @@ namespace Neo.Compiler.MSIL
             Assert.IsNotNull(var1);
             Assert.AreEqual(var1, var2);
         }
-
     }
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
@@ -20,5 +20,19 @@ namespace Neo.Compiler.MSIL
             Assert.IsTrue(bequal);
         }
 
+        [TestMethod]
+        public void Test_StaticVarInit()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_StaticVarInit.cs");
+            var result = testengine.ExecuteTestCaseStandard("staticinit");
+
+            //test (1+5)*7 == 42
+            var retvar = result.Pop();
+
+            StackItem wantresult = 42;
+            var bequal = wantresult.Equals(retvar);
+            Assert.IsTrue(bequal);
+        }
     }
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_StaticVar.cs
@@ -23,16 +23,25 @@ namespace Neo.Compiler.MSIL
         [TestMethod]
         public void Test_StaticVarInit()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_StaticVarInit.cs");
-            var result = testengine.ExecuteTestCaseStandard("staticinit");
-
-            //test (1+5)*7 == 42
-            var retvar = result.Pop();
-
-            StackItem wantresult = 42;
-            var bequal = wantresult.Equals(retvar);
-            Assert.IsTrue(bequal);
+            ByteArray var1;
+            ByteArray var2;
+            {
+                var testengine = new TestEngine();
+                testengine.AddEntryScript("./TestClasses/Contract_StaticVarInit.cs");
+                var result = testengine.ExecuteTestCaseStandard("staticinit");
+                //test (1+5)*7 == 42
+                var1 = (result.Pop() as ByteArray);
+            }
+            {
+                var testengine = new TestEngine();
+                testengine.AddEntryScript("./TestClasses/Contract_StaticVarInit.cs");
+                var result = testengine.ExecuteTestCaseStandard("directget");
+                //test (1+5)*7 == 42
+                var2 = (result.Pop() as ByteArray);
+            }
+            Assert.IsNotNull(var1);
+            Assert.AreEqual(var1, var2);
         }
+
     }
 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
@@ -59,18 +59,23 @@ namespace Neo.Compiler.MSIL.Utils
 
             converterIL = new ModuleConverter(log);
             ConvOption option = new ConvOption();
+#if NDEBUG
             try
+
+#endif
             {
                 converterIL.Convert(modIL, option);
                 finalNEF = converterIL.outModule.Build();
                 IsBuild = true;
             }
+#if NDEBUG
             catch (Exception err)
             {
                 this.Error = err;
                 log.Log("Convert IL->ASM Error:" + err.ToString());
                 return;
             }
+#endif
             try
             {
                 finialABI = vmtool.FuncExport.Export(converterIL.outModule, finalNEF);


### PR DESCRIPTION
before only can init const value in cctor step.
``` c#
     static byte[] callscript = HexToBytes("112233aa....");
```

now we can run code like:
``` c#
  static byte[] callscript = ExecutionEngine.EntryScriptHash;
```

add unittest:Test_StaticVarInit
