### PR TITLE
Add state check to UT

### DIFF
--- a/tests/Neo.Compiler.MSIL.UnitTests/UnitTest1.cs
+++ b/tests/Neo.Compiler.MSIL.UnitTests/UnitTest1.cs
@@ -86,6 +86,7 @@ namespace Neo.Compiler.MSIL.UnitTests
             var testengine = new TestEngine();
             testengine.AddEntryScript("./TestClasses/Contract1.cs");
             var result = testengine.ExecuteTestCaseStandard("testArgs3", 1, 2);
+            Assert.AreEqual(testengine.State, VM.VMState.HALT);
             Assert.AreEqual(0, result.Count);
         }
 
@@ -95,6 +96,7 @@ namespace Neo.Compiler.MSIL.UnitTests
             var testengine = new TestEngine();
             testengine.AddEntryScript("./TestClasses/Contract1.cs");
             var result = testengine.ExecuteTestCaseStandard("testArgs4", 1, 2).Pop();
+            Assert.AreEqual(testengine.State, VM.VMState.HALT);
             Assert.AreEqual(5, result.GetInteger());
         }
 


### PR DESCRIPTION
As the old UT can also PASS without state check, to identify the fix effect, add state check.