### PR TITLE
Fix byte array reverse

### DIFF
--- a/src/Neo.Compiler.MSIL/MSIL/Converter.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Converter.cs
@@ -897,6 +897,13 @@ namespace Neo.Compiler.MSIL
                         //1 c3 PICKITEM
                         //*/
 
+                        // In neo3, we must convert it first, It's too complicated!
+                        // CONVERT StackItemType.Buffer
+                        // set index
+                        // set value
+                        // SETITEM
+
+
                         //if ((to.body_Codes[addr - 1].code == VM.OpCode.PICKITEM)
                         //  && (to.body_Codes[addr - 4].code == VM.OpCode.PICKITEM)
                         //  && (to.body_Codes[addr - 7].code == VM.OpCode.PICKITEM)

--- a/src/Neo.SmartContract.Framework/Helper.cs
+++ b/src/Neo.SmartContract.Framework/Helper.cs
@@ -12,7 +12,7 @@ namespace Neo.SmartContract.Framework
         //const string StackItemType_Boolean = "0x20";
         const string StackItemType_Integer = "0x21";
         const string StackItemType_ByteArray = "0x28";
-        //const string StackItemType_Buffer = "0x30";
+        const string StackItemType_Buffer = "0x30";
         //const string StackItemType_Array = "0x40";
         //const string StackItemType_Struct = "0x41";
         //const string StackItemType_Map = "0x48";
@@ -212,21 +212,31 @@ namespace Neo.SmartContract.Framework
         public extern static byte[] Last(this byte[] source, int count);
 
         /// <summary>
-        /// Returns a reversed copy of byte[] parameter 'source' (parameter is not affected because byte[] is copy-based on NeoVM).
-        /// Example: [0a,0b,0c,0d,0e] -> [0e,0d,0c,0b,0a]
+        /// Reverse byte array, be careful, it'll convert to Buffer for reversing.
         /// </summary>
-        public static byte[] Reverse(this byte[] source)
-        {
-            for (int k = 0; k < source.Length / 2; k++)
-            {
-                int m = source.Length - k - 1;
-                byte bg = source[k]; // must store on variable before next assignment
-                byte ed = source[m]; // must store on variable before next assignment
-                source[k] = ed;
-                source[m] = bg;
-            }
-            return source;
-        }
+        /// <param name="source"></param>
+        /// <returns></returns>
+        [OpCode(OpCode.CONVERT, StackItemType_Buffer)]
+        [OpCode(OpCode.DUP)]
+        [OpCode(OpCode.REVERSEITEMS)]
+        public extern static byte[] Reverse(this byte[] source);
+
+        ///// <summary>
+        ///// Returns a reversed copy of byte[] parameter 'source' (parameter is not affected because byte[] is copy-based on NeoVM).
+        ///// Example: [0a,0b,0c,0d,0e] -> [0e,0d,0c,0b,0a]
+        ///// </summary>
+        //public static byte[] Reverse(this byte[] source)
+        //{
+        //    for (int k = 0; k < source.Length / 2; k++)
+        //    {
+        //        int m = source.Length - k - 1;
+        //        byte bg = source[k]; // must store on variable before next assignment
+        //        byte ed = source[m]; // must store on variable before next assignment
+        //        source[k] = ed;
+        //        source[m] = bg;
+        //    }
+        //    return source;
+        //}
 
         [Script]
         public extern static Delegate ToDelegate(this byte[] source);

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestByteArray.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestByteArray.cs
@@ -88,41 +88,19 @@ namespace Neo.SmartContract.Framework.UnitTests
         [TestMethod]
         public void TestLast()
         {
-            //var testengine = new TestEngine();
-            //testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
 
-            //var result = testengine.ExecuteTestCaseStandard("testByteLast");
+            var result = testengine.ExecuteTestCaseStandard("testByteLast");
 
-            //Assert.AreEqual(1, testengine.Notifications.Count);
-            //var array = testengine.Notifications[0].State as Array;
-            //Assert.AreEqual(1, array.Count);
-            //var buffer = array[0] as Buffer;
-            //Assert.AreEqual(new byte[] { 0x32 }, buffer.ConvertTo(StackItemType.ByteArray));
+            Assert.AreEqual(1, testengine.Notifications.Count);
+            var array = testengine.Notifications[0].State as Array;
+            Assert.AreEqual(1, array.Count);
+            var buffer = array[0] as Buffer;
+            Assert.AreEqual(new byte[] { 0x32 }, buffer.ConvertTo(StackItemType.ByteArray));
 
-            //buffer = result.Pop() as Buffer;
-            //Assert.AreEqual(new byte[] { 0x32 }, buffer.ConvertTo(StackItemType.ByteArray));
-
-
-            Dictionary<byte[], int> map = new Dictionary<byte[], int>();
-
-            var k1 = new byte[] { 0x00, 0x01 };
-            var k2 = new byte[] { 0x01, 0x01 };
-            map[k1] = 1;
-            map[k2] = 2;
-
-            System.Console.WriteLine("before map[k1]: " + map[k1] + "\t k1 hashcode: " + k1.GetHashCode());
-            System.Console.WriteLine("before map[k2]: " + map[k2] + "\t k2 hashcode: " + k2.GetHashCode());
-
-            k1[0] = 0x01;
-            k2[0] = 0x00;
-
-            System.Console.WriteLine("after map[k1]: " + map[k1] + "\t k1 hashcode: " + k1.GetHashCode());
-            System.Console.WriteLine("after map[k2]: " + map[k2] + "\t k2 hashcode: " + k2.GetHashCode());
-
-            int a = 1;
-            System.Console.WriteLine(a + " hashcode " + a.GetHashCode());
-            a = 2;
-            System.Console.WriteLine(a + " hashcode " + a.GetHashCode());
+            buffer = result.Pop() as Buffer;
+            Assert.AreEqual(new byte[] { 0x32 }, buffer.ConvertTo(StackItemType.ByteArray));
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestByteArray.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestByteArray.cs
@@ -1,0 +1,128 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.MSIL.UnitTests.Utils;
+using Neo.VM.Types;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo.SmartContract.Framework.UnitTests
+{
+    [TestClass]
+    public class TestByteArray
+    {
+        //[TestMethod]
+        //public void TestByteSet()
+        //{
+        //    var testengine = new TestEngine();
+        //    testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+
+        //    var result = testengine.ExecuteTestCaseStandard("testByteSet");
+        //    var buffer = result.Pop() as Buffer;
+        //    Assert.AreEqual(new byte[] { 0x01, 0x04, 0x03 }, buffer.ConvertTo(StackItemType.ByteArray));
+        //}
+
+        [TestMethod]
+        public void TestByteReverse()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+
+            var result = testengine.ExecuteTestCaseStandard("testByteReverse");
+            var buffer = result.Pop() as Buffer;
+            Assert.AreEqual(new byte[] { 0x03, 0x02, 0x01 }, buffer.ConvertTo(StackItemType.ByteArray));
+        }
+
+        [TestMethod]
+        public void TestConcat()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+
+            var result = testengine.ExecuteTestCaseStandard("testByteCocat");
+
+            Assert.AreEqual(1, testengine.Notifications.Count);
+            var array = testengine.Notifications[0].State as Array;
+            Assert.AreEqual(1, array.Count);
+            var buffer = array[0] as Buffer;
+            Assert.AreEqual(new byte[] { 0x12, 0x23, 0x32, 0x55, 0x23, 0x01, 0x02 }, buffer.ConvertTo(StackItemType.ByteArray));
+
+            buffer = result.Pop() as Buffer;
+            Assert.AreEqual(new byte[] { 0x12, 0x23, 0x32, 0x55, 0x23, 0x01, 0x02 }, buffer.ConvertTo(StackItemType.ByteArray));
+        }
+
+        [TestMethod]
+        public void TestRange()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+
+            var result = testengine.ExecuteTestCaseStandard("testByteRange");
+
+            Assert.AreEqual(1, testengine.Notifications.Count);
+            var array = testengine.Notifications[0].State as Array;
+            Assert.AreEqual(1, array.Count);
+            var buffer = array[0] as Buffer;
+            Assert.AreEqual(new byte[] { 0x12, 0x23 }, buffer.ConvertTo(StackItemType.ByteArray));
+
+            buffer = result.Pop() as Buffer;
+            Assert.AreEqual(new byte[] { 0x12, 0x23 }, buffer.ConvertTo(StackItemType.ByteArray));
+        }
+
+        [TestMethod]
+        public void TestTake()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+
+            var result = testengine.ExecuteTestCaseStandard("testByteTake");
+
+            Assert.AreEqual(1, testengine.Notifications.Count);
+            var array = testengine.Notifications[0].State as Array;
+            Assert.AreEqual(1, array.Count);
+            var buffer = array[0] as Buffer;
+            Assert.AreEqual(new byte[] { 0x12 }, buffer.ConvertTo(StackItemType.ByteArray));
+
+            buffer = result.Pop() as Buffer;
+            Assert.AreEqual(new byte[] { 0x12 }, buffer.ConvertTo(StackItemType.ByteArray));
+        }
+
+        [TestMethod]
+        public void TestLast()
+        {
+            //var testengine = new TestEngine();
+            //testengine.AddEntryScript("./TestClasses/Contract_ByteArray.cs");
+
+            //var result = testengine.ExecuteTestCaseStandard("testByteLast");
+
+            //Assert.AreEqual(1, testengine.Notifications.Count);
+            //var array = testengine.Notifications[0].State as Array;
+            //Assert.AreEqual(1, array.Count);
+            //var buffer = array[0] as Buffer;
+            //Assert.AreEqual(new byte[] { 0x32 }, buffer.ConvertTo(StackItemType.ByteArray));
+
+            //buffer = result.Pop() as Buffer;
+            //Assert.AreEqual(new byte[] { 0x32 }, buffer.ConvertTo(StackItemType.ByteArray));
+
+
+            Dictionary<byte[], int> map = new Dictionary<byte[], int>();
+
+            var k1 = new byte[] { 0x00, 0x01 };
+            var k2 = new byte[] { 0x01, 0x01 };
+            map[k1] = 1;
+            map[k2] = 2;
+
+            System.Console.WriteLine("before map[k1]: " + map[k1] + "\t k1 hashcode: " + k1.GetHashCode());
+            System.Console.WriteLine("before map[k2]: " + map[k2] + "\t k2 hashcode: " + k2.GetHashCode());
+
+            k1[0] = 0x01;
+            k2[0] = 0x00;
+
+            System.Console.WriteLine("after map[k1]: " + map[k1] + "\t k1 hashcode: " + k1.GetHashCode());
+            System.Console.WriteLine("after map[k2]: " + map[k2] + "\t k2 hashcode: " + k2.GetHashCode());
+
+            int a = 1;
+            System.Console.WriteLine(a + " hashcode " + a.GetHashCode());
+            a = 2;
+            System.Console.WriteLine(a + " hashcode " + a.GetHashCode());
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_ByteArray.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_ByteArray.cs
@@ -1,0 +1,46 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services.Neo;
+
+namespace Neo.Compiler.MSIL.TestClasses
+{
+    public class Contract_ByteArray : SmartContract.Framework.SmartContract
+    {
+        // Support in the future, when our vm removed Buffer
+        //public static byte[] TestByteSet()
+        //{
+        //    var a = new byte[] { 0x01, 0x02, 0x03 };
+        //    a[1] = 0x04;
+        //    return a;
+        //}
+
+        public static byte[] TestByteReverse()
+        {
+            var a = new byte[] { 0x01, 0x02, 0x03 };
+            return a.Reverse();
+        }
+
+        public static byte[] TestByteCocat()
+        {
+            Runtime.Notify((new byte[] { 0x12, 0x23, 0x32 }).Concat(new byte[] { 0x55, 0x23 }.Concat(new byte[] { 0x01, 0x02 })));
+            return (new byte[] { 0x12, 0x23, 0x32 }).Concat(new byte[] { 0x55, 0x23 }.Concat(new byte[] { 0x01, 0x02 }));
+        }
+
+        public static byte[] TestByteRange()
+        {
+            Runtime.Notify((new byte[] { 0x12, 0x23, 0x32 }).Range(0, 2));
+            return (new byte[] { 0x12, 0x23, 0x32 }).Range(0, 2);
+        }
+
+        public static byte[] TestByteTake()
+        {
+            Runtime.Notify((new byte[] { 0x12, 0x23, 0x32 }).Take(1));
+            return (new byte[] { 0x12, 0x23, 0x32 }).Take(1);
+        }
+
+        public static byte[] TestByteLast()
+        {
+            Runtime.Notify((new byte[] { 0x12, 0x23, 0x32 }).Last(1));
+            return (new byte[] { 0x12, 0x23, 0x32 }).Last(1);
+        }
+    }
+}


### PR DESCRIPTION
paritly close #217 close #218 

- support Bytes.Reverse
- add ut for Helper.Concat, Helper.Ranage, Helper.Take, Helper.Last

But, we don't support to assign the element of byte array, eg: `bytes[i] = 0x01`.

@lightszero @shargon @ProDog plz, have a reivew.