### PR TITLE
debug info hash property is needed

### DIFF
--- a/src/Neo.Compiler.MSIL/DebugExport.cs
+++ b/src/Neo.Compiler.MSIL/DebugExport.cs
@@ -117,17 +117,33 @@ namespace Neo.Compiler
             return outjson;
         }
 
-        public static JObject Export(NeoModule module, IReadOnlyDictionary<int, int> addrConvTable)
+        public static JObject Export(NeoModule module, byte[] script, IReadOnlyDictionary<int, int> addrConvTable)
         {
             var docMap = GetDocumentMap(module);
             addrConvTable ??= ImmutableDictionary<int, int>.Empty;
 
             var outjson = new JObject();
-            // outjson["entrypoint"]= module.mainMethod;
+            outjson["hash"] = ComputeHash(script);
             outjson["documents"] = GetDocuments(docMap);
             outjson["methods"] = GetMethods(module, docMap, addrConvTable);
             outjson["events"] = GetEvents(module);
             return outjson;
+        }
+
+        static string ComputeHash(byte[] script)
+        {
+            var sha256 = System.Security.Cryptography.SHA256.Create();
+            byte[] hash256 = sha256.ComputeHash(script);
+            var ripemd160 = new Neo.Cryptography.RIPEMD160Managed();
+            var hash = ripemd160.ComputeHash(hash256);
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("0x");
+            for (int i = hash.Length - 1; i >= 0; i--)
+            {
+                sb.Append(hash[i].ToString("x02"));
+            }
+            return sb.ToString();
         }
     }
 }

--- a/src/Neo.Compiler.MSIL/Program.cs
+++ b/src/Neo.Compiler.MSIL/Program.cs
@@ -191,7 +191,7 @@ namespace Neo.Compiler
 
                 try
                 {
-                    var outjson = DebugExport.Export(module, addrConvTable);
+                    var outjson = DebugExport.Export(module, bytes, addrConvTable);
                     debugstr = outjson.ToString(false);
                     log.Log("gen debug succ");
                 }

--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_DebugInfo.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest_DebugInfo.cs
@@ -14,6 +14,9 @@ namespace Neo.Compiler.MSIL
             var testengine = new TestEngine();
             testengine.AddEntryScript("./TestClasses/Contract_Event.cs");
             var debugInfo = testengine.ScriptEntry.debugInfo;
+            Assert.IsTrue(debugInfo.ContainsProperty("hash"));
+            Assert.IsInstanceOfType(debugInfo["hash"], typeof(JString));
+            Neo.UInt160.Parse(debugInfo["hash"].AsString());
             Assert.IsTrue(debugInfo.ContainsProperty("documents"));
             Assert.IsInstanceOfType(debugInfo["documents"], typeof(JArray));
             Assert.AreEqual((debugInfo["documents"] as JArray).Count, 1);

--- a/tests/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/Utils/BuildScript.cs
@@ -87,7 +87,7 @@ namespace Neo.Compiler.MSIL.UnitTests.Utils
 
             try
             {
-                debugInfo = DebugExport.Export(converterIL.outModule, addrConvTable);
+                debugInfo = DebugExport.Export(converterIL.outModule, finalNEFScript, addrConvTable);
             }
             catch (Exception err)
             {


### PR DESCRIPTION
I missed that #391 removed the script hash value from the debug info. Even though the script hash used for invocation is now generated at first deploy, we still need to actual script hash in the debug info to map the executing script to its associated debug info. This PR adds the hash property back to the debug info.