### PR TITLE
Add System.Runtime.GetAddressVersion to Smart Contract Framework

### DIFF
--- a/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
+++ b/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <PackageReference Include="Neo" Version="3.1.0" />
+    <PackageReference Include="Neo" Version="3.2.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta3.22114.1" />
   </ItemGroup>

--- a/src/Neo.SmartContract.Framework/Services/Runtime.cs
+++ b/src/Neo.SmartContract.Framework/Services/Runtime.cs
@@ -69,6 +69,12 @@ namespace Neo.SmartContract.Framework.Services
             get;
         }
 
+        public static extern byte AddressVersion
+        {
+            [Syscall("System.Runtime.GetAddressVersion")]
+            get;
+        }
+
         /// <summary>
         /// This method gets current invocation notifications from specific 'scriptHash'
         /// 'scriptHash' must have 20 bytes, but if it's all zero 0000...0000 it refers to all existing notifications (like a * wildcard)

--- a/src/Neo.SmartContract.Framework/UInt160.cs
+++ b/src/Neo.SmartContract.Framework/UInt160.cs
@@ -62,5 +62,16 @@ namespace Neo
             data = Helper.Concat(data, this);
             return StdLib.Base58CheckEncode((ByteString)data);
         }
+
+        /// <summary>
+        /// Converts the specified script hash to an address, using the current blockchain AddressVersion value
+        /// </summary>
+        /// <returns>The converted address.</returns>
+        public string ToAddress()
+        {
+            byte[] data = { Neo.SmartContract.Framework.Services.Runtime.AddressVersion };
+            data = Helper.Concat(data, this);
+            return StdLib.Base58CheckEncode((ByteString)data);
+        }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/Services/RuntimeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Services/RuntimeTest.cs
@@ -162,6 +162,17 @@ namespace Neo.SmartContract.Framework.UnitTests.Services
         }
 
         [TestMethod]
+        public void Test_GetAddressVersion()
+        {
+            var result = _engine.ExecuteTestCaseStandard("getAddressVersion");
+            Assert.AreEqual(1, result.Count);
+
+            var item = result.Pop();
+            Assert.IsInstanceOfType(item, typeof(Integer));
+            Assert.AreEqual((BigInteger)ProtocolSettings.Default.AddressVersion, item.GetInteger());
+        }
+
+        [TestMethod]
         public void Test_GasLeft()
         {
             var result = _engine.ExecuteTestCaseStandard("getGasLeft");

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Runtime.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestClasses/Contract_Runtime.cs
@@ -35,6 +35,11 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return Runtime.GetNetwork();
         }
 
+        public static uint GetAddressVersion()
+        {
+            return Runtime.AddressVersion;
+        }
+
         public static byte GetTrigger()
         {
             return (byte)Runtime.Trigger;


### PR DESCRIPTION
Also adds UInt160.ToAddress overload that uses System.Runtime.GetAddressVersion
Fixes #725