### PR TITLE
UT: add unit test for return-switch

### DIFF
--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_Switch6.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_Switch6.cs
@@ -1,3 +1,5 @@
+using Neo.SmartContract.Framework;
+
 namespace Neo.Compiler.CSharp.UnitTests.TestClasses
 {
     public class Contract_SwitchValid : SmartContract.Framework.SmartContract
@@ -12,9 +14,22 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
                 case "3": return 4;
                 case "4": return 5;
                 case "5": return 6;
-
                 default: return 99;
             }
+        }
+
+        public static object Main2(string method)
+        {
+            return method switch
+            {
+                "0" => 1,
+                "1" => 2,
+                "2" => 3,
+                "3" => 4,
+                "4" => 5,
+                "5" => 6,
+                _ => 99
+            };
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Switch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Switch.cs
@@ -134,12 +134,18 @@ namespace Neo.Compiler.CSharp.UnitTests
                 testengine.Reset();
                 result = testengine.ExecuteTestCaseStandard("main", x.ToString());
                 Assert.AreEqual(result.Pop().GetInteger(), x + 1);
+                testengine.Reset();
+                result = testengine.ExecuteTestCaseStandard("main2", x.ToString());
+                Assert.AreEqual(result.Pop().GetInteger(), x + 1);
             }
 
             // Test default
 
             testengine.Reset();
             result = testengine.ExecuteTestCaseStandard("main", 6.ToString());
+            Assert.AreEqual(result.Pop().GetInteger(), 99);
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("main2", 6.ToString());
             Assert.AreEqual(result.Pop().GetInteger(), 99);
         }
     }


### PR DESCRIPTION
This pr only add a new unit test for return-switch syntax.

I have to say erik has written this compiler pretty complete, only very few C# syntaxs are not supported. 