### PR TITLE
set the default context as current context.

### DIFF
--- a/src/Neo.SmartContract.Framework/Services/Storage.cs
+++ b/src/Neo.SmartContract.Framework/Services/Storage.cs
@@ -100,8 +100,8 @@ namespace Neo.SmartContract.Framework.Services
         public static extern Iterator Find(StorageContext context, byte[] prefix, FindOptions options = FindOptions.None);
 
 #pragma Interface with default Context
-        public static ByteString Get(ByteString key) => Get(CurrentContext, key);
-        public static ByteString Get(byte[] key) => Get(CurrentContext, key);
+        public static ByteString Get(ByteString key) => Get(CurrentReadOnlyContext, key);
+        public static ByteString Get(byte[] key) => Get(CurrentReadOnlyContext, key);
         public static void Put(ByteString key, ByteString value) => Put(CurrentContext, key, value);
         public static void Put(byte[] key, ByteString value) => Put(CurrentContext, key, value);
         public static void Put(byte[] key, byte[] value) => Put(CurrentContext, key, value);
@@ -109,7 +109,7 @@ namespace Neo.SmartContract.Framework.Services
         public static void Put(byte[] key, BigInteger value) => Put(CurrentContext, key, value);
         public static void Delete(ByteString key) => Delete(CurrentContext, key);
         public static void Delete(byte[] key) => Delete(CurrentContext, key);
-        public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None) => Find(CurrentContext, prefix, options);
-        public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None) => Find(CurrentContext, prefix, options);
+        public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None) => Find(CurrentReadOnlyContext, prefix, options);
+        public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None) => Find(CurrentReadOnlyContext, prefix, options);
     }
 }

--- a/src/Neo.SmartContract.Framework/Services/Storage.cs
+++ b/src/Neo.SmartContract.Framework/Services/Storage.cs
@@ -100,16 +100,16 @@ namespace Neo.SmartContract.Framework.Services
         public static extern Iterator Find(StorageContext context, byte[] prefix, FindOptions options = FindOptions.None);
 
 #pragma Interface with default Context
-        public static ByteString Get(ByteString key)=> Get(CurrentContext, key);
-        public static ByteString Get(byte[] key)=> Get(CurrentContext, key);
-        public static void Put(ByteString key, ByteString value)=> Put(CurrentContext, key, value);
-        public static void Put(byte[] key, ByteString value)=> Put(CurrentContext, key, value);
-        public static void Put(byte[] key, byte[] value)=> Put(CurrentContext, key, value);
-        public static void Put(ByteString key, BigInteger value)=> Put(CurrentContext, key, value);
-        public static void Put(byte[] key, BigInteger value)=> Put(CurrentContext, key, value);
-        public static void Delete(ByteString key)=> Delete(CurrentContext, key);
-        public static void Delete(byte[] key)=> Delete(CurrentContext, key);
-        public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None)=> Find(CurrentContext, prefix, options);
-        public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None)=> Find(CurrentContext, prefix, options);
+        public static ByteString Get(ByteString key) => Get(CurrentContext, key);
+        public static ByteString Get(byte[] key) => Get(CurrentContext, key);
+        public static void Put(ByteString key, ByteString value) => Put(CurrentContext, key, value);
+        public static void Put(byte[] key, ByteString value) => Put(CurrentContext, key, value);
+        public static void Put(byte[] key, byte[] value) => Put(CurrentContext, key, value);
+        public static void Put(ByteString key, BigInteger value) => Put(CurrentContext, key, value);
+        public static void Put(byte[] key, BigInteger value) => Put(CurrentContext, key, value);
+        public static void Delete(ByteString key) => Delete(CurrentContext, key);
+        public static void Delete(byte[] key) => Delete(CurrentContext, key);
+        public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None) => Find(CurrentContext, prefix, options);
+        public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None) => Find(CurrentContext, prefix, options);
     }
 }

--- a/src/Neo.SmartContract.Framework/Services/Storage.cs
+++ b/src/Neo.SmartContract.Framework/Services/Storage.cs
@@ -99,7 +99,7 @@ namespace Neo.SmartContract.Framework.Services
         [Syscall("System.Storage.Find")]
         public static extern Iterator Find(StorageContext context, byte[] prefix, FindOptions options = FindOptions.None);
 
-#pragma Interface with default Context
+#region Interface with default Context
         public static ByteString Get(ByteString key) => Get(CurrentReadOnlyContext, key);
         public static ByteString Get(byte[] key) => Get(CurrentReadOnlyContext, key);
         public static void Put(ByteString key, ByteString value) => Put(CurrentContext, key, value);
@@ -111,5 +111,6 @@ namespace Neo.SmartContract.Framework.Services
         public static void Delete(byte[] key) => Delete(CurrentContext, key);
         public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None) => Find(CurrentReadOnlyContext, prefix, options);
         public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None) => Find(CurrentReadOnlyContext, prefix, options);
+#endregion
     }
 }

--- a/src/Neo.SmartContract.Framework/Services/Storage.cs
+++ b/src/Neo.SmartContract.Framework/Services/Storage.cs
@@ -99,7 +99,7 @@ namespace Neo.SmartContract.Framework.Services
         [Syscall("System.Storage.Find")]
         public static extern Iterator Find(StorageContext context, byte[] prefix, FindOptions options = FindOptions.None);
 
-#region Interface with default Context
+        #region Interface with default Context
         public static ByteString Get(ByteString key) => Get(CurrentReadOnlyContext, key);
         public static ByteString Get(byte[] key) => Get(CurrentReadOnlyContext, key);
         public static void Put(ByteString key, ByteString value) => Put(CurrentContext, key, value);
@@ -111,6 +111,6 @@ namespace Neo.SmartContract.Framework.Services
         public static void Delete(byte[] key) => Delete(CurrentContext, key);
         public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None) => Find(CurrentReadOnlyContext, prefix, options);
         public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None) => Find(CurrentReadOnlyContext, prefix, options);
-#endregion
+        #endregion
     }
 }

--- a/src/Neo.SmartContract.Framework/Services/Storage.cs
+++ b/src/Neo.SmartContract.Framework/Services/Storage.cs
@@ -98,5 +98,18 @@ namespace Neo.SmartContract.Framework.Services
         /// </summary>
         [Syscall("System.Storage.Find")]
         public static extern Iterator Find(StorageContext context, byte[] prefix, FindOptions options = FindOptions.None);
+
+#pragma Interface with default Context
+        public static ByteString Get(ByteString key)=> Get(CurrentContext, key);
+        public static ByteString Get(byte[] key)=> Get(CurrentContext, key);
+        public static void Put(ByteString key, ByteString value)=> Put(CurrentContext, key, value);
+        public static void Put(byte[] key, ByteString value)=> Put(CurrentContext, key, value);
+        public static void Put(byte[] key, byte[] value)=> Put(CurrentContext, key, value);
+        public static void Put(ByteString key, BigInteger value)=> Put(CurrentContext, key, value);
+        public static void Put(byte[] key, BigInteger value)=> Put(CurrentContext, key, value);
+        public static void Delete(ByteString key)=> Delete(CurrentContext, key);
+        public static void Delete(byte[] key)=> Delete(CurrentContext, key);
+        public static Iterator Find(ByteString prefix, FindOptions options = FindOptions.None)=> Find(CurrentContext, prefix, options);
+        public static Iterator Find(byte[] prefix, FindOptions options = FindOptions.None)=> Find(CurrentContext, prefix, options);
     }
 }


### PR DESCRIPTION
Turns out Storage does not need specifically set the context.