### PR TITLE
skip emitting debug info for methods w/o body_Codes

### DIFF
--- a/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_Event.cs
+++ b/Neo.Compiler.MSIL.UnitTests/TestClasses/Contract_Event.cs
@@ -9,6 +9,9 @@ namespace Neo.Compiler.MSIL.TestClasses
         [DisplayName("transfer")]
         public static event Action<byte[], byte[], BigInteger> Transferred;
 
+        [Neo.SmartContract.Framework.Appcall("1234567890abcdef1234567890abcdef12345678")]
+        public static extern string DynamicTest(string arg);
+
         public static void Main(string method, object[] args) { }
     }
 }

--- a/Neo.Compiler.MSIL.UnitTests/UnitTest_DebugInfo.cs
+++ b/Neo.Compiler.MSIL.UnitTests/UnitTest_DebugInfo.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.MSIL.Utils;
 using System;
 using System.Collections.Generic;

--- a/Neo.Compiler.MSIL.UnitTests/Utils/DefLogger.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/DefLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Neo.Compiler.MSIL.Utils
 {

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestBlock.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestBlock.cs
@@ -1,4 +1,4 @@
-﻿using Neo.VM;
+using Neo.VM;
 using System;
 using System.Collections.Generic;
 

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestCrypto.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestCrypto.cs
@@ -1,4 +1,4 @@
-﻿using Neo.VM;
+using Neo.VM;
 using System;
 
 namespace Neo.Compiler.MSIL.Utils

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestHeader.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestHeader.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.Compiler.MSIL.Utils
+namespace Neo.Compiler.MSIL.Utils
 {
     internal class TestHeader
     {

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestInteropService.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestInteropService.cs
@@ -1,4 +1,4 @@
-﻿using Neo.VM;
+using Neo.VM;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestTable.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestTable.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Neo.VM;
 
 namespace Neo.Compiler.MSIL.Utils

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestTransaction.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestTransaction.cs
@@ -1,4 +1,4 @@
-﻿using Neo.VM;
+using Neo.VM;
 using System;
 using System.Collections.Generic;
 

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestTxInput.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestTxInput.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Neo.Compiler.MSIL.Utils
 {

--- a/Neo.Compiler.MSIL.UnitTests/Utils/TestTxOutput.cs
+++ b/Neo.Compiler.MSIL.UnitTests/Utils/TestTxOutput.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Neo.Compiler.MSIL.Utils
 {

--- a/Neo.Compiler.MSIL/ConvOption.cs
+++ b/Neo.Compiler.MSIL/ConvOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.Compiler
+namespace Neo.Compiler
 {
     public class ConvOption
     {

--- a/Neo.Compiler.MSIL/DebugExport.cs
+++ b/Neo.Compiler.MSIL/DebugExport.cs
@@ -59,6 +59,11 @@ namespace Neo.Compiler
 
             foreach (var method in module.mapMethods.Values)
             {
+                if (method.body_Codes.Values.Count == 0)
+                {
+                    continue;
+                }
+
                 var name = string.Format("{0},{1}",
                     method._namespace, method.displayName);
 

--- a/Neo.Compiler.MSIL/FuncExport.cs
+++ b/Neo.Compiler.MSIL/FuncExport.cs
@@ -1,4 +1,4 @@
-﻿using Neo.Compiler;
+using Neo.Compiler;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Neo.Compiler.MSIL/Helper.cs
+++ b/Neo.Compiler.MSIL/Helper.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Cecil;
+using Mono.Cecil;
 using System;
 using System.Security.Cryptography;
 using System.Text;

--- a/Neo.Compiler.MSIL/ILogger.cs
+++ b/Neo.Compiler.MSIL/ILogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.Compiler
+namespace Neo.Compiler
 {
     public interface ILogger
     {

--- a/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
+++ b/Neo.Compiler.MSIL/MSIL/CctorSubVM.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Neo.Compiler.MSIL/MyJson.cs
+++ b/Neo.Compiler.MSIL/MyJson.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
+++ b/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>2015-2019 The Neo Project</Copyright>
     <AssemblyTitle>Neo.Compiler.MSIL</AssemblyTitle>
-    <Version>2.6</Version>
+    <Version>2.6.1</Version>
     <Authors>The Neo Project</Authors>
     <AssemblyName>neon</AssemblyName>
     <PackageTags>NEO;Blockchain;Smart Contract;Compiler</PackageTags>

--- a/Neo.Compiler.MSIL/RIPEMD160Managed.cs
+++ b/Neo.Compiler.MSIL/RIPEMD160Managed.cs
@@ -1,4 +1,4 @@
-﻿#if !NET461
+#if !NET461
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/Neo.Compiler.MSIL/base58.cs
+++ b/Neo.Compiler.MSIL/base58.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Numerics;
 using System.Text;

--- a/Neo.ConvertTask/ConvertTask.cs
+++ b/Neo.ConvertTask/ConvertTask.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Diagnostics;
 

--- a/Neo.ConvertTask/Properties/AssemblyInfo.cs
+++ b/Neo.ConvertTask/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // 有关程序集的一般信息由以下

--- a/Neo.SmartContract.Framework/AppcallAttribute.cs
+++ b/Neo.SmartContract.Framework/AppcallAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace Neo.SmartContract.Framework

--- a/Neo.SmartContract.Framework/IApiInterface.cs
+++ b/Neo.SmartContract.Framework/IApiInterface.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework
+namespace Neo.SmartContract.Framework
 {
     public interface IApiInterface
     {

--- a/Neo.SmartContract.Framework/IScriptContainer.cs
+++ b/Neo.SmartContract.Framework/IScriptContainer.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework
+namespace Neo.SmartContract.Framework
 {
     public interface IScriptContainer : IApiInterface
     {

--- a/Neo.SmartContract.Framework/Neo.SmartContract.Framework.csproj
+++ b/Neo.SmartContract.Framework/Neo.SmartContract.Framework.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>2016-2017 The Neo Project</Copyright>

--- a/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
+++ b/Neo.SmartContract.Framework/NonemitWithConvertAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Neo.SmartContract.Framework
 {

--- a/Neo.SmartContract.Framework/Services/Neo/Account.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Account.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Account
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Asset.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Asset.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Asset
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Block.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Block.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Block : Header
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Blockchain.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Blockchain.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public static class Blockchain
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Contract.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Contract.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Contract
     {

--- a/Neo.SmartContract.Framework/Services/Neo/ContractPropertyState.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/ContractPropertyState.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public enum ContractPropertyState : byte
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Header.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Header.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Header : IScriptContainer
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Helper.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Helper.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 namespace Neo.SmartContract.Framework.Services.Neo
 {

--- a/Neo.SmartContract.Framework/Services/Neo/InvocationTransaction.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/InvocationTransaction.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class InvocationTransaction : Transaction
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Iterator.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Iterator.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Iterator<TKey, TValue>
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Runtime.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Runtime.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public static class Runtime
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Storage.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Storage.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 namespace Neo.SmartContract.Framework.Services.Neo
 {

--- a/Neo.SmartContract.Framework/Services/Neo/StorageContext.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/StorageContext.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class StorageContext
     {

--- a/Neo.SmartContract.Framework/Services/Neo/StorageMap.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/StorageMap.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class StorageMap
     {

--- a/Neo.SmartContract.Framework/Services/Neo/Transaction.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/Transaction.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Transaction : IScriptContainer
     {

--- a/Neo.SmartContract.Framework/Services/Neo/TransactionAttribute.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/TransactionAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class TransactionAttribute : IApiInterface
     {

--- a/Neo.SmartContract.Framework/Services/Neo/TransactionInput.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/TransactionInput.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class TransactionInput : IApiInterface
     {

--- a/Neo.SmartContract.Framework/Services/Neo/TransactionOutput.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/TransactionOutput.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class TransactionOutput : IApiInterface
     {

--- a/Neo.SmartContract.Framework/Services/Neo/TriggerType.cs
+++ b/Neo.SmartContract.Framework/Services/Neo/TriggerType.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.Neo
+namespace Neo.SmartContract.Framework.Services.Neo
 {
     public enum TriggerType : byte
     {

--- a/Neo.SmartContract.Framework/Services/System/ExecutionEngine.cs
+++ b/Neo.SmartContract.Framework/Services/System/ExecutionEngine.cs
@@ -1,4 +1,4 @@
-﻿namespace Neo.SmartContract.Framework.Services.System
+namespace Neo.SmartContract.Framework.Services.System
 {
     public static class ExecutionEngine
     {

--- a/Neo.SmartContract.Framework/SyscallAttribute.cs
+++ b/Neo.SmartContract.Framework/SyscallAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Neo.SmartContract.Framework
 {

--- a/neo-devpack-dotnet.sln
+++ b/neo-devpack-dotnet.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28803.452


### PR DESCRIPTION
fixes #264 

Note, this PR also bumps version of Neo.Compiler.MSIL from 2.6 to 2.6.1. I plan on publishing the updated dotnet tool on nuget shortly after this PR is merged 