### PR TITLE
build dependency on Neo.Compiler.MSIL for Template.NEP5.CSharp

### DIFF
--- a/neo-devpack-dotnet.sln
+++ b/neo-devpack-dotnet.sln
@@ -23,6 +23,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D5266066-0AFD-44D5-A83E-2F73668A63C8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Template.NEP5.CSharp", "templates\Template.NEP5.CSharp\Template.NEP5.CSharp.csproj", "{ADD05222-DC45-4FDC-A41A-30A97BACC95F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{42C0FF0F-0A7C-4166-A773-1F944642C209} = {42C0FF0F-0A7C-4166-A773-1F944642C209}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Template.NEP5.UnitTests", "tests\Template.NEP5.UnitTests\Template.NEP5.UnitTests.csproj", "{780141EE-D6E9-4591-8470-8F91B12027CA}"
 EndProject


### PR DESCRIPTION
When running `dotnet build` from root of a clean repo, Template.NEP5.CSharp builds before Neo.Compiler.MSIL even though Template.NEP5.CSharp has a post build step that runs NEON. This PR adds a build dependency in the SLN file so that the build happens in the correct order