### PR TITLE
Add Neo.SmartContract.Framework.List<T>

### DIFF
--- a/src/Neo.Compiler.MSIL/FuncExport.cs
+++ b/src/Neo.Compiler.MSIL/FuncExport.cs
@@ -2,9 +2,9 @@ using Mono.Cecil;
 using Neo.IO.Json;
 using Neo.SmartContract.Framework;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using SCG = System.Collections.Generic;
 
 namespace Neo.Compiler
 {
@@ -74,7 +74,7 @@ namespace Neo.Compiler
             return sb.ToString();
         }
 
-        public static JObject Export(NeoModule module, byte[] script, SCG.Dictionary<int, int> addrConvTable)
+        public static JObject Export(NeoModule module, byte[] script, Dictionary<int, int> addrConvTable)
         {
             var outjson = new JObject();
 
@@ -85,7 +85,7 @@ namespace Neo.Compiler
             var methods = new JArray();
             outjson["methods"] = methods;
 
-            SCG.HashSet<string> names = new SCG.HashSet<string>();
+            HashSet<string> names = new HashSet<string>();
             foreach (var function in module.mapMethods)
             {
                 var mm = function.Value;
@@ -176,7 +176,7 @@ namespace Neo.Compiler
             return extra;
         }
 
-        private static string BuildExtraAttributes(SCG.List<Mono.Collections.Generic.Collection<CustomAttributeArgument>> extraAttributes)
+        private static string BuildExtraAttributes(ICollection<Mono.Collections.Generic.Collection<CustomAttributeArgument>> extraAttributes)
         {
             if (extraAttributes == null || extraAttributes.Count == 0)
             {
@@ -210,7 +210,7 @@ namespace Neo.Compiler
                 .Select(u => (ContractFeatures)u.ConstructorArguments.FirstOrDefault().Value)
                 .FirstOrDefault();
 
-            var extraAttributes = module == null ? new SCG.List<Mono.Collections.Generic.Collection<CustomAttributeArgument>>() : module.attributes.Where(u => u.AttributeType.FullName == "Neo.SmartContract.Framework.ManifestExtraAttribute").Select(attribute => attribute.ConstructorArguments).ToList();
+            var extraAttributes = module == null ? Array.Empty<Mono.Collections.Generic.Collection<CustomAttributeArgument>>() : module.attributes.Where(u => u.AttributeType.FullName == "Neo.SmartContract.Framework.ManifestExtraAttribute").Select(attribute => attribute.ConstructorArguments).ToArray();
             var supportedStandardsAttribute = module?.attributes.Where(u => u.AttributeType.FullName == "Neo.SmartContract.Framework.SupportedStandardsAttribute").Select(attribute => attribute.ConstructorArguments).FirstOrDefault();
 
             var extra = BuildExtraAttributes(extraAttributes);

--- a/src/Neo.Compiler.MSIL/FuncExport.cs
+++ b/src/Neo.Compiler.MSIL/FuncExport.cs
@@ -2,9 +2,9 @@ using Mono.Cecil;
 using Neo.IO.Json;
 using Neo.SmartContract.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SCG = System.Collections.Generic;
 
 namespace Neo.Compiler
 {
@@ -74,7 +74,7 @@ namespace Neo.Compiler
             return sb.ToString();
         }
 
-        public static JObject Export(NeoModule module, byte[] script, Dictionary<int, int> addrConvTable)
+        public static JObject Export(NeoModule module, byte[] script, SCG.Dictionary<int, int> addrConvTable)
         {
             var outjson = new JObject();
 
@@ -85,7 +85,7 @@ namespace Neo.Compiler
             var methods = new JArray();
             outjson["methods"] = methods;
 
-            HashSet<string> names = new HashSet<string>();
+            SCG.HashSet<string> names = new SCG.HashSet<string>();
             foreach (var function in module.mapMethods)
             {
                 var mm = function.Value;
@@ -176,7 +176,7 @@ namespace Neo.Compiler
             return extra;
         }
 
-        private static string BuildExtraAttributes(List<Mono.Collections.Generic.Collection<CustomAttributeArgument>> extraAttributes)
+        private static string BuildExtraAttributes(SCG.List<Mono.Collections.Generic.Collection<CustomAttributeArgument>> extraAttributes)
         {
             if (extraAttributes == null || extraAttributes.Count == 0)
             {
@@ -210,7 +210,7 @@ namespace Neo.Compiler
                 .Select(u => (ContractFeatures)u.ConstructorArguments.FirstOrDefault().Value)
                 .FirstOrDefault();
 
-            var extraAttributes = module == null ? new List<Mono.Collections.Generic.Collection<CustomAttributeArgument>>() : module.attributes.Where(u => u.AttributeType.FullName == "Neo.SmartContract.Framework.ManifestExtraAttribute").Select(attribute => attribute.ConstructorArguments).ToList();
+            var extraAttributes = module == null ? new SCG.List<Mono.Collections.Generic.Collection<CustomAttributeArgument>>() : module.attributes.Where(u => u.AttributeType.FullName == "Neo.SmartContract.Framework.ManifestExtraAttribute").Select(attribute => attribute.ConstructorArguments).ToList();
             var supportedStandardsAttribute = module?.attributes.Where(u => u.AttributeType.FullName == "Neo.SmartContract.Framework.SupportedStandardsAttribute").Select(attribute => attribute.ConstructorArguments).FirstOrDefault();
 
             var extra = BuildExtraAttributes(extraAttributes);

--- a/src/Neo.SmartContract.Framework/List.cs
+++ b/src/Neo.SmartContract.Framework/List.cs
@@ -1,0 +1,37 @@
+namespace Neo.SmartContract.Framework
+{
+    public class List<T>
+    {
+        [OpCode(OpCode.NEWARRAY0)]
+        public extern List();
+
+        public extern int Count
+        {
+            [OpCode(OpCode.SIZE)]
+            get;
+        }
+
+        public extern T this[int key]
+        {
+            [OpCode(OpCode.PICKITEM)]
+            get;
+            [OpCode(OpCode.SETITEM)]
+            set;
+        }
+
+        [OpCode(OpCode.APPEND)]
+        public extern void Add(T item);
+
+        [OpCode(OpCode.REMOVE)]
+        public extern void RemoveAt(int index);
+
+        [OpCode(OpCode.CLEARITEMS)]
+        public extern void Clear();
+
+        public extern T[] Values
+        {
+            [OpCode(OpCode.VALUES)]
+            get;
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/List.cs
+++ b/src/Neo.SmartContract.Framework/List.cs
@@ -30,5 +30,11 @@ namespace Neo.SmartContract.Framework
 
         [OpCode(OpCode.VALUES)]
         public extern List<T> Clone();
+
+        [Script]
+        public static extern implicit operator List<T>(T[] array);
+
+        [Script]
+        public static extern implicit operator T[](List<T> array);
     }
 }

--- a/src/Neo.SmartContract.Framework/List.cs
+++ b/src/Neo.SmartContract.Framework/List.cs
@@ -28,10 +28,7 @@ namespace Neo.SmartContract.Framework
         [OpCode(OpCode.CLEARITEMS)]
         public extern void Clear();
 
-        public extern T[] Values
-        {
-            [OpCode(OpCode.VALUES)]
-            get;
-        }
+        [OpCode(OpCode.VALUES)]
+        public extern List<T> Clone();
     }
 }

--- a/src/Neo.SmartContract.Framework/Map.cs
+++ b/src/Neo.SmartContract.Framework/Map.cs
@@ -19,6 +19,9 @@ namespace Neo.SmartContract.Framework
             set;
         }
 
+        [OpCode(OpCode.CLEARITEMS)]
+        public extern void Clear();
+
         public extern TKey[] Keys
         {
             [OpCode(OpCode.KEYS)]

--- a/src/Neo.SmartContract.Framework/Map.cs
+++ b/src/Neo.SmartContract.Framework/Map.cs
@@ -5,6 +5,12 @@ namespace Neo.SmartContract.Framework
         [OpCode(OpCode.NEWMAP)]
         public extern Map();
 
+        public extern int Count
+        {
+            [OpCode(OpCode.SIZE)]
+            get;
+        }
+
         public extern TValue this[TKey key]
         {
             [OpCode(OpCode.PICKITEM)]

--- a/tests/Neo.SmartContract.Framework.UnitTests/ListTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ListTest.cs
@@ -88,6 +88,25 @@ namespace Neo.SmartContract.Framework.UnitTests
             Assert.AreEqual(0, jarray.Count);
         }
 
+        [TestMethod]
+        public void TestArrayConvert()
+        {
+            _engine.Reset();
+            StackItem count = 4;
+            var result = _engine.ExecuteTestCaseStandard("testArrayConvert", count);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+            var item = result.Pop();
+            Assert.IsTrue(item is Array);
+            var array = (Array)item;
+            Assert.AreEqual(4, array.Count);
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.IsTrue(array[i] is Integer);
+                Assert.AreEqual(i, array[i].GetInteger());
+            }
+        }
+
         static JObject ParseJson(StackItem item)
         {
             Assert.IsInstanceOfType(item, typeof(ByteString));

--- a/tests/Neo.SmartContract.Framework.UnitTests/ListTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ListTest.cs
@@ -1,0 +1,98 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.MSIL.UnitTests.Utils;
+using Neo.IO.Json;
+using Neo.VM;
+using Neo.VM.Types;
+
+namespace Neo.SmartContract.Framework.UnitTests
+{
+    [TestClass]
+    public class ListTest
+    {
+        private TestEngine _engine;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _engine = new TestEngine();
+            _engine.AddEntryScript("./TestClasses/Contract_List.cs");
+        }
+
+        [TestMethod]
+        public void TestCount()
+        {
+            _engine.Reset();
+            StackItem count = 4;
+            var result = _engine.ExecuteTestCaseStandard("testCount", count);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+            var item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Integer));
+            Assert.AreEqual(4, (item as Integer).GetInteger());
+        }
+
+        [TestMethod]
+        public void TestAdd()
+        {
+            _engine.Reset();
+            StackItem count = 4;
+            var result = _engine.ExecuteTestCaseStandard("testAdd", count);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+            var item = result.Pop();
+            var json = ParseJson(item);
+
+            Assert.IsTrue(json is JArray);
+            var jarray = (JArray)json;
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.IsTrue(jarray[i] is JNumber);
+                Assert.AreEqual(i, jarray[i].AsNumber());
+            }
+        }
+
+        [TestMethod]
+        public void TestRemoveAt()
+        {
+            _engine.Reset();
+            StackItem count = 5;
+            StackItem removeAt = 2;
+            var result = _engine.ExecuteTestCaseStandard("testRemoveAt", count, removeAt);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+            var item = result.Pop();
+            var json = ParseJson(item);
+
+            Assert.IsTrue(json is JArray);
+            var jarray = (JArray)json;
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.IsTrue(jarray[i] is JNumber);
+                Assert.AreEqual(i < 2 ? i : i + 1, jarray[i].AsNumber());
+            }
+        }
+
+        [TestMethod]
+        public void TestClear()
+        {
+            _engine.Reset();
+            StackItem count = 4;
+            var result = _engine.ExecuteTestCaseStandard("testClear", count);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+            var item = result.Pop();
+            var json = ParseJson(item);
+
+            Assert.IsTrue(json is JArray);
+            var jarray = (JArray)json;
+            Assert.AreEqual(0, jarray.Count);
+        }
+
+        static JObject ParseJson(StackItem item)
+        {
+            Assert.IsInstanceOfType(item, typeof(ByteString));
+            var json = System.Text.Encoding.UTF8.GetString(item.GetSpan());
+            return JObject.Parse(json);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
@@ -18,6 +18,19 @@ namespace Neo.SmartContract.Framework.UnitTests
         }
 
         [TestMethod]
+        public void TestCount()
+        {
+            _engine.Reset();
+            StackItem count = 4;
+            var result = _engine.ExecuteTestCaseStandard("testCount", count);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+            var item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Integer));
+            Assert.AreEqual(4, (item as Integer).GetInteger());
+        }
+
+        [TestMethod]
         public void TestByteArrayMap()
         {
             Assert.ThrowsException<System.Exception>(() => _engine.AddEntryScript("./TestClasses/Contract_MapException.cs"));

--- a/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
@@ -52,6 +52,22 @@ namespace Neo.SmartContract.Framework.UnitTests
         }
 
         [TestMethod]
+        public void TestClear()
+        {
+            _engine.Reset();
+            StackItem key = System.Text.Encoding.ASCII.GetBytes("a");
+            var result = _engine.ExecuteTestCaseStandard("testClear", key);
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+
+            var item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(ByteString));
+            // Except: {}
+            Assert.AreEqual("7b7d", (item as ByteString).GetSpan().ToHexString());
+        }
+
+
+        [TestMethod]
         public void TestByteArray2()
         {
             _engine.Reset();

--- a/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/RuntimeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/RuntimeTest.cs
@@ -9,8 +9,6 @@ using Neo.VM;
 using Neo.VM.Types;
 using System;
 using System.IO;
-using System.Text;
-using SCG = System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
 {
@@ -152,7 +150,7 @@ namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
         [TestMethod]
         public void Test_Log()
         {
-            var list = new SCG.List<LogEventArgs>();
+            var list = new System.Collections.Generic.List<LogEventArgs>();
             var method = new EventHandler<LogEventArgs>((s, e) => list.Add(e));
 
             ApplicationEngine.Log += method;

--- a/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/RuntimeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/RuntimeTest.cs
@@ -8,9 +8,9 @@ using Neo.SmartContract.Manifest;
 using Neo.VM;
 using Neo.VM.Types;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using SCG = System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
 {
@@ -152,7 +152,7 @@ namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
         [TestMethod]
         public void Test_Log()
         {
-            var list = new List<LogEventArgs>();
+            var list = new SCG.List<LogEventArgs>();
             var method = new EventHandler<LogEventArgs>((s, e) => list.Add(e));
 
             ApplicationEngine.Log += method;

--- a/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/StorageTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/StorageTest.cs
@@ -3,8 +3,8 @@ using Neo.Compiler.MSIL.UnitTests.Utils;
 using Neo.Ledger;
 using Neo.VM.Types;
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using SCG = System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
 {
@@ -51,7 +51,7 @@ namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
 
         private byte[] Concat(byte[] prefix, params byte[] key)
         {
-            var l = new List<byte>(prefix);
+            var l = new SCG.List<byte>(prefix);
             l.AddRange(key);
 
             return l.ToArray();

--- a/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/StorageTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Services/Neo/StorageTest.cs
@@ -4,7 +4,6 @@ using Neo.Ledger;
 using Neo.VM.Types;
 using System;
 using System.Linq;
-using SCG = System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
 {
@@ -49,12 +48,9 @@ namespace Neo.SmartContract.Framework.UnitTests.Services.Neo
             Assert.AreEqual(0, testengine.Snapshot.Storages.GetChangeSet().Count(a => a.Key.Key.SequenceEqual(Concat(prefix, key))));
         }
 
-        private byte[] Concat(byte[] prefix, params byte[] key)
+        private byte[] Concat(byte[] prefix, byte[] key)
         {
-            var l = new SCG.List<byte>(prefix);
-            l.AddRange(key);
-
-            return l.ToArray();
+            return global::Neo.Helper.Concat(prefix, key);
         }
 
         private TestEngine testengine;

--- a/tests/Neo.SmartContract.Framework.UnitTests/SyscallTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SyscallTest.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Mono.Cecil;
+using System.Collections.Generic;
 using System.IO;
-using SCG = System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.UnitTests
 {
@@ -13,7 +13,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Current syscalls
 
-            var list = new SCG.List<string>();
+            var list = new HashSet<string>();
 
             using (var stream = File.OpenRead(typeof(SmartContract).Assembly.Location))
             {
@@ -28,7 +28,7 @@ namespace Neo.SmartContract.Framework.UnitTests
 
             // Neo syscalls
 
-            var notFound = new SCG.List<string>();
+            var notFound = new System.Collections.Generic.List<string>();
 
             foreach (var syscall in ApplicationEngine.Services)
             {
@@ -55,7 +55,7 @@ namespace Neo.SmartContract.Framework.UnitTests
             }
         }
 
-        private void CheckType(TypeDefinition type, string expectedType, SCG.List<string> list)
+        private void CheckType(TypeDefinition type, string expectedType, HashSet<string> list)
         {
             foreach (var nested in type.NestedTypes)
             {
@@ -69,7 +69,7 @@ namespace Neo.SmartContract.Framework.UnitTests
                     if (attr.AttributeType.FullName == expectedType)
                     {
                         var syscall = attr.ConstructorArguments[0].Value.ToString();
-                        if (!list.Contains(syscall)) list.Add(syscall);
+                        list.Add(syscall);
                     }
                 }
             }

--- a/tests/Neo.SmartContract.Framework.UnitTests/SyscallTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SyscallTest.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Mono.Cecil;
-using System.Collections.Generic;
 using System.IO;
+using SCG = System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.UnitTests
 {
@@ -13,7 +13,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Current syscalls
 
-            var list = new List<string>();
+            var list = new SCG.List<string>();
 
             using (var stream = File.OpenRead(typeof(SmartContract).Assembly.Location))
             {
@@ -28,7 +28,7 @@ namespace Neo.SmartContract.Framework.UnitTests
 
             // Neo syscalls
 
-            var notFound = new List<string>();
+            var notFound = new SCG.List<string>();
 
             foreach (var syscall in ApplicationEngine.Services)
             {
@@ -55,7 +55,7 @@ namespace Neo.SmartContract.Framework.UnitTests
             }
         }
 
-        private void CheckType(TypeDefinition type, string expectedType, List<string> list)
+        private void CheckType(TypeDefinition type, string expectedType, SCG.List<string> list)
         {
             foreach (var nested in type.NestedTypes)
             {

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_List.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_List.cs
@@ -1,0 +1,55 @@
+using Neo.SmartContract.Framework.Services.Neo;
+
+namespace Neo.SmartContract.Framework.UnitTests.TestClasses
+{
+    public class Contract_List : SmartContract
+    {
+        public static int TestCount(int count)
+        {
+            List<int> some = new List<int>();
+            for (int i = 0; i < count; i++)
+            {
+                some.Add(i);
+            }
+
+            return some.Count;
+        }
+
+        public static string TestAdd(int count)
+        {
+            List<int> some = new List<int>();
+            for (int i = 0; i < count; i++)
+            {
+                some.Add(i);
+            }
+
+            return Json.Serialize(some);
+        }
+
+        public static string TestRemoveAt(int count, int removeAt)
+        {
+            if (removeAt >= count) throw new System.Exception("Invalid test parameters");
+
+            List<int> some = new List<int>();
+            for (int i = 0; i < count; i++)
+            {
+                some.Add(i);
+            }
+
+            some.RemoveAt(removeAt);
+            return Json.Serialize(some);
+        }
+
+        public static string TestClear(int count)
+        {
+            List<int> some = new List<int>();
+            for (int i = 0; i < count; i++)
+            {
+                some.Add(i);
+            }
+
+            some.Clear();
+            return Json.Serialize(some);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_List.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_List.cs
@@ -51,5 +51,16 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             some.Clear();
             return Json.Serialize(some);
         }
+
+        public static int[] TestArrayConvert(int count)
+        {
+            List<int> some = new List<int>();
+            for (int i = 0; i < count; i++)
+            {
+                some.Add(i);
+            }
+
+            return some;
+        }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
@@ -25,6 +25,14 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return Json.Serialize(some);
         }
 
+        public static object TestClear(byte[] key)
+        {
+            Map<string, string> some = new Map<string, string>();
+            some[key.ToByteString()] = "teststring2";
+            some.Clear();
+            return Json.Serialize(some);
+        }
+
         public static string TestByteArray2()
         {
             Map<string, string> some = new Map<string, string>();

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
@@ -7,6 +7,17 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
     public class Contract_Map : SmartContract
     {
+        public static int TestCount(int count)
+        {
+            Map<int, int> some = new Map<int, int>();
+            for (int i = 0; i < count; i++)
+            {
+                some[i] = i;
+            }
+
+            return some.Count;
+        }
+        
         public static object TestByteArray(byte[] key)
         {
             Map<string, string> some = new Map<string, string>();


### PR DESCRIPTION
fixes #358 

Note, I had to alias `System.Collections.Generic` to SCG in both NEON and the unit tests in order to avoid type name collisions between `System.Collections.Generic.List` and `Neo.SmartContract.Framework.List`