### PR TITLE
Change -o not required

### DIFF
--- a/src/Neo.Compiler.MSIL/Program.cs
+++ b/src/Neo.Compiler.MSIL/Program.cs
@@ -18,7 +18,7 @@ namespace Neo.Compiler
             [Option('f', "file", Required = true, HelpText = "File for compile.")]
             public string File { get; set; }
 
-            [Option('o', "optimize", Required = true, HelpText = "Optimize.")]
+            [Option('o', "optimize", Required = false, HelpText = "Optimize.")]
             public bool Optimize { get; set; } = false;
         }
 


### PR DESCRIPTION
As CommandLine.Parser has a problem about boolean type https://github.com/commandlineparser/commandline/issues/290  and sometimes, we want to close the optimize function.

And we have also add `-o` as a default value in `Installer`.