### PR TITLE
catch the Unauthorized  Access exception

### DIFF
--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -54,7 +54,7 @@ namespace Neo.Compiler
                         command.Invoke("--help");
                     }
                 }
-                catch (Exception)
+                catch (UnauthorizedAccessException)
                 {
                     Console.Error.WriteLine("Unauthorized to access the project directory, or no project is specified. Please ensure you have the proper permissions and a project is specified.");
                 }

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -44,12 +44,21 @@ namespace Neo.Compiler
         {
             if (paths is null || paths.Length == 0)
             {
-                context.ExitCode = ProcessDirectory(options, Environment.CurrentDirectory);
-                if (context.ExitCode == 2)
+                // catch Unhandled exception: System.Reflection.TargetInvocationException
+                try
                 {
-                    // Display help without args
-                    command.Invoke("--help");
+                    context.ExitCode = ProcessDirectory(options, Environment.CurrentDirectory);
+                    if (context.ExitCode == 2)
+                    {
+                        // Display help without args
+                        command.Invoke("--help");
+                    }
                 }
+                catch (Exception)
+                {
+                    Console.Error.WriteLine("Unauthorized to access the project directory, or no project is specified. Please ensure you have the proper permissions and a project is specified.");
+                }
+
                 return;
             }
             paths = paths.Select(p => Path.GetFullPath(p)).ToArray();


### PR DESCRIPTION
```C#
C:\Users\liaoj>nccs
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.UnauthorizedAccessException: Access to the path 'C:\Users\liaoj\Application Data' is denied.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateRelativeDirectoryHandle(ReadOnlySpan`1 relativePath, String fullPath)
   at System.IO.Enumeration.FileSystemEnumerator`1.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
   at Neo.Compiler.Program.ProcessDirectory(Options options, String path) in C:\Users\liaoj\git\neo-devpack-dotnet\src\Neo.Compiler.CSharp\Program.cs:line 103
   at Neo.Compiler.Program.Handle(RootCommand command, Options options, String[] paths, InvocationContext context) in C:\Users\liaoj\git\neo-devpack-dotnet\src\Neo.Compiler.CSharp\Program.cs:line 50
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.CommandLine.NamingConventionBinder.ModelBindingCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.NamingConventionBinder.ModelBindingCommandHandler.Invoke(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass12_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass19_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__18_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__5_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass8_0.<<UseExceptionHandler>b__0>d.MoveNext()
```