### PR TITLE
add try catch and map ut

### DIFF
--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_TryCatch.cs
@@ -7,7 +7,13 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
     public class Contract_shift : SmartContract.Framework.SmartContract
     {
         [InitialValue("0a0b0c0d0E0F", ContractParameterType.ByteArray)]
-        private static readonly ByteString rawECpoint = default;
+        private static readonly ByteString invalidECpoint = default;
+        [InitialValue("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", ContractParameterType.ByteArray)]
+        private static readonly ByteString byteString2Ecpoint = default;
+        [InitialValue("NXV7ZhHiyM1aHXwpVsRZC6BwNFP2jghXAq", ContractParameterType.Hash160)]
+        private static readonly ByteString validUInt160 = default;
+        [InitialValue("edcf8679104ec2911a4fe29ad7db232a493e5b990fb1da7af0c7b989948c8925", ContractParameterType.ByteArray)]
+        private static readonly byte[] validUInt256 = default;
         public static object try01()
         {
             int v = 0;
@@ -171,7 +177,102 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
             try
             {
                 v = 2;
-                ECPoint pubkey = (ECPoint)rawECpoint;
+                ECPoint pubkey = (ECPoint)invalidECpoint;
+            }
+            catch
+            {
+                v = 3;
+            }
+            finally
+            {
+                v++;
+            }
+            return v;
+        }
+
+        public static object tryvalidByteString2Ecpoint()
+        {
+            int v = 0;
+            try
+            {
+                v = 2;
+                ECPoint pubkey = (ECPoint)byteString2Ecpoint;
+            }
+            catch
+            {
+                v = 3;
+            }
+            finally
+            {
+                v++;
+            }
+            return v;
+        }
+
+        public static object tryinvalidByteArray2UInt160()
+        {
+            int v = 0;
+            try
+            {
+                v = 2;
+                UInt160 data = (UInt160)invalidECpoint;
+            }
+            catch
+            {
+                v = 3;
+            }
+            finally
+            {
+                v++;
+            }
+            return v;
+        }
+
+        public static object tryvalidByteArray2UInt160()
+        {
+            int v = 0;
+            try
+            {
+                v = 2;
+                UInt160 data = (UInt160)validUInt160;
+            }
+            catch
+            {
+                v = 3;
+            }
+            finally
+            {
+                v++;
+            }
+            return v;
+        }
+
+        public static object tryinvalidByteArray2UInt256()
+        {
+            int v = 0;
+            try
+            {
+                v = 2;
+                UInt256 data = (UInt256)invalidECpoint;
+            }
+            catch
+            {
+                v = 3;
+            }
+            finally
+            {
+                v++;
+            }
+            return v;
+        }
+
+        public static object tryvalidByteArray2UInt256()
+        {
+            int v = 0;
+            try
+            {
+                v = 2;
+                UInt256 data = (UInt256)validUInt256;
             }
             catch
             {

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_Types_ECPoint.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_Types_ECPoint.cs
@@ -25,6 +25,5 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
         {
             return (byte[])publicKey2Ecpoint;
         }
-
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_Types_ECPoint.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_Types_ECPoint.cs
@@ -1,9 +1,30 @@
 using Neo.Cryptography.ECC;
+using Neo.SmartContract;
+using Neo.SmartContract.Framework;
 
 namespace Neo.Compiler.CSharp.UnitTests.TestClasses
 {
     public class Contract_Types_ECPoint : SmartContract.Framework.SmartContract
     {
+        [InitialValue("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", ContractParameterType.PublicKey)]
+        private static readonly ECPoint publicKey2Ecpoint = default;
+
         public static bool isValid(ECPoint point) { return point.IsValid; }
+
+        public static string ecpoint2String()
+        {
+            return (ByteString)publicKey2Ecpoint;
+        }
+
+        public static ECPoint ecpointReturn()
+        {
+            return publicKey2Ecpoint;
+        }
+
+        public static object ecpoint2ByteArray()
+        {
+            return (byte[])publicKey2Ecpoint;
+        }
+
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
@@ -137,5 +137,75 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(num.GetInteger(), 4);
         }
 
+        [TestMethod]
+        public void Test_TryValidECPointCast()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_TryCatch.cs");
+            var result = testengine.ExecuteTestCaseStandard("tryvalidByteString2Ecpoint");
+            Console.WriteLine("state=" + testengine.State + "  result on stack= " + result.Count);
+            var value = result.Pop();
+            Console.WriteLine("result:" + value.Type + "  " + value.ToString());
+            var num = value as Neo.VM.Types.Integer;
+            Console.WriteLine("result = " + num.GetInteger().ToString());
+            Assert.AreEqual(num.GetInteger(), 3);
+        }
+
+        [TestMethod]
+        public void Test_TryInvalidUInt160Cast()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_TryCatch.cs");
+            var result = testengine.ExecuteTestCaseStandard("tryinvalidByteArray2UInt160");
+            Console.WriteLine("state=" + testengine.State + "  result on stack= " + result.Count);
+            var value = result.Pop();
+            Console.WriteLine("result:" + value.Type + "  " + value.ToString());
+            var num = value as Neo.VM.Types.Integer;
+            Console.WriteLine("result = " + num.GetInteger().ToString());
+            Assert.AreEqual(num.GetInteger(), 4);
+        }
+
+        [TestMethod]
+        public void Test_TryValidUInt160Cast()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_TryCatch.cs");
+            var result = testengine.ExecuteTestCaseStandard("tryvalidByteArray2UInt160");
+            Console.WriteLine("state=" + testengine.State + "  result on stack= " + result.Count);
+            var value = result.Pop();
+            Console.WriteLine("result:" + value.Type + "  " + value.ToString());
+            var num = value as Neo.VM.Types.Integer;
+            Console.WriteLine("result = " + num.GetInteger().ToString());
+            Assert.AreEqual(num.GetInteger(), 3);
+        }
+
+        [TestMethod]
+        public void Test_TryInvalidUInt256Cast()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_TryCatch.cs");
+            var result = testengine.ExecuteTestCaseStandard("tryinvalidByteArray2UInt256");
+            Console.WriteLine("state=" + testengine.State + "  result on stack= " + result.Count);
+            var value = result.Pop();
+            Console.WriteLine("result:" + value.Type + "  " + value.ToString());
+            var num = value as Neo.VM.Types.Integer;
+            Console.WriteLine("result = " + num.GetInteger().ToString());
+            Assert.AreEqual(num.GetInteger(), 4);
+        }
+
+        [TestMethod]
+        public void Test_TryValidUInt256Cast()
+        {
+            var testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_TryCatch.cs");
+            var result = testengine.ExecuteTestCaseStandard("tryvalidByteArray2UInt256");
+            Console.WriteLine("state=" + testengine.State + "  result on stack= " + result.Count);
+            var value = result.Pop();
+            Console.WriteLine("result:" + value.Type + "  " + value.ToString());
+            var num = value as Neo.VM.Types.Integer;
+            Console.WriteLine("result = " + num.GetInteger().ToString());
+            Assert.AreEqual(num.GetInteger(), 3);
+        }
+
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
@@ -206,6 +206,5 @@ namespace Neo.Compiler.CSharp.UnitTests
             Console.WriteLine("result = " + num.GetInteger().ToString());
             Assert.AreEqual(num.GetInteger(), 3);
         }
-
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types.cs
@@ -7,6 +7,7 @@ using Neo.VM.Types;
 using Neo.Wallets;
 using System.Linq;
 using System.Numerics;
+using Neo.Cryptography.ECC;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -524,6 +525,28 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(1, result.Count);
             item = result.Pop();
             Assert.IsTrue(item is Boolean b3 && !b3.GetBoolean());
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("ecpoint2String");
+            Assert.AreEqual(1, result.Count);
+            item = result.Pop();
+            Assert.IsTrue(item is ByteString s1);
+            Assert.AreEqual(item.GetSpan().ToHexString(), "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9");
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("ecpointReturn");
+            Assert.AreEqual(1, result.Count);
+            item = result.Pop();
+            Assert.IsTrue(item is ByteString s2);
+            Assert.AreEqual(item.GetSpan().ToHexString(), "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9");
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("ecpoint2ByteArray");
+            Assert.AreEqual(1, result.Count);
+            item = result.Pop();
+            Assert.IsTrue(item is Buffer bf1);
+            Assert.AreEqual(item.GetSpan().ToHexString(), "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9");
+
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types.cs
@@ -7,7 +7,6 @@ using Neo.VM.Types;
 using Neo.Wallets;
 using System.Linq;
 using System.Numerics;
-using Neo.Cryptography.ECC;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -546,7 +545,6 @@ namespace Neo.Compiler.CSharp.UnitTests
             item = result.Pop();
             Assert.IsTrue(item is Buffer bf1);
             Assert.AreEqual(item.GetSpan().ToHexString(), "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9");
-
         }
 
         [TestMethod]

--- a/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
@@ -156,5 +156,21 @@ namespace Neo.SmartContract.Framework.UnitTests
             Assert.IsTrue(map.ContainsKey("a"));
             Assert.AreEqual((VM.Types.ByteString)"testdeserialize", map["a"]);
         }
+
+        [TestMethod]
+        public void TestUInt160KeyDeserialize()
+        {
+            _engine.Reset();
+            var result = _engine.ExecuteTestCaseStandard("testuint160Key");
+            Assert.AreEqual(VMState.HALT, _engine.State);
+            Assert.AreEqual(1, result.Count);
+
+            var item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Map));
+            var map = item as Map;
+            Assert.AreEqual(1, map.Count);
+            Assert.IsTrue(map.ContainsKey("a"));
+            Assert.AreEqual((VM.Types.ByteString)"testdeserialize", map["a"]);
+        }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
@@ -169,8 +169,8 @@ namespace Neo.SmartContract.Framework.UnitTests
             Assert.IsInstanceOfType(item, typeof(Map));
             var map = item as Map;
             Assert.AreEqual(1, map.Count);
-            Assert.IsTrue(map.ContainsKey("a"));
-            Assert.AreEqual((VM.Types.ByteString)"testdeserialize", map["a"]);
+            Assert.IsTrue(map.ContainsKey(new byte[20]));
+            Assert.AreEqual(1, map[new byte[20]]);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Neo.SmartContract.Framework.Native;
-using Neo.SmartContract.Framework.Services;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
@@ -18,7 +14,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 
             return some.Count;
         }
-        
+
         public static object TestByteArray(byte[] key)
         {
             Map<string, string> some = new Map<string, string>();
@@ -91,7 +87,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             UInt160 key = UInt160.Zero;
             some[key] = 1;
             string serializestr = StdLib.JsonSerialize(some);
-            return StdLib.JsonDeserialize(sea);
+            return StdLib.JsonDeserialize(serializestr);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Map.cs
@@ -84,5 +84,14 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             string sea = StdLib.JsonSerialize(some);
             return StdLib.JsonDeserialize(sea);
         }
+
+        public static object testuint160Key()
+        {
+            Map<UInt160, int> some = new Map<UInt160, int>();
+            UInt160 key = UInt160.Zero;
+            some[key] = 1;
+            string serializestr = StdLib.JsonSerialize(some);
+            return StdLib.JsonDeserialize(sea);
+        }
     }
 }


### PR DESCRIPTION
also added a Map<> use UInt160 as key type, think we should add support for Map<UInt160, int>, because there is request for it, for example, vote contracts need to record vote for each account.