### PR TITLE
Fix operations of string "Concat" and "Substr"

### DIFF
--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
@@ -513,14 +513,6 @@ namespace Neo.Compiler.MSIL
                     {
                         Convert1by1(VM.OpCode.NUMEQUAL, src, to);
                     }
-                    else if (_ref.DeclaringType.FullName == "System.String")
-                    {
-                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
-                        Convert1by1(VM.OpCode.SWAP, null, to);
-                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
-                        Convert1by1(VM.OpCode.SWAP, null, to);
-                        Convert1by1(VM.OpCode.EQUAL, src, to);
-                    }
                     else
                     {
                         Convert1by1(VM.OpCode.EQUAL, src, to);
@@ -546,15 +538,6 @@ namespace Neo.Compiler.MSIL
                         || _ref.DeclaringType.FullName == "System.Numerics.BigInteger")
                     {
                         Convert1by1(VM.OpCode.NUMNOTEQUAL, src, to);
-                    }
-                    else if (_ref.DeclaringType.FullName == "System.String")
-                    {
-                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
-                        Convert1by1(VM.OpCode.SWAP, null, to);
-                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
-                        Convert1by1(VM.OpCode.SWAP, null, to);
-                        Convert1by1(VM.OpCode.EQUAL, src, to);
-                        Convert1by1(VM.OpCode.NOT, null, to);
                     }
                     else
                     {
@@ -651,12 +634,14 @@ namespace Neo.Compiler.MSIL
                 {
                     //"System.String System.String::Concat(System.String,System.String)"
                     Convert1by1(VM.OpCode.CAT, src, to);
+                    Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
                     return 0;
                 }
 
                 else if (src.tokenMethod == "System.String System.String::Substring(System.Int32,System.Int32)")
                 {
                     Convert1by1(VM.OpCode.SUBSTR, src, to);
+                    Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
                     return 0;
 
                 }

--- a/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
+++ b/src/Neo.Compiler.MSIL/MSIL/Conv_Multi.cs
@@ -513,6 +513,14 @@ namespace Neo.Compiler.MSIL
                     {
                         Convert1by1(VM.OpCode.NUMEQUAL, src, to);
                     }
+                    else if (_ref.DeclaringType.FullName == "System.String")
+                    {
+                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
+                        Convert1by1(VM.OpCode.SWAP, null, to);
+                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
+                        Convert1by1(VM.OpCode.SWAP, null, to);
+                        Convert1by1(VM.OpCode.EQUAL, src, to);
+                    }
                     else
                     {
                         Convert1by1(VM.OpCode.EQUAL, src, to);
@@ -538,6 +546,15 @@ namespace Neo.Compiler.MSIL
                         || _ref.DeclaringType.FullName == "System.Numerics.BigInteger")
                     {
                         Convert1by1(VM.OpCode.NUMNOTEQUAL, src, to);
+                    }
+                    else if (_ref.DeclaringType.FullName == "System.String")
+                    {
+                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
+                        Convert1by1(VM.OpCode.SWAP, null, to);
+                        Insert1(VM.OpCode.CONVERT, "", to, new byte[] { (byte)VM.Types.StackItemType.ByteString });
+                        Convert1by1(VM.OpCode.SWAP, null, to);
+                        Convert1by1(VM.OpCode.EQUAL, src, to);
+                        Convert1by1(VM.OpCode.NOT, null, to);
                     }
                     else
                     {

--- a/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.MSIL.UnitTests.Utils;
+using Neo.VM;
+using Neo.VM.Types;
+
+namespace Neo.SmartContract.Framework.UnitTests
+{
+    [TestClass]
+    public class StringTest
+    {
+        private TestEngine _engine;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _engine = new TestEngine();
+            _engine.AddEntryScript("./TestClasses/Contract_String.cs");
+        }
+
+        [TestMethod]
+        public void TestStringAdd()
+        {
+            var result = _engine.ExecuteTestCaseStandard("testStringAdd", "stu", "dent");
+            Assert.AreEqual(1, result.Count);
+
+            var item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Integer));
+            Assert.AreEqual(4, item);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
@@ -20,12 +20,31 @@ namespace Neo.SmartContract.Framework.UnitTests
         [TestMethod]
         public void TestStringAdd()
         {
-            var result = _engine.ExecuteTestCaseStandard("testStringAdd", "stu", "dent");
+            // ab => 3
+            var result = _engine.ExecuteTestCaseStandard("testStringAdd", "a", "b");
             Assert.AreEqual(1, result.Count);
 
             var item = result.Pop();
             Assert.IsInstanceOfType(item, typeof(Integer));
+            Assert.AreEqual(3, item);
+
+            // hello => 4
+            _engine.Reset();
+            result = _engine.ExecuteTestCaseStandard("testStringAdd", "he", "llo");
+            Assert.AreEqual(1, result.Count);
+
+            item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Integer));
             Assert.AreEqual(4, item);
+
+            // world => 5
+            _engine.Reset();
+            result = _engine.ExecuteTestCaseStandard("testStringAdd", "wo", "rld");
+            Assert.AreEqual(1, result.Count);
+
+            item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Integer));
+            Assert.AreEqual(5, item);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
@@ -1,6 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.MSIL.UnitTests.Utils;
-using Neo.VM;
 using Neo.VM.Types;
 
 namespace Neo.SmartContract.Framework.UnitTests

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_String.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_String.cs
@@ -12,11 +12,11 @@ namespace Neo.Compiler.MSIL.TestClasses
         {
             int a = 3;
             string c = s1 + s2;
-            if (c == "student")
+            if (c == "hello")
             {
                 a = 4;
             }
-            else if (c == "test")
+            else if (c == "world")
             {
                 a = 5;
             }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_String.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_String.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services.Neo;
+
+namespace Neo.Compiler.MSIL.TestClasses
+{
+    public class Contract_String : SmartContract.Framework.SmartContract
+    {
+        public static int TestStringAdd(string s1, string s2)
+        {
+            int a = 3;
+            string c = s1 + s2;
+            if (c == "student")
+            {
+                a = 4;
+            }
+            else if (c == "test")
+            {
+                a = 5;
+            }
+            return a;
+        }
+    }
+}


### PR DESCRIPTION
close #294 
The `CAT` 、`SUBSTR`、`LEFT` and `RIGHT`  would save the result as `Buffer`，So we can convert them to `ByteString`, but that doesn't seem like a good solution.