### PR TITLE
use binary value to assign the enum item

### DIFF
--- a/src/Neo.SmartContract.Framework/Services/TriggerType.cs
+++ b/src/Neo.SmartContract.Framework/Services/TriggerType.cs
@@ -5,22 +5,22 @@ namespace Neo.SmartContract.Framework.Services
         /// <summary>
         /// Indicate that the contract is triggered by the system to execute the OnPersist method of the native contracts.
         /// </summary>
-        OnPersist = 0x01,
+        OnPersist = 0b_0000_0001,
 
         /// <summary>
         /// Indicate that the contract is triggered by the system to execute the PostPersist method of the native contracts.
         /// </summary>
-        PostPersist = 0x02,
+        PostPersist = 0b_0000_0010,
 
         /// <summary>
         /// Indicates that the contract is triggered by the verification of a <see cref="IVerifiable"/>.
         /// </summary>
-        Verification = 0x20,
+        Verification = 0b_0010_0000,
 
         /// <summary>
         /// Indicates that the contract is triggered by the execution of transactions.
         /// </summary>
-        Application = 0x40,
+        Application = 0b_0100_0000,
 
         /// <summary>
         /// The combination of all system triggers.


### PR DESCRIPTION
As there have combination items in the TriggerType, it makes more sense to use binary value here.