### PR TITLE
Fix templates

### DIFF
--- a/templates/Template.CSharp/ProjectTemplate.csproj
+++ b/templates/Template.CSharp/ProjectTemplate.csproj
@@ -11,7 +11,7 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Message Text="Start NeoContract converter, Source File: $(TargetPath)" Importance="high">
     </Message>
-    <Exec Command="dotnet $(SolutionDir)src\Neo.Compiler.MSIL\bin\$(ConfigurationName)\netcoreapp3.1\neon.dll -f &quot;$(TargetPath)&quot; -o" />
+    <Exec Command="neon -f &quot;$(TargetPath)&quot; -o" />
   </Target>
 
 </Project>

--- a/templates/Template.VB/ProjectTemplate.vbproj
+++ b/templates/Template.VB/ProjectTemplate.vbproj
@@ -12,7 +12,7 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Message Text="Start NeoContract converter, Source File: $(TargetPath)" Importance="high">
     </Message>
-    <Exec Command="dotnet $(SolutionDir)src\Neo.Compiler.MSIL\bin\$(ConfigurationName)\netcoreapp3.1\neon.dll -f &quot;$(TargetPath)&quot; -o" />
+    <Exec Command="neon -f &quot;$(TargetPath)&quot; -o" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Some change in d492ed0 are incorrect. Because `Template.CSharp` and `Template.VB` are project templates. There is no `Neo.Compiler.MSIL` in the same solution.