### PR TITLE
Add comments to Compiler

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -35,40 +35,40 @@ namespace Neo.Compiler
 {
     public class CompilationContext
     {
-        private static readonly MetadataReference[] commonReferences;
-        private static readonly Dictionary<string, MetadataReference> metaReferences = new();
-        private readonly Compilation compilation;
-        private string? displayName, className;
-        private bool scTypeFound;
-        private readonly List<Diagnostic> diagnostics = new();
-        private readonly HashSet<string> supportedStandards = new();
-        private readonly List<AbiMethod> methodsExported = new();
-        private readonly List<AbiEvent> eventsExported = new();
-        private readonly PermissionBuilder permissions = new();
-        private readonly HashSet<string> trusts = new();
-        private readonly JObject manifestExtra = new();
-        private readonly MethodConvertCollection methodsConverted = new();
-        private readonly MethodConvertCollection methodsForward = new();
-        private readonly List<MethodToken> methodTokens = new();
-        private readonly Dictionary<IFieldSymbol, byte> staticFields = new(SymbolEqualityComparer.Default);
-        private readonly List<byte> anonymousStaticFields = new();
-        private readonly Dictionary<ITypeSymbol, byte> vtables = new(SymbolEqualityComparer.Default);
-        private byte[]? script;
+        private static readonly MetadataReference[] CommonReferences;
+        private static readonly Dictionary<string, MetadataReference> MetaReferences = new();
+        private readonly Compilation _compilation;
+        private string? _displayName, _className;
+        private bool _scTypeFound;
+        private readonly List<Diagnostic> _diagnostics = new();
+        private readonly HashSet<string> _supportedStandards = new();
+        private readonly List<AbiMethod> _methodsExported = new();
+        private readonly List<AbiEvent> _eventsExported = new();
+        private readonly PermissionBuilder _permissions = new();
+        private readonly HashSet<string> _trusts = new();
+        private readonly JObject _manifestExtra = new();
+        private readonly MethodConvertCollection _methodsConverted = new();
+        private readonly MethodConvertCollection _methodsForward = new();
+        private readonly List<MethodToken> _methodTokens = new();
+        private readonly Dictionary<IFieldSymbol, byte> _staticFields = new(SymbolEqualityComparer.Default);
+        private readonly List<byte> _anonymousStaticFields = new();
+        private readonly Dictionary<ITypeSymbol, byte> _vtables = new(SymbolEqualityComparer.Default);
+        private byte[]? _script;
 
-        public bool Success => diagnostics.All(p => p.Severity != DiagnosticSeverity.Error);
-        public IReadOnlyList<Diagnostic> Diagnostics => diagnostics;
-        public string? ContractName => displayName ?? Options.BaseName ?? className;
+        public bool Success => _diagnostics.All(p => p.Severity != DiagnosticSeverity.Error);
+        public IReadOnlyList<Diagnostic> Diagnostics => _diagnostics;
+        public string? ContractName => _displayName ?? Options.BaseName ?? _className;
         private string? Source { get; set; }
         internal Options Options { get; private set; }
-        internal IEnumerable<IFieldSymbol> StaticFieldSymbols => staticFields.OrderBy(p => p.Value).Select(p => p.Key);
-        internal IEnumerable<(byte, ITypeSymbol)> VTables => vtables.OrderBy(p => p.Value).Select(p => (p.Value, p.Key));
-        internal int StaticFieldCount => staticFields.Count + anonymousStaticFields.Count + vtables.Count;
-        private byte[] Script => script ??= GetInstructions().Select(p => p.ToArray()).SelectMany(p => p).ToArray();
+        internal IEnumerable<IFieldSymbol> StaticFieldSymbols => _staticFields.OrderBy(p => p.Value).Select(p => p.Key);
+        internal IEnumerable<(byte, ITypeSymbol)> VTables => _vtables.OrderBy(p => p.Value).Select(p => (p.Value, p.Key));
+        internal int StaticFieldCount => _staticFields.Count + _anonymousStaticFields.Count + _vtables.Count;
+        private byte[] Script => _script ??= GetInstructions().Select(p => p.ToArray()).SelectMany(p => p).ToArray();
 
         static CompilationContext()
         {
             string coreDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-            commonReferences = new[]
+            CommonReferences = new[]
             {
                 MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.dll")),
                 MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.InteropServices.dll")),
@@ -80,31 +80,31 @@ namespace Neo.Compiler
 
         private CompilationContext(Compilation compilation, Options options)
         {
-            this.compilation = compilation;
+            this._compilation = compilation;
             this.Options = options;
         }
 
         private void RemoveEmptyInitialize()
         {
-            int index = methodsExported.FindIndex(p => p.Name == "_initialize");
+            int index = _methodsExported.FindIndex(p => p.Name == "_initialize");
             if (index < 0) return;
-            AbiMethod method = methodsExported[index];
-            if (methodsConverted[method.Symbol].Instructions.Count <= 1)
+            AbiMethod method = _methodsExported[index];
+            if (_methodsConverted[method.Symbol].Instructions.Count <= 1)
             {
-                methodsExported.RemoveAt(index);
-                methodsConverted.Remove(method.Symbol);
+                _methodsExported.RemoveAt(index);
+                _methodsConverted.Remove(method.Symbol);
             }
         }
 
         private IEnumerable<Instruction> GetInstructions()
         {
-            return methodsConverted.SelectMany(p => p.Instructions).Concat(methodsForward.SelectMany(p => p.Instructions));
+            return _methodsConverted.SelectMany(p => p.Instructions).Concat(_methodsForward.SelectMany(p => p.Instructions));
         }
 
         private int GetAbiOffset(IMethodSymbol method)
         {
-            if (!methodsForward.TryGetValue(method, out MethodConvert? convert))
-                convert = methodsConverted[method];
+            if (!_methodsForward.TryGetValue(method, out MethodConvert? convert))
+                convert = _methodsConverted[method];
             return convert.Instructions[0].Offset;
         }
 
@@ -119,10 +119,10 @@ namespace Neo.Compiler
         private void Compile()
         {
             HashSet<INamedTypeSymbol> processed = new(SymbolEqualityComparer.Default);
-            foreach (SyntaxTree tree in compilation.SyntaxTrees)
+            foreach (SyntaxTree tree in _compilation.SyntaxTrees)
             {
-                SemanticModel model = compilation.GetSemanticModel(tree);
-                diagnostics.AddRange(model.GetDiagnostics());
+                SemanticModel model = _compilation.GetSemanticModel(tree);
+                _diagnostics.AddRange(model.GetDiagnostics());
                 if (!Success) continue;
                 try
                 {
@@ -130,14 +130,14 @@ namespace Neo.Compiler
                 }
                 catch (CompilationException ex)
                 {
-                    diagnostics.Add(ex.Diagnostic);
+                    _diagnostics.Add(ex.Diagnostic);
                 }
             }
             if (Success)
             {
-                if (!scTypeFound)
+                if (!_scTypeFound)
                 {
-                    diagnostics.Add(Diagnostic.Create(DiagnosticId.NoEntryPoint, DiagnosticCategory.Default, "No SmartContract is found in the sources.", DiagnosticSeverity.Error, DiagnosticSeverity.Error, true, 0));
+                    _diagnostics.Add(Diagnostic.Create(DiagnosticId.NoEntryPoint, DiagnosticCategory.Default, "No SmartContract is found in the sources.", DiagnosticSeverity.Error, DiagnosticSeverity.Error, true, 0));
                     return;
                 }
                 RemoveEmptyInitialize();
@@ -151,7 +151,7 @@ namespace Neo.Compiler
         internal static CompilationContext Compile(IEnumerable<string> sourceFiles, IEnumerable<MetadataReference> references, Options options)
         {
             IEnumerable<SyntaxTree> syntaxTrees = sourceFiles.OrderBy(p => p).Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), options: options.GetParseOptions(), path: p));
-            if (IsSingleAbstractClass(syntaxTrees)) throw new FormatException("The given class is abstract, no valid neo SmartContract found.");
+            if (IsSingleAbstractClass(syntaxTrees)) throw new CompilationException(DiagnosticId.NoEntryPoint, "The given class is abstract, no valid neo SmartContract found.");
             CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, deterministic: true, nullableContextOptions: options.Nullable);
             CSharpCompilation compilation = CSharpCompilation.Create(null, syntaxTrees, references, compilationOptions);
             CompilationContext context = new(compilation, options);
@@ -161,7 +161,7 @@ namespace Neo.Compiler
 
         public static CompilationContext CompileSources(string[] sourceFiles, Options options)
         {
-            List<MetadataReference> references = new(commonReferences);
+            List<MetadataReference> references = new(CommonReferences);
             references.Add(MetadataReference.CreateFromFile(typeof(scfx.Neo.SmartContract.Framework.SmartContract).Assembly.Location));
             return Compile(sourceFiles, references, options);
         }
@@ -173,7 +173,7 @@ namespace Neo.Compiler
             HashSet<string> sourceFiles = Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories)
                 .Where(p => !p.StartsWith(obj))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            List<MetadataReference> references = new(commonReferences);
+            List<MetadataReference> references = new(CommonReferences);
             CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, deterministic: true, nullableContextOptions: options.Nullable);
             XDocument document = XDocument.Load(csproj);
             sourceFiles.UnionWith(document.Root!.Elements("ItemGroup").Elements("Compile").Attributes("Include").Select(p => Path.GetFullPath(p.Value, folder)));
@@ -197,7 +197,7 @@ namespace Neo.Compiler
         private static MetadataReference? GetReference(string name, JObject package, JObject assets, string folder, Options options, CSharpCompilationOptions compilationOptions)
         {
             string assemblyName = Path.GetDirectoryName(name)!;
-            if (!metaReferences.TryGetValue(assemblyName, out var reference))
+            if (!MetaReferences.TryGetValue(assemblyName, out var reference))
             {
                 switch (assets["libraries"]![name]!["type"]!.GetString())
                 {
@@ -225,7 +225,7 @@ namespace Neo.Compiler
                         else
                         {
                             IEnumerable<SyntaxTree> st = files.OrderBy(p => p).Select(p => Path.Combine(packagesPath, namePath, p)).Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), path: p));
-                            CSharpCompilation cr = CSharpCompilation.Create(assemblyName, st, commonReferences, compilationOptions);
+                            CSharpCompilation cr = CSharpCompilation.Create(assemblyName, st, CommonReferences, compilationOptions);
                             reference = cr.ToMetadataReference();
                         }
                         break;
@@ -237,7 +237,7 @@ namespace Neo.Compiler
                     default:
                         throw new NotSupportedException();
                 }
-                metaReferences.Add(assemblyName, reference);
+                MetaReferences.Add(assemblyName, reference);
             }
             return reference;
         }
@@ -259,7 +259,7 @@ namespace Neo.Compiler
             {
                 Compiler = $"{titleAttribute.Title} {versionAttribute.InformationalVersion}",
                 Source = Source ?? string.Empty,
-                Tokens = methodTokens.ToArray(),
+                Tokens = _methodTokens.ToArray(),
                 Script = Script
             };
             nef.CheckSum = NefFile.ComputeChecksum(nef);
@@ -281,14 +281,14 @@ namespace Neo.Compiler
                 builder.AppendLine();
             }
             StringBuilder builder = new();
-            foreach (MethodConvert method in methodsConverted)
+            foreach (MethodConvert method in _methodsConverted)
             {
                 builder.Append("// ");
                 builder.AppendLine(method.Symbol.ToString());
                 builder.AppendLine();
                 WriteMethod(builder, method);
             }
-            foreach (MethodConvert method in methodsForward)
+            foreach (MethodConvert method in _methodsForward)
             {
                 builder.Append("// ");
                 builder.Append(method.Symbol.ToString());
@@ -306,10 +306,10 @@ namespace Neo.Compiler
                 ["name"] = ContractName,
                 ["groups"] = new JArray(),
                 ["features"] = new JObject(),
-                ["supportedstandards"] = supportedStandards.OrderBy(p => p).Select(p => (JString)p!).ToArray(),
+                ["supportedstandards"] = _supportedStandards.OrderBy(p => p).Select(p => (JString)p!).ToArray(),
                 ["abi"] = new JObject
                 {
-                    ["methods"] = methodsExported.Select(p => new JObject
+                    ["methods"] = _methodsExported.Select(p => new JObject
                     {
                         ["name"] = p.Name,
                         ["offset"] = GetAbiOffset(p.Symbol),
@@ -317,15 +317,15 @@ namespace Neo.Compiler
                         ["returntype"] = p.ReturnType,
                         ["parameters"] = p.Parameters.Select(p => p.ToJson()).ToArray()
                     }).ToArray(),
-                    ["events"] = eventsExported.Select(p => new JObject
+                    ["events"] = _eventsExported.Select(p => new JObject
                     {
                         ["name"] = p.Name,
                         ["parameters"] = p.Parameters.Select(p => p.ToJson()).ToArray()
                     }).ToArray()
                 },
-                ["permissions"] = permissions.ToJson(),
-                ["trusts"] = trusts.Contains("*") ? "*" : trusts.OrderBy(p => p.Length).ThenBy(p => p).Select(u => new JString(u)).ToArray(),
-                ["extra"] = manifestExtra
+                ["permissions"] = _permissions.ToJson(),
+                ["trusts"] = _trusts.Contains("*") ? "*" : _trusts.OrderBy(p => p.Length).ThenBy(p => p).Select(u => new JString(u)).ToArray(),
+                ["extra"] = _manifestExtra
             };
             // Ensure that is serializable
             return ContractManifest.Parse(json.ToString(false));
@@ -335,7 +335,7 @@ namespace Neo.Compiler
         {
             List<string> documents = new();
             List<JObject> methods = new();
-            foreach (var m in methodsConverted.Where(p => p.SyntaxNode is not null))
+            foreach (var m in _methodsConverted.Where(p => p.SyntaxNode is not null))
             {
                 List<JString> sequencePoints = new();
                 foreach (var ins in m.Instructions.Where(i => i.SourceLocation is not null))
@@ -380,9 +380,9 @@ namespace Neo.Compiler
                 ["hash"] = Script.ToScriptHash().ToString(),
                 ["documents"] = documents.Select(p => (JString)p!).ToArray(),
                 ["document-root"] = string.IsNullOrEmpty(folder) ? JToken.Null : folder,
-                ["static-variables"] = staticFields.OrderBy(p => p.Value).Select(p => ((JString)$"{p.Key.Name},{p.Key.Type.GetContractParameterType()},{p.Value}")!).ToArray(),
+                ["static-variables"] = _staticFields.OrderBy(p => p.Value).Select(p => ((JString)$"{p.Key.Name},{p.Key.Type.GetContractParameterType()},{p.Value}")!).ToArray(),
                 ["methods"] = methods.ToArray(),
-                ["events"] = eventsExported.Select(e => new JObject
+                ["events"] = _eventsExported.Select(e => new JObject
                 {
                     ["id"] = e.Name,
                     ["name"] = $"{e.Symbol.ContainingType},{e.Symbol.Name}",
@@ -422,36 +422,36 @@ namespace Neo.Compiler
             bool isSmartContract = isPublic && !isAbstract && isContractType;
             if (isSmartContract)
             {
-                if (scTypeFound) throw new CompilationException(DiagnosticId.MultiplyContracts, "Only one smart contract is allowed.");
-                scTypeFound = true;
+                if (_scTypeFound) throw new CompilationException(DiagnosticId.MultiplyContracts, "Only one smart contract is allowed.");
+                _scTypeFound = true;
                 foreach (var attribute in symbol.GetAttributesWithInherited())
                 {
                     switch (attribute.AttributeClass!.Name)
                     {
                         case nameof(DisplayNameAttribute):
-                            displayName = (string)attribute.ConstructorArguments[0].Value!;
+                            _displayName = (string)attribute.ConstructorArguments[0].Value!;
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ContractSourceCodeAttribute):
                             Source = (string)attribute.ConstructorArguments[0].Value!;
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ManifestExtraAttribute):
-                            manifestExtra[(string)attribute.ConstructorArguments[0].Value!] = (string)attribute.ConstructorArguments[1].Value!;
+                            _manifestExtra[(string)attribute.ConstructorArguments[0].Value!] = (string)attribute.ConstructorArguments[1].Value!;
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ContractPermissionAttribute):
-                            permissions.Add((string)attribute.ConstructorArguments[0].Value!, attribute.ConstructorArguments[1].Values.Select(p => (string)p.Value!).ToArray());
+                            _permissions.Add((string)attribute.ConstructorArguments[0].Value!, attribute.ConstructorArguments[1].Values.Select(p => (string)p.Value!).ToArray());
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ContractTrustAttribute):
                             string trust = (string)attribute.ConstructorArguments[0].Value!;
                             if (!ValidateContractTrust(trust))
                                 throw new ArgumentException($"The value {trust} is not a valid one for ContractTrust");
-                            trusts.Add(trust);
+                            _trusts.Add(trust);
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.SupportedStandardsAttribute):
-                            supportedStandards.UnionWith(attribute.ConstructorArguments[0].Values.Select(p => (string)p.Value!));
+                            _supportedStandards.UnionWith(attribute.ConstructorArguments[0].Values.Select(p => (string)p.Value!));
                             break;
                     }
                 }
-                className = symbol.Name;
+                _className = symbol.Name;
             }
             foreach (ISymbol member in symbol.GetAllMembers())
             {
@@ -481,9 +481,9 @@ namespace Neo.Compiler
             if (!type.DelegateInvokeMethod!.ReturnsVoid)
                 throw new CompilationException(symbol, DiagnosticId.EventReturns, $"Event return value is not supported.");
             AbiEvent ev = new(symbol);
-            if (eventsExported.Any(u => u.Name == ev.Name))
+            if (_eventsExported.Any(u => u.Name == ev.Name))
                 throw new CompilationException(symbol, DiagnosticId.EventNameConflict, $"Duplicate event name: {ev.Name}.");
-            eventsExported.Add(ev);
+            _eventsExported.Add(ev);
         }
 
         private void ProcessMethod(SemanticModel model, IMethodSymbol symbol, bool export)
@@ -504,25 +504,24 @@ namespace Neo.Compiler
             {
                 AbiMethod method = new(symbol);
                 // methods with the same name (case sensitive) and parameter count are considered the same methods
-                if (methodsExported.Any(u => u.Name == method.Name && u.Parameters.Length == method.Parameters.Length))
+                if (_methodsExported.Any(u => u.Name == method.Name && u.Parameters.Length == method.Parameters.Length))
                     throw new CompilationException(symbol, DiagnosticId.MethodNameConflict, $"Duplicate method key: {method.Name},{method.Parameters.Length}.");
-                methodsExported.Add(method);
+                _methodsExported.Add(method);
             }
             MethodConvert convert = ConvertMethod(model, symbol);
             if (export && !symbol.IsStatic)
             {
                 MethodConvert forward = new(this, symbol);
                 forward.ConvertForward(model, convert);
-                methodsForward.Add(forward);
+                _methodsForward.Add(forward);
             }
         }
 
         internal MethodConvert ConvertMethod(SemanticModel model, IMethodSymbol symbol)
         {
-            // only method that is not converted will be converted
-            if (methodsConverted.TryGetValue(symbol, out MethodConvert? method)) return method;
+            if (_methodsConverted.TryGetValue(symbol, out MethodConvert? method)) return method;
             method = new MethodConvert(this, symbol);
-            methodsConverted.Add(method);
+            _methodsConverted.Add(method);
             if (!symbol.DeclaringSyntaxReferences.IsEmpty)
             {
                 ISourceAssemblySymbol assembly = (ISourceAssemblySymbol)symbol.ContainingAssembly;
@@ -534,9 +533,9 @@ namespace Neo.Compiler
 
         internal ushort AddMethodToken(UInt160 hash, string method, ushort parametersCount, bool hasReturnValue, CallFlags callFlags)
         {
-            int index = methodTokens.FindIndex(p => p.Hash == hash && p.Method == method && p.ParametersCount == parametersCount && p.HasReturnValue == hasReturnValue && p.CallFlags == callFlags);
+            int index = _methodTokens.FindIndex(p => p.Hash == hash && p.Method == method && p.ParametersCount == parametersCount && p.HasReturnValue == hasReturnValue && p.CallFlags == callFlags);
             if (index >= 0) return (ushort)index;
-            methodTokens.Add(new MethodToken
+            _methodTokens.Add(new MethodToken
             {
                 Hash = hash,
                 Method = method,
@@ -544,16 +543,16 @@ namespace Neo.Compiler
                 HasReturnValue = hasReturnValue,
                 CallFlags = callFlags
             });
-            permissions.Add(hash.ToString(), method);
-            return (ushort)(methodTokens.Count - 1);
+            _permissions.Add(hash.ToString(), method);
+            return (ushort)(_methodTokens.Count - 1);
         }
 
         internal byte AddStaticField(IFieldSymbol symbol)
         {
-            if (!staticFields.TryGetValue(symbol, out byte index))
+            if (!_staticFields.TryGetValue(symbol, out byte index))
             {
                 index = (byte)StaticFieldCount;
-                staticFields.Add(symbol, index);
+                _staticFields.Add(symbol, index);
             }
             return index;
         }
@@ -561,16 +560,16 @@ namespace Neo.Compiler
         internal byte AddAnonymousStaticField()
         {
             byte index = (byte)StaticFieldCount;
-            anonymousStaticFields.Add(index);
+            _anonymousStaticFields.Add(index);
             return index;
         }
 
         internal byte AddVTable(ITypeSymbol type)
         {
-            if (!vtables.TryGetValue(type, out byte index))
+            if (!_vtables.TryGetValue(type, out byte index))
             {
                 index = (byte)StaticFieldCount;
-                vtables.Add(type, index);
+                _vtables.Add(type, index);
             }
             return index;
         }

--- a/src/Neo.Compiler.CSharp/DiagnosticId.cs
+++ b/src/Neo.Compiler.CSharp/DiagnosticId.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -12,26 +12,68 @@ namespace Neo.Compiler
 {
     static class DiagnosticId
     {
+        // No SmartContract is found in the sources.
         public const string NoEntryPoint = "NC1001";
+
+        // Use of external methods not supported or allowed in the smart contract.
         public const string ExternMethod = "NC1002";
+
+        // Smart contract class lacks a parameterless constructor, which might be required.
         public const string NoParameterlessConstructor = "NC1003";
+
+        // Improper or conflicting use of multiple contracts (interfaces, abstract classes) in the smart contract.
         public const string MultiplyContracts = "NC1004";
+
+        // Syntax in the smart contract code not supported by the compiler or the tool.
         public const string SyntaxNotSupported = "NC2001";
+
+        // Event handlers in the smart contract returning values, typically not allowed.
         public const string EventReturns = "NC2002";
+
+        // Using non-static delegates in the smart contract where static ones are required.
         public const string NonStaticDelegate = "NC2003";
+
+        // Using floating point numbers in the smart contract, unsupported or inappropriate in this context.
         public const string FloatingPointNumber = "NC2004";
+
+        // Multiple 'throw' statements in the smart contract, indicating complex or unclean exception handling.
         public const string MultiplyThrows = "NC2005";
+
+        // Multiple 'catch' blocks in the smart contract, suggesting overcomplicated error handling.
         public const string MultiplyCatches = "NC2006";
+
+        // Use of catch filters in the smart contract, potentially unsupported or not recommended.
         public const string CatchFilter = "NC2007";
+
+        // Using multidimensional arrays in the smart contract, potentially unsupported or not recommended.
         public const string MultidimensionalArray = "NC2008";
+
+        // Issues related to interface method calls in the smart contract, indicating incorrect or unsupported usage.
         public const string InterfaceCall = "NC2009";
+
+        // Problems with array ranges in the smart contract, such as out-of-bounds errors.
         public const string ArrayRange = "NC2010";
+
+        // Invalid usage of 'ToString' method or incorrect type handling in smart contract 'ToString' implementations.
         public const string InvalidToStringType = "NC2011";
+
+        // Alignment clauses in the smart contract indicating syntax errors or misuse.
         public const string AlignmentClause = "NC2012";
+
+        // Issues with format clauses in the smart contract, syntactically incorrect or misused.
         public const string FormatClause = "NC2013";
+
+        // Invalid initial value types in the smart contract, indicating type mismatches or inappropriate value assignments.
         public const string InvalidInitialValueType = "NC3001";
+
+        // Using invalid method names in the smart contract, conflicting with reserved names or naming conventions.
         public const string InvalidMethodName = "NC3002";
+
+        // Conflicts between method names in the smart contract, issues with overloading or naming.
         public const string MethodNameConflict = "NC3003";
+
+        // Conflicts in event names in the smart contract
         public const string EventNameConflict = "NC3004";
+
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -9,7 +9,6 @@
 // modifications are permitted.
 
 extern alias scfx;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -259,38 +258,75 @@ namespace Neo.Compiler
                 switch (Symbol.MethodKind)
                 {
                     case MethodKind.Constructor:
-                        ProcessFields(model);
-                        ProcessConstructorInitializer(model);
+                        // Example: public MyClass() { ... }
+                        ProcessFields(model);                 // Process fields
+                        ProcessConstructorInitializer(model); // Process constructor initializer
                         break;
                     case MethodKind.StaticConstructor:
-                        ProcessStaticFields(model);
+                        // Example: static MyClass() { ... }
+                        // Static constructors (also known as type constructors) in C#
+                        // are automatically called by the Common Language Runtime (CLR)
+                        // to initialize static class members and execute static constructor code.
+                        ProcessStaticFields(model); // Process static fields
                         break;
                     case MethodKind.AnonymousFunction:
+                    // Example: var result = delegate(int x) { return x * 2; };
+                    // Handle anonymous function
                     case MethodKind.Conversion:
+                    // Example: public static implicit operator MyType(string value) { ... }
+                    // Handle conversion operator
                     case MethodKind.DelegateInvoke:
+                    // Example: myDelegate(); // where myDelegate is a delegate instance
+                    // Handle delegate invocation
                     case MethodKind.Destructor:
+                    // Example: ~MyClass() { ... }
+                    // Handle destructor (finalizer)
                     case MethodKind.EventAdd:
+                    // Example: public event EventHandler MyEvent { add { ... } remove { ... } }
+                    // Handle event add method
                     case MethodKind.EventRaise:
+                    // Example: private void OnMyEvent(EventArgs e) { ... }
+                    // Handle event raise method
                     case MethodKind.EventRemove:
+                    // Example: public event EventHandler MyEvent { add { ... } remove { ... } }
+                    // Handle event remove method
                     case MethodKind.ExplicitInterfaceImplementation:
+                    // Example: void IMyInterface.MyMethod() { ... }
+                    // Handle explicit interface implementation
                     case MethodKind.UserDefinedOperator:
+                    // Example: public static MyType operator +(MyType left, MyType right) { ... }
+                    // Handle user-defined operator
                     case MethodKind.Ordinary:
+                    // Example: public void MyMethod() { ... }
+                    // Handle ordinary method
                     case MethodKind.PropertyGet:
+                    // Example: public int MyProperty { get { ... } }
+                    // Handle property getter method
                     case MethodKind.PropertySet:
+                    // Example: public int MyProperty { set { ... } }
+                    // Handle property setter method
                     case MethodKind.ReducedExtension:
+                    // Example: public static void MyExtensionMethod(this SomeType x) { ... }
+                    // Handle reduced extension method
                     case MethodKind.BuiltinOperator:
+                    // Example: public static bool operator ==(MyType left, MyType right) { ... }
+                    // Handle built-in operator
                     case MethodKind.DeclareMethod:
+                    // Handle declare method
                     case MethodKind.LocalFunction:
+                    // Example: void MyLocalFunction() { ... }
+                    // Handle local function
                     case MethodKind.FunctionPointerSignature:
+                    // Example: delegate*<int, int> ptr = &MyFunction;
+                    // Handle function pointer signature
                     default:
                         // Only internal core methods can start with an underscore
                         if (Symbol.Name.StartsWith("_") && !Symbol.IsInternalCoreMethod())
                             throw new CompilationException(Symbol, DiagnosticId.InvalidMethodName, $"The method name {Symbol.Name} is not valid.");
                         break;
                 }
-                // Common modifiers in C#:
-                // public, private, protected, internal, protected internal,
-                // static, readonly, const, virtual, override, abstract, sealed
+
+                // modifier of ModifierAttribute, specifically for neo contract
                 var modifiers = ConvertModifier(model).ToArray();
                 ConvertSourceCode(model);
                 if (Symbol.MethodKind == MethodKind.StaticConstructor && _context.StaticFieldCount > 0)
@@ -815,6 +851,7 @@ namespace Neo.Compiler
             // parameters and locals.
             _initSlot = !_inline;
         }
+
         #endregion
 
         #region ConvertStatement
@@ -3615,6 +3652,7 @@ namespace Neo.Compiler
         #endregion
 
         #region ConvertPattern
+
         /// <summary>
         /// Converts C# Pattern syntax to corresponding VM instructions.
         /// </summary>
@@ -4081,6 +4119,7 @@ namespace Neo.Compiler
             if (_tryStack.TryPeek(out ExceptionHandling? result))
                 result.BreakTargetCount--;
         }
+
         #endregion
 
         #region SlotHelpers
@@ -4097,6 +4136,7 @@ namespace Neo.Compiler
                 ? AddInstruction(new Instruction { OpCode = opcode, Operand = new[] { index } })
                 : AddInstruction(opcode - 7 + index);
         }
+
         #endregion
 
         /// <summary>
@@ -4437,7 +4477,8 @@ namespace Neo.Compiler
         /// <param name="callingConvention">Calling convention</param>
         private void PrepareArgumentsForMethod(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode> arguments, CallingConvention callingConvention = CallingConvention.Cdecl)
         {
-            var namedArguments = arguments.OfType<ArgumentSyntax>().Where(p => p.NameColon is not null).Select(p => (Symbol: (IParameterSymbol)model.GetSymbolInfo(p.NameColon!.Name).Symbol!, p.Expression)).ToDictionary(p => p.Symbol, p => p.Expression, (IEqualityComparer<IParameterSymbol>)SymbolEqualityComparer.Default);
+            var namedArguments = arguments.OfType<ArgumentSyntax>().Where(p => p.NameColon is not null).Select(p => (Symbol: (IParameterSymbol)model.GetSymbolInfo(p.NameColon!.Name).Symbol!, p.Expression))
+                .ToDictionary(p => p.Symbol, p => p.Expression, (IEqualityComparer<IParameterSymbol>)SymbolEqualityComparer.Default);
             IEnumerable<IParameterSymbol> parameters = symbol.Parameters;
             if (callingConvention == CallingConvention.Cdecl)
                 parameters = parameters.Reverse();
@@ -5042,6 +5083,7 @@ namespace Neo.Compiler
             AddInstruction(OpCode.PICKITEM);
             AddInstruction(OpCode.CALLA);
         }
+
         #endregion
     }
 

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -3373,36 +3373,73 @@ namespace Neo.Compiler
             }
         }
 
+        /// <summary>
+        /// Converts a prefix unary expression into a series of low-level instructions.
+        /// This method handles various unary operators like +, -, ~, !, ++, --, and ^.
+        /// </summary>
+        /// <param name="model">The semantic model used for conversion.</param>
+        /// <param name="expression">The prefix unary expression to be converted.</param>
         private void ConvertPrefixUnaryExpression(SemanticModel model, PrefixUnaryExpressionSyntax expression)
         {
             switch (expression.OperatorToken.ValueText)
             {
                 case "+":
+                    // Example: +x
+                    // If x = 5, '+x' simply refers to '5'.
+                    // Converts the operand x without additional instructions.
                     ConvertExpression(model, expression.Operand);
                     break;
+
                 case "-":
+                    // Example: -x
+                    // If x = 5, '-x' is '-5'.
+                    // Converts the operand x and adds a NEGATE instruction to negate the value.
                     ConvertExpression(model, expression.Operand);
                     AddInstruction(OpCode.NEGATE);
                     break;
+
                 case "~":
+                    // Example: ~x
+                    // If x = 5 (binary 0101), '~x' results in binary 1010 (decimal -6).
+                    // Converts the operand x and adds an INVERT instruction for bitwise negation.
                     ConvertExpression(model, expression.Operand);
                     AddInstruction(OpCode.INVERT);
                     break;
+
                 case "!":
+                    // Example: !x
+                    // If x = 5 (non-zero), '!x' results in 'false'.
+                    // Converts the operand x and adds a NOT instruction for logical negation.
                     ConvertExpression(model, expression.Operand);
                     AddInstruction(OpCode.NOT);
                     break;
+
                 case "++":
-                case "--":
+                    // Example: ++x
+                    // If x = 5, '++x' increments x to 6.
+                    // Handles the pre-increment operation of x.
                     ConvertPreIncrementOrDecrementExpression(model, expression);
                     break;
-                case "^":
-                    AddInstruction(OpCode.DUP);
-                    AddInstruction(OpCode.SIZE);
-                    ConvertExpression(model, expression.Operand);
-                    AddInstruction(OpCode.SUB);
+
+                case "--":
+                    // Example: --x
+                    // If x = 5, '--x' decrements x to 4.
+                    // Handles the pre-decrement operation of x.
+                    ConvertPreIncrementOrDecrementExpression(model, expression);
                     break;
+
+                case "^":
+                    // Example: ^x
+                    // If x = 2 in a sequence of length 5, '^x' refers to the third element from the end.
+                    // The operations might involve duplicating the sequence length, converting the operand x, and then performing subtraction to calculate the index.
+                    AddInstruction(OpCode.DUP);     // Duplicate the sequence length
+                    AddInstruction(OpCode.SIZE);    // Get the size (context-dependent)
+                    ConvertExpression(model, expression.Operand); // Convert the operand x
+                    AddInstruction(OpCode.SUB);     // Perform subtraction to get the index
+                    break;
+
                 default:
+                    // Throws a compilation exception for unsupported operators.
                     throw new CompilationException(expression.OperatorToken, DiagnosticId.SyntaxNotSupported, $"Unsupported operator: {expression.OperatorToken}");
             }
         }

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -37,7 +37,7 @@ namespace Neo.Compiler
 
         #region Fields
 
-        // Stores context of the compilation, possibly including syntax trees and semantic models.
+        // Stores context of the compilation, including syntax trees and semantic models.
         private readonly CompilationContext _context;
 
         // Default calling convention for method invocations.
@@ -58,7 +58,7 @@ namespace Neo.Compiler
         // Maps local variable symbols to their indices, used for managing local variables within methods.
         private readonly Dictionary<ILocalSymbol, byte> _localVariables = new(SymbolEqualityComparer.Default);
 
-        // A list of anonymous variables, possibly used for temporary or intermediate values during conversion.
+        // A list of anonymous variables, used for temporary or intermediate values during conversion.
         private readonly List<byte> _anonymousVariables = new();
 
         // Counter for the number of local variables.

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -3273,7 +3273,27 @@ namespace Neo.Compiler
 
             if (indexOrRange is RangeExpressionSyntax range)
             {
-                // Special handling based on the type (e.g., byte array or string).
+                if (range.RightOperand is null)
+                {
+                    AddInstruction(OpCode.DUP);
+                    AddInstruction(OpCode.SIZE);
+                }
+                else
+                {
+                    ConvertExpression(model, range.RightOperand);
+                }
+                AddInstruction(OpCode.SWAP);
+                if (range.LeftOperand is null)
+                {
+                    Push(0);
+                }
+                else
+                {
+                    ConvertExpression(model, range.LeftOperand);
+                }
+                AddInstruction(OpCode.ROT);
+                AddInstruction(OpCode.OVER);
+                AddInstruction(OpCode.SUB);
                 switch (type.ToString())
                 {
                     case "byte[]":
@@ -3289,13 +3309,10 @@ namespace Neo.Compiler
             }
             else
             {
-                // Handle single index access.
-                // Example: array[index] or string[index]
                 ConvertExpression(model, indexOrRange);
                 AddInstruction(OpCode.PICKITEM);
             }
         }
-
 
         /// <summary>
         /// Converts an identifier name expression into a series of low-level instructions.

--- a/src/Neo.Compiler.CSharp/Options.cs
+++ b/src/Neo.Compiler.CSharp/Options.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -26,16 +26,16 @@ namespace Neo.Compiler
         public bool NoInline { get; set; }
         public byte AddressVersion { get; set; }
 
-        private CSharpParseOptions? parseOptions = null;
+        private CSharpParseOptions? _parseOptions = null;
         public CSharpParseOptions GetParseOptions()
         {
-            if (parseOptions is null)
+            if (_parseOptions is null)
             {
                 List<string> preprocessorSymbols = new();
                 if (Debug) preprocessorSymbols.Add("DEBUG");
-                parseOptions = new CSharpParseOptions(preprocessorSymbols: preprocessorSymbols);
+                _parseOptions = new CSharpParseOptions(preprocessorSymbols: preprocessorSymbols);
             }
-            return parseOptions;
+            return _parseOptions;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/PermissionBuilder.cs
+++ b/src/Neo.Compiler.CSharp/PermissionBuilder.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -16,10 +16,10 @@ namespace Neo.Compiler
 {
     class PermissionBuilder
     {
-        private readonly HashSet<(string Hash, string Method)> normalItems = new();
-        private readonly HashSet<string> wildcardHashes = new();
-        private readonly HashSet<string> wildcardMethods = new();
-        private bool isWildcard;
+        private readonly HashSet<(string Hash, string Method)> _normalItems = new();
+        private readonly HashSet<string> _wildcardHashes = new();
+        private readonly HashSet<string> _wildcardMethods = new();
+        private bool _isWildcard;
 
         public void Add(string hash, string[] methods)
         {
@@ -32,30 +32,30 @@ namespace Neo.Compiler
 
         public void Add(string hash, string method)
         {
-            if (isWildcard) return;
+            if (_isWildcard) return;
             if (hash == "*")
             {
                 if (method == "*")
                 {
-                    isWildcard = true;
+                    _isWildcard = true;
                 }
                 else
                 {
-                    if (wildcardMethods.Add(method))
-                        normalItems.RemoveWhere(p => p.Method == method);
+                    if (_wildcardMethods.Add(method))
+                        _normalItems.RemoveWhere(p => p.Method == method);
                 }
             }
             else
             {
                 if (method == "*")
                 {
-                    if (wildcardHashes.Add(hash))
-                        normalItems.RemoveWhere(p => p.Hash == hash);
+                    if (_wildcardHashes.Add(hash))
+                        _normalItems.RemoveWhere(p => p.Hash == hash);
                 }
                 else
                 {
-                    if (!wildcardHashes.Contains(hash) && !wildcardMethods.Contains(method))
-                        normalItems.Add((hash, method));
+                    if (!_wildcardHashes.Contains(hash) && !_wildcardMethods.Contains(method))
+                        _normalItems.Add((hash, method));
                 }
             }
         }
@@ -63,7 +63,7 @@ namespace Neo.Compiler
         public JArray ToJson()
         {
             JArray permissions = new();
-            if (isWildcard)
+            if (_isWildcard)
             {
                 permissions.Add(new JObject
                 {
@@ -73,23 +73,23 @@ namespace Neo.Compiler
             }
             else
             {
-                foreach (var group in normalItems.GroupBy(p => p.Hash, p => p.Method).OrderBy(p => p.Key))
+                foreach (var group in _normalItems.GroupBy(p => p.Hash, p => p.Method).OrderBy(p => p.Key))
                     permissions.Add(new JObject
                     {
                         ["contract"] = group.Key,
                         ["methods"] = new JArray(group.OrderBy(p => p).Select(p => (JString)p!))
                     });
-                foreach (string hash in wildcardHashes.OrderBy(p => p))
+                foreach (string hash in _wildcardHashes.OrderBy(p => p))
                     permissions.Add(new JObject
                     {
                         ["contract"] = hash,
                         ["methods"] = "*"
                     });
-                if (wildcardMethods.Count > 0)
+                if (_wildcardMethods.Count > 0)
                     permissions.Add(new JObject
                     {
                         ["contract"] = "*",
-                        ["methods"] = new JArray(wildcardMethods.OrderBy(p => p).Select(p => (JString)p!))
+                        ["methods"] = new JArray(_wildcardMethods.OrderBy(p => p).Select(p => (JString)p!))
                     });
             }
             return permissions;

--- a/src/Neo.Compiler.CSharp/SequencePointInserter.cs
+++ b/src/Neo.Compiler.CSharp/SequencePointInserter.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -16,20 +16,20 @@ namespace Neo.Compiler
 {
     class SequencePointInserter : IDisposable
     {
-        private readonly IReadOnlyList<Instruction> instructions;
-        private readonly SyntaxNodeOrToken syntax;
-        private readonly int position;
+        private readonly IReadOnlyList<Instruction> _instructions;
+        private readonly SyntaxNodeOrToken _syntax;
+        private readonly int _position;
 
         public SequencePointInserter(IReadOnlyList<Instruction> instructions, SyntaxNodeOrToken syntax)
         {
-            this.instructions = instructions;
-            this.syntax = syntax;
-            this.position = instructions.Count;
+            this._instructions = instructions;
+            this._syntax = syntax;
+            this._position = instructions.Count;
         }
         void IDisposable.Dispose()
         {
-            if (position < instructions.Count)
-                instructions[position].SourceLocation = syntax.GetLocation();
+            if (_position < _instructions.Count)
+                _instructions[_position].SourceLocation = _syntax.GetLocation();
         }
     }
 }


### PR DESCRIPTION
This pr will focus on adding comments to the method convert class of the compiler. It focuses on:

- Adding comments to existing code.
- Adding comments to the syntex that compiler does not support.
- Adding examples of syntex that compiler support.
- Update variable and method names (only a few) that are not clear not not standard style.
-  Update the exception to make it align to the diagnosticID