### PR TITLE
Include path when compiling from source or project (2x)

### DIFF
--- a/Neo.Compiler.MSIL/Compiler.cs
+++ b/Neo.Compiler.MSIL/Compiler.cs
@@ -159,7 +159,10 @@ namespace Neo.Compiler
         /// <returns>Assembly</returns>
         public static Assembly CompileVBFiles(string[] filenames, string[] references, bool releaseMode = true)
         {
-            var tree = filenames.Select(u => VisualBasicSyntaxTree.ParseText(File.ReadAllText(u))).ToArray();
+            var tree = filenames.Select(u => VisualBasicSyntaxTree.ParseText(
+                            File.ReadAllText(u),
+                            path: u,
+                            encoding: System.Text.Encoding.UTF8)).ToArray();
             var op = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: releaseMode ? OptimizationLevel.Release : OptimizationLevel.Debug);
             return Assembly.Create(VisualBasicCompilation.Create("SmartContract", tree, CreateReferences(references), op));
         }
@@ -173,7 +176,10 @@ namespace Neo.Compiler
         /// <returns>Assembly</returns>
         public static Assembly CompileCSFiles(string[] filenames, string[] references, bool releaseMode = true)
         {
-            var tree = filenames.Select(u => CSharpSyntaxTree.ParseText(File.ReadAllText(u))).ToArray();
+            var tree = filenames.Select(u => CSharpSyntaxTree.ParseText(
+                            File.ReadAllText(u),
+                            path: u,
+                            encoding: System.Text.Encoding.UTF8)).ToArray();
             var op = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: releaseMode ? OptimizationLevel.Release : OptimizationLevel.Debug);
             return Assembly.Create(CSharpCompilation.Create("SmartContract", tree, CreateReferences(references), op));
         }

--- a/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
+++ b/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>2015-2019 The Neo Project</Copyright>
     <AssemblyTitle>Neo.Compiler.MSIL</AssemblyTitle>
-    <Version>2.6.1</Version>
+    <Version>2.6.2</Version>
     <Authors>The Neo Project</Authors>
     <AssemblyName>neon</AssemblyName>
     <PackageTags>NEO;Blockchain;Smart Contract;Compiler</PackageTags>


### PR DESCRIPTION
PDBs generated when compiling from source or project files are missing source path information. 

fixes #275 for master-2.x branch. @devhawk will make similar fix for master branch when he ports over the code to generate debug info files for neo-debugger. 