### PR TITLE
fix notequal with null problem

### DIFF
--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
@@ -1152,6 +1152,23 @@ namespace Neo.Compiler.MSIL
                 }
             }
         }
+        private int _ConvertCgt(ILMethod method, OpCode src, NeoMethod to)
+        {
+            var code = to.body_Codes.Last().Value;
+            if (code.code == VM.OpCode.PUSHNULL)
+            {
+                //remove last code
+                to.body_Codes.Remove(code.addr);
+                this.addr = code.addr;
+                _Convert1by1(VM.OpCode.ISNULL, src, to);
+                _Convert1by1(VM.OpCode.NOT, src, to);
+            }
+            else
+            {
+                _Convert1by1(VM.OpCode.GT, src, to);
+            }
+            return 0;
+        }
         private int _ConvertCeq(ILMethod method, OpCode src, NeoMethod to)
         {
             var code = to.body_Codes.Last().Value;

--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -865,7 +865,8 @@ namespace Neo.Compiler.MSIL
                     break;
                 case CodeEx.Cgt:
                 case CodeEx.Cgt_Un:
-                    _Convert1by1(VM.OpCode.GT, src, to);
+                    skipcount = _ConvertCgt(method, src, to);
+
                     break;
                 case CodeEx.Ceq:
                     skipcount = _ConvertCeq(method, src, to);

--- a/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_NULL.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_NULL.cs
@@ -19,6 +19,16 @@ namespace Neo.Compiler.MSIL.TestClasses
             return value == null;
         }
 
+        public static bool EqualNotNullA(byte[] value)
+        {
+            return null != value;
+        }
+
+        public static bool EqualNotNullB(byte[] value)
+        {
+            return value != null;
+        }
+
         public static string NullCoalescing(string code)
         {
             string myname = code?.Substring(1, 2);

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_NULL.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_NULL.cs
@@ -168,5 +168,45 @@ namespace Neo.Compiler.MSIL
             Assert.IsInstanceOfType(item, typeof(Boolean));
             Assert.IsFalse(item.ToBoolean());
         }
+
+        [TestMethod]
+        public void EqualNotNull()
+        {
+            // True
+
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("equalNotNullA", StackItem.Null);
+            var item = result.Pop();
+
+            Assert.IsInstanceOfType(item, typeof(Boolean));
+            Assert.IsFalse(item.ToBoolean());
+
+            // False
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("equalNotNullA", new Integer(1));
+            item = result.Pop();
+
+            Assert.IsInstanceOfType(item, typeof(Boolean));
+            Assert.IsTrue(item.ToBoolean());
+
+            // True
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("equalNotNullB", StackItem.Null);
+            item = result.Pop();
+
+            Assert.IsInstanceOfType(item, typeof(Boolean));
+            Assert.IsFalse(item.ToBoolean());
+
+            // False
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("equalNotNullB", new Integer(1));
+            item = result.Pop();
+
+            Assert.IsInstanceOfType(item, typeof(Boolean));
+            Assert.IsTrue(item.ToBoolean());
+        }
     }
 }


### PR DESCRIPTION
fixed #184 
fix a notequal with null problem.

in c#
```c#
a!=null
```

now convert to
```
ISNULL
NOT
```