### PR TITLE
Add code assist for native contract.

### DIFF
--- a/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
+++ b/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
@@ -1,14 +1,113 @@
+using System.Numerics;
+
 namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Native
     {
-        [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-        public static extern object NEO(string method, object[] arguments);
+        public static class NEO
+        {
+            /// <param name="method">Please input &quot;name&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string Name(string method = "name");
 
-        [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-        public static extern object GAS(string method, object[] arguments);
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string Symbol(string method = "symbol");
 
-        [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-        public static extern object Policy(string method, object[] arguments);
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string Decimals(string method = "decimals");
+
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string TotalSupply(string method = "totalSupply");
+
+            /// <param name="method">Please input &quot;BalanceOf&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string BalanceOf(string method, byte[] scriptHash);
+
+            /// <param name="method">Please input &quot;Transfer&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string Transfer(string method, byte[] from, byte[] to, BigInteger amount);
+
+            /// <param name="method">Please input &quot;RegisterCandidate&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string RegisterCandidate(string method, byte[] publicKey);
+
+            /// <param name="method">Please input &quot;UnregisterCandidate&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string UnregisterCandidate(string method, byte[] publicKey);
+
+            /// <param name="method">Please input &quot;Vote&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string Vote(string method, byte[] scriptHash, byte[][] candidatePublicKey);
+
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string GetValidators(string method = "GetValidators");
+
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string GetCandidates(string method = "GetCandidates");
+
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string GetCommittee(string method = "GetCommittee");
+
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string GetNextBlockValidators(string method = "GetNextBlockValidators");
+
+            /// <param name="method">Please input &quot;UnclaimedGas&quot;</param>
+            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            public static extern string UnclaimedGas(string method, byte[] scriptHash, uint endBlockIndex);
+        }
+
+        public static class GAS
+        {
+            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            public static extern string Name(string method = "name");
+
+            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            public static extern string Symbol(string method = "symbol");
+
+            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            public static extern string Decimals(string method = "decimals");
+
+            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            public static extern string TotalSupply(string method = "totalSupply");
+
+            /// <param name="method">Please input &quot;BalanceOf&quot;</param>
+            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            public static extern string BalanceOf(string method, byte[] scriptHash);
+
+            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            public static extern string Transfer(string method, byte[] from, byte[] to, BigInteger amount);
+        }
+
+        public static class Policy
+        {
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string GetMaxTransactionsPerBlock(string method = "GetMaxTransactionsPerBlock");
+
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string GetFeePerByte(string method = "GetFeePerByte");
+
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string GetBlockedAccounts(string method = "GetBlockedAccounts");
+
+            /// <param name="method">Please input &quot;SetMaxBlockSize&quot;</param>
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string SetMaxBlockSize(string method, BigInteger maxBlockSize);
+
+            /// <param name="method">Please input &quot;SetMaxTransactionsPerBlock&quot;</param>
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string SetMaxTransactionsPerBlock(string method, BigInteger maxTransactionsPerBlock);
+
+            /// <param name="method">Please input &quot;SetFeePerByte&quot;</param>
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string SetFeePerByte(string method, BigInteger feePerByte);
+
+            /// <param name="method">Please input &quot;BlockAccount&quot;</param>
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string BlockAccount(string method, byte[] scriptHash);
+
+            /// <param name="method">Please input &quot;UnblockAccount&quot;</param>
+            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            public static extern string UnblockAccount(string method, byte[] scriptHash);
+        }
     }
 }

--- a/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
+++ b/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
@@ -6,7 +6,6 @@ namespace Neo.SmartContract.Framework.Services.Neo
     {
         public static class NEO
         {
-            /// <param name="method">Please input &quot;name&quot;</param>
             [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
             public static extern string Name(string method = "name");
 

--- a/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
+++ b/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
@@ -6,106 +6,106 @@ namespace Neo.SmartContract.Framework.Services.Neo
     {
         public static class NEO
         {
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string Name(string method = "name");
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string Symbol(string method = "symbol");
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string Decimals(string method = "decimals");
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string TotalSupply(string method = "totalSupply");
 
             /// <param name="method">Please input &quot;BalanceOf&quot;</param>
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string BalanceOf(string method, byte[] scriptHash);
 
             /// <param name="method">Please input &quot;Transfer&quot;</param>
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string Transfer(string method, byte[] from, byte[] to, BigInteger amount);
 
             /// <param name="method">Please input &quot;RegisterCandidate&quot;</param>
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string RegisterCandidate(string method, byte[] publicKey);
 
             /// <param name="method">Please input &quot;UnregisterCandidate&quot;</param>
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string UnregisterCandidate(string method, byte[] publicKey);
 
             /// <param name="method">Please input &quot;Vote&quot;</param>
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string Vote(string method, byte[] scriptHash, byte[][] candidatePublicKey);
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string GetValidators(string method = "GetValidators");
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string GetCandidates(string method = "GetCandidates");
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string GetCommittee(string method = "GetCommittee");
 
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string GetNextBlockValidators(string method = "GetNextBlockValidators");
 
             /// <param name="method">Please input &quot;UnclaimedGas&quot;</param>
-            [Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789")]
+            [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern string UnclaimedGas(string method, byte[] scriptHash, uint endBlockIndex);
         }
 
         public static class GAS
         {
-            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern string Name(string method = "name");
 
-            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern string Symbol(string method = "symbol");
 
-            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern string Decimals(string method = "decimals");
 
-            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern string TotalSupply(string method = "totalSupply");
 
             /// <param name="method">Please input &quot;BalanceOf&quot;</param>
-            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern string BalanceOf(string method, byte[] scriptHash);
 
-            [Appcall("0x8c23f196d8a1bfd103a9dcb1f9ccf0c611377d3b")]
+            [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern string Transfer(string method, byte[] from, byte[] to, BigInteger amount);
         }
 
         public static class Policy
         {
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string GetMaxTransactionsPerBlock(string method = "GetMaxTransactionsPerBlock");
 
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string GetFeePerByte(string method = "GetFeePerByte");
 
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string GetBlockedAccounts(string method = "GetBlockedAccounts");
 
             /// <param name="method">Please input &quot;SetMaxBlockSize&quot;</param>
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string SetMaxBlockSize(string method, BigInteger maxBlockSize);
 
             /// <param name="method">Please input &quot;SetMaxTransactionsPerBlock&quot;</param>
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string SetMaxTransactionsPerBlock(string method, BigInteger maxTransactionsPerBlock);
 
             /// <param name="method">Please input &quot;SetFeePerByte&quot;</param>
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string SetFeePerByte(string method, BigInteger feePerByte);
 
             /// <param name="method">Please input &quot;BlockAccount&quot;</param>
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string BlockAccount(string method, byte[] scriptHash);
 
             /// <param name="method">Please input &quot;UnblockAccount&quot;</param>
-            [Appcall("0x3209d09120465bf181ced70693b897ec6ea4619a")]
+            [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
             public static extern string UnblockAccount(string method, byte[] scriptHash);
         }
     }

--- a/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
+++ b/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
@@ -6,17 +6,21 @@ namespace Neo.SmartContract.Framework.Services.Neo
     {
         public class NEO
         {
+            /// <param name="method">Please input &quot;name&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Name(string method = "name", object[] arguments = null);
+            public static extern string Name(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;symbol&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Symbol(string method = "symbol", object[] arguments = null);
+            public static extern string Symbol(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;decimals&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern int Decimals(string method = "decimals", object[] arguments = null);
+            public static extern int Decimals(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;totalSupply&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern BigInteger TotalSupply(string method = "totalSupply", object[] arguments = null);
+            public static extern BigInteger TotalSupply(string method, object[] arguments);
 
             /// <param name="method">Please input &quot;BalanceOf&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
@@ -38,17 +42,21 @@ namespace Neo.SmartContract.Framework.Services.Neo
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
             public static extern bool Vote(string method, byte[] scriptHash, byte[][] candidatePublicKey);
 
+            /// <param name="method">Please input &quot;GetValidators&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern byte[][] GetValidators(string method = "GetValidators", object[] arguments = null);
+            public static extern byte[][] GetValidators(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;GetCandidates&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern byte[][] GetCandidates(string method = "GetCandidates", object[] arguments = null);
+            public static extern byte[][] GetCandidates(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;GetCommittee&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern byte[][] GetCommittee(string method = "GetCommittee", object[] arguments = null);
+            public static extern byte[][] GetCommittee(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;GetNextBlockValidators&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern byte[][] GetNextBlockValidators(string method = "GetNextBlockValidators", object[] arguments = null);
+            public static extern byte[][] GetNextBlockValidators(string method, object[] arguments);
 
             /// <param name="method">Please input &quot;UnclaimedGas&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
@@ -57,36 +65,44 @@ namespace Neo.SmartContract.Framework.Services.Neo
 
         public class GAS
         {
+            /// <param name="method">Please input &quot;name&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string Name(string method = "name", object[] arguments = null);
+            public static extern string Name(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;symbol&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string Symbol(string method = "symbol", object[] arguments = null);
+            public static extern string Symbol(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;decimals&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern int Decimals(string method = "decimals", object[] arguments = null);
+            public static extern int Decimals(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;totalSupply&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern BigInteger TotalSupply(string method = "totalSupply", object[] arguments = null);
+            public static extern BigInteger TotalSupply(string method, object[] arguments);
 
             /// <param name="method">Please input &quot;BalanceOf&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern BigInteger BalanceOf(string method, byte[] scriptHash);
 
+            /// <param name="method">Please input &quot;Transfer&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
             public static extern bool Transfer(string method, byte[] from, byte[] to, BigInteger amount);
         }
 
         public class Policy
         {
+            /// <param name="method">Please input &quot;GetMaxTransactionsPerBlock&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern BigInteger GetMaxTransactionsPerBlock(string method = "GetMaxTransactionsPerBlock", object[] arguments = null);
+            public static extern BigInteger GetMaxTransactionsPerBlock(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;deGetFeePerBytecimals&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern BigInteger GetFeePerByte(string method = "GetFeePerByte", object[] arguments = null);
+            public static extern BigInteger GetFeePerByte(string method, object[] arguments);
 
+            /// <param name="method">Please input &quot;GetBlockedAccounts&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern byte[][] GetBlockedAccounts(string method = "GetBlockedAccounts", object[] arguments = null);
+            public static extern byte[][] GetBlockedAccounts(string method, object[] arguments);
 
             /// <param name="method">Please input &quot;SetMaxBlockSize&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]

--- a/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
+++ b/src/Neo.SmartContract.Framework/Services/Neo/Native.cs
@@ -4,109 +4,109 @@ namespace Neo.SmartContract.Framework.Services.Neo
 {
     public class Native
     {
-        public static class NEO
+        public class NEO
         {
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Name(string method = "name");
+            public static extern string Name(string method = "name", object[] arguments = null);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Symbol(string method = "symbol");
+            public static extern string Symbol(string method = "symbol", object[] arguments = null);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Decimals(string method = "decimals");
+            public static extern int Decimals(string method = "decimals", object[] arguments = null);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string TotalSupply(string method = "totalSupply");
+            public static extern BigInteger TotalSupply(string method = "totalSupply", object[] arguments = null);
 
             /// <param name="method">Please input &quot;BalanceOf&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string BalanceOf(string method, byte[] scriptHash);
+            public static extern BigInteger BalanceOf(string method, byte[] scriptHash);
 
             /// <param name="method">Please input &quot;Transfer&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Transfer(string method, byte[] from, byte[] to, BigInteger amount);
+            public static extern bool Transfer(string method, byte[] from, byte[] to, BigInteger amount);
 
             /// <param name="method">Please input &quot;RegisterCandidate&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string RegisterCandidate(string method, byte[] publicKey);
+            public static extern bool RegisterCandidate(string method, byte[] publicKey);
 
             /// <param name="method">Please input &quot;UnregisterCandidate&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string UnregisterCandidate(string method, byte[] publicKey);
+            public static extern bool UnregisterCandidate(string method, byte[] publicKey);
 
             /// <param name="method">Please input &quot;Vote&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string Vote(string method, byte[] scriptHash, byte[][] candidatePublicKey);
+            public static extern bool Vote(string method, byte[] scriptHash, byte[][] candidatePublicKey);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string GetValidators(string method = "GetValidators");
+            public static extern byte[][] GetValidators(string method = "GetValidators", object[] arguments = null);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string GetCandidates(string method = "GetCandidates");
+            public static extern byte[][] GetCandidates(string method = "GetCandidates", object[] arguments = null);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string GetCommittee(string method = "GetCommittee");
+            public static extern byte[][] GetCommittee(string method = "GetCommittee", object[] arguments = null);
 
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string GetNextBlockValidators(string method = "GetNextBlockValidators");
+            public static extern byte[][] GetNextBlockValidators(string method = "GetNextBlockValidators", object[] arguments = null);
 
             /// <param name="method">Please input &quot;UnclaimedGas&quot;</param>
             [Appcall("0xde5f57d430d3dece511cf975a8d37848cb9e0525")]
-            public static extern string UnclaimedGas(string method, byte[] scriptHash, uint endBlockIndex);
+            public static extern BigInteger UnclaimedGas(string method, byte[] scriptHash, uint endBlockIndex);
         }
 
-        public static class GAS
+        public class GAS
         {
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string Name(string method = "name");
+            public static extern string Name(string method = "name", object[] arguments = null);
 
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string Symbol(string method = "symbol");
+            public static extern string Symbol(string method = "symbol", object[] arguments = null);
 
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string Decimals(string method = "decimals");
+            public static extern int Decimals(string method = "decimals", object[] arguments = null);
 
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string TotalSupply(string method = "totalSupply");
+            public static extern BigInteger TotalSupply(string method = "totalSupply", object[] arguments = null);
 
             /// <param name="method">Please input &quot;BalanceOf&quot;</param>
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string BalanceOf(string method, byte[] scriptHash);
+            public static extern BigInteger BalanceOf(string method, byte[] scriptHash);
 
             [Appcall("0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc")]
-            public static extern string Transfer(string method, byte[] from, byte[] to, BigInteger amount);
+            public static extern bool Transfer(string method, byte[] from, byte[] to, BigInteger amount);
         }
 
-        public static class Policy
+        public class Policy
         {
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string GetMaxTransactionsPerBlock(string method = "GetMaxTransactionsPerBlock");
+            public static extern BigInteger GetMaxTransactionsPerBlock(string method = "GetMaxTransactionsPerBlock", object[] arguments = null);
 
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string GetFeePerByte(string method = "GetFeePerByte");
+            public static extern BigInteger GetFeePerByte(string method = "GetFeePerByte", object[] arguments = null);
 
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string GetBlockedAccounts(string method = "GetBlockedAccounts");
+            public static extern byte[][] GetBlockedAccounts(string method = "GetBlockedAccounts", object[] arguments = null);
 
             /// <param name="method">Please input &quot;SetMaxBlockSize&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string SetMaxBlockSize(string method, BigInteger maxBlockSize);
+            public static extern bool SetMaxBlockSize(string method, BigInteger maxBlockSize);
 
             /// <param name="method">Please input &quot;SetMaxTransactionsPerBlock&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string SetMaxTransactionsPerBlock(string method, BigInteger maxTransactionsPerBlock);
+            public static extern bool SetMaxTransactionsPerBlock(string method, BigInteger maxTransactionsPerBlock);
 
             /// <param name="method">Please input &quot;SetFeePerByte&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string SetFeePerByte(string method, BigInteger feePerByte);
+            public static extern bool SetFeePerByte(string method, BigInteger feePerByte);
 
             /// <param name="method">Please input &quot;BlockAccount&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string BlockAccount(string method, byte[] scriptHash);
+            public static extern bool BlockAccount(string method, byte[] scriptHash);
 
             /// <param name="method">Please input &quot;UnblockAccount&quot;</param>
             [Appcall("0xce06595079cd69583126dbfd1d2e25cca74cffe9")]
-            public static extern string UnblockAccount(string method, byte[] scriptHash);
+            public static extern bool UnblockAccount(string method, byte[] scriptHash);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Native.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Native.cs
@@ -9,30 +9,30 @@ namespace Neo.Compiler.MSIL.TestClasses
         [DisplayName("NEO_Decimals")]
         public static int NEO_Decimals()
         {
-            return (int)Native.NEO("decimals", new object[0]);
+            return (int)Native.NEO.Decimals();
         }
 
         [DisplayName("NEO_Name")]
         public static string NEO_Name()
         {
-            return (string)Native.NEO("name", new object[0]);
+            return (string)Native.NEO.Name();
         }
 
         [DisplayName("GAS_Decimals")]
         public static int GAS_Decimals()
         {
-            return (int)Native.GAS("decimals", new object[0]);
+            return (int)Native.GAS.Decimals();
         }
 
         [DisplayName("GAS_Name")]
         public static string GAS_Name()
         {
-            return (string)Native.GAS("name", new object[0]);
+            return (string)Native.GAS.Name();
         }
 
         public static BigInteger Policy_GetFeePerByte()
         {
-            return (BigInteger)Native.Policy("getFeePerByte", new object[0]);
+            return (BigInteger)Native.Policy.GetFeePerByte();
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Native.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Native.cs
@@ -9,30 +9,30 @@ namespace Neo.Compiler.MSIL.TestClasses
         [DisplayName("NEO_Decimals")]
         public static int NEO_Decimals()
         {
-            return (int)Native.NEO.Decimals();
+            return (int)Native.NEO.Decimals("decimals", new object[0]);
         }
 
         [DisplayName("NEO_Name")]
         public static string NEO_Name()
         {
-            return (string)Native.NEO.Name();
+            return (string)Native.NEO.Name("name", new object[0]);
         }
 
         [DisplayName("GAS_Decimals")]
         public static int GAS_Decimals()
         {
-            return (int)Native.GAS.Decimals();
+            return (int)Native.GAS.Decimals("decimals", new object[0]);
         }
 
         [DisplayName("GAS_Name")]
         public static string GAS_Name()
         {
-            return (string)Native.GAS.Name();
+            return (string)Native.GAS.Name("name", new object[0]);
         }
 
         public static BigInteger Policy_GetFeePerByte()
         {
-            return (BigInteger)Native.Policy.GetFeePerByte();
+            return (BigInteger)Native.Policy.GetFeePerByte("getFeePerByte", new object[0]);
         }
     }
 }


### PR DESCRIPTION
Add code assist for native contract.
There may be a better modification method for code assist, but it seems that a large number of modifications to Neo.Compiler.MSIL are required.

such as:

``` csharp
[Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789", "name")]
public static extern string Name();

[Appcall("0x9bde8f209c88dd0e7ca3bf0af0f476cdd8207789", "BalanceOf")]
public static extern string BalanceOf(byte[] scriptHash);
```