### PR TITLE
Fix: fix name style

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -36,40 +36,40 @@ namespace Neo.Compiler
 {
     public class CompilationContext
     {
-        private static readonly MetadataReference[] commonReferences;
-        private static readonly Dictionary<string, MetadataReference> metaReferences = new();
-        private readonly Compilation compilation;
-        private string? displayName, className;
-        private bool scTypeFound;
-        private readonly List<Diagnostic> diagnostics = new();
-        private readonly HashSet<string> supportedStandards = new();
-        private readonly List<AbiMethod> methodsExported = new();
-        private readonly List<AbiEvent> eventsExported = new();
-        private readonly PermissionBuilder permissions = new();
-        private readonly HashSet<string> trusts = new();
-        private readonly JObject manifestExtra = new();
-        private readonly MethodConvertCollection methodsConverted = new();
-        private readonly MethodConvertCollection methodsForward = new();
-        private readonly List<MethodToken> methodTokens = new();
-        private readonly Dictionary<IFieldSymbol, byte> staticFields = new(SymbolEqualityComparer.Default);
-        private readonly List<byte> anonymousStaticFields = new();
-        private readonly Dictionary<ITypeSymbol, byte> vtables = new(SymbolEqualityComparer.Default);
-        private byte[]? script;
+        private static readonly MetadataReference[] CommonReferences;
+        private static readonly Dictionary<string, MetadataReference> MetaReferences = new();
+        private readonly Compilation _compilation;
+        private string? _displayName, _className;
+        private bool _scTypeFound;
+        private readonly List<Diagnostic> _diagnostics = new();
+        private readonly HashSet<string> _supportedStandards = new();
+        private readonly List<AbiMethod> _methodsExported = new();
+        private readonly List<AbiEvent> _eventsExported = new();
+        private readonly PermissionBuilder _permissions = new();
+        private readonly HashSet<string> _trusts = new();
+        private readonly JObject _manifestExtra = new();
+        private readonly MethodConvertCollection _methodsConverted = new();
+        private readonly MethodConvertCollection _methodsForward = new();
+        private readonly List<MethodToken> _methodTokens = new();
+        private readonly Dictionary<IFieldSymbol, byte> _staticFields = new(SymbolEqualityComparer.Default);
+        private readonly List<byte> _anonymousStaticFields = new();
+        private readonly Dictionary<ITypeSymbol, byte> _vTables = new(SymbolEqualityComparer.Default);
+        private byte[]? _script;
 
-        public bool Success => diagnostics.All(p => p.Severity != DiagnosticSeverity.Error);
-        public IReadOnlyList<Diagnostic> Diagnostics => diagnostics;
-        public string? ContractName => displayName ?? Options.BaseName ?? className;
+        public bool Success => _diagnostics.All(p => p.Severity != DiagnosticSeverity.Error);
+        public IReadOnlyList<Diagnostic> Diagnostics => _diagnostics;
+        public string? ContractName => _displayName ?? Options.BaseName ?? _className;
         private string? Source { get; set; }
         internal Options Options { get; private set; }
-        internal IEnumerable<IFieldSymbol> StaticFieldSymbols => staticFields.OrderBy(p => p.Value).Select(p => p.Key);
-        internal IEnumerable<(byte, ITypeSymbol)> VTables => vtables.OrderBy(p => p.Value).Select(p => (p.Value, p.Key));
-        internal int StaticFieldCount => staticFields.Count + anonymousStaticFields.Count + vtables.Count;
-        private byte[] Script => script ??= GetInstructions().Select(p => p.ToArray()).SelectMany(p => p).ToArray();
+        internal IEnumerable<IFieldSymbol> StaticFieldSymbols => _staticFields.OrderBy(p => p.Value).Select(p => p.Key);
+        internal IEnumerable<(byte, ITypeSymbol)> VTables => _vTables.OrderBy(p => p.Value).Select(p => (p.Value, p.Key));
+        internal int StaticFieldCount => _staticFields.Count + _anonymousStaticFields.Count + _vTables.Count;
+        private byte[] Script => _script ??= GetInstructions().Select(p => p.ToArray()).SelectMany(p => p).ToArray();
 
         static CompilationContext()
         {
             string coreDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-            commonReferences = new[]
+            CommonReferences = new[]
             {
                 MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.dll")),
                 MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.InteropServices.dll")),
@@ -81,31 +81,31 @@ namespace Neo.Compiler
 
         private CompilationContext(Compilation compilation, Options options)
         {
-            this.compilation = compilation;
+            this._compilation = compilation;
             this.Options = options;
         }
 
         private void RemoveEmptyInitialize()
         {
-            int index = methodsExported.FindIndex(p => p.Name == "_initialize");
+            int index = _methodsExported.FindIndex(p => p.Name == "_initialize");
             if (index < 0) return;
-            AbiMethod method = methodsExported[index];
-            if (methodsConverted[method.Symbol].Instructions.Count <= 1)
+            AbiMethod method = _methodsExported[index];
+            if (_methodsConverted[method.Symbol].Instructions.Count <= 1)
             {
-                methodsExported.RemoveAt(index);
-                methodsConverted.Remove(method.Symbol);
+                _methodsExported.RemoveAt(index);
+                _methodsConverted.Remove(method.Symbol);
             }
         }
 
         private IEnumerable<Instruction> GetInstructions()
         {
-            return methodsConverted.SelectMany(p => p.Instructions).Concat(methodsForward.SelectMany(p => p.Instructions));
+            return _methodsConverted.SelectMany(p => p.Instructions).Concat(_methodsForward.SelectMany(p => p.Instructions));
         }
 
         private int GetAbiOffset(IMethodSymbol method)
         {
-            if (!methodsForward.TryGetValue(method, out MethodConvert? convert))
-                convert = methodsConverted[method];
+            if (!_methodsForward.TryGetValue(method, out MethodConvert? convert))
+                convert = _methodsConverted[method];
             return convert.Instructions[0].Offset;
         }
 
@@ -120,10 +120,10 @@ namespace Neo.Compiler
         private void Compile()
         {
             HashSet<INamedTypeSymbol> processed = new(SymbolEqualityComparer.Default);
-            foreach (SyntaxTree tree in compilation.SyntaxTrees)
+            foreach (SyntaxTree tree in _compilation.SyntaxTrees)
             {
-                SemanticModel model = compilation.GetSemanticModel(tree);
-                diagnostics.AddRange(model.GetDiagnostics());
+                SemanticModel model = _compilation.GetSemanticModel(tree);
+                _diagnostics.AddRange(model.GetDiagnostics());
                 if (!Success) continue;
                 try
                 {
@@ -131,14 +131,14 @@ namespace Neo.Compiler
                 }
                 catch (CompilationException ex)
                 {
-                    diagnostics.Add(ex.Diagnostic);
+                    _diagnostics.Add(ex.Diagnostic);
                 }
             }
             if (Success)
             {
-                if (!scTypeFound)
+                if (!_scTypeFound)
                 {
-                    diagnostics.Add(Diagnostic.Create(DiagnosticId.NoEntryPoint, DiagnosticCategory.Default, "No SmartContract is found in the sources.", DiagnosticSeverity.Error, DiagnosticSeverity.Error, true, 0));
+                    _diagnostics.Add(Diagnostic.Create(DiagnosticId.NoEntryPoint, DiagnosticCategory.Default, "No SmartContract is found in the sources.", DiagnosticSeverity.Error, DiagnosticSeverity.Error, true, 0));
                     return;
                 }
                 RemoveEmptyInitialize();
@@ -162,7 +162,7 @@ namespace Neo.Compiler
 
         public static CompilationContext CompileSources(string[] sourceFiles, Options options)
         {
-            List<MetadataReference> references = new(commonReferences);
+            List<MetadataReference> references = new(CommonReferences);
             references.Add(MetadataReference.CreateFromFile(typeof(scfx.Neo.SmartContract.Framework.SmartContract).Assembly.Location));
             return Compile(sourceFiles, references, options);
         }
@@ -174,7 +174,7 @@ namespace Neo.Compiler
             HashSet<string> sourceFiles = Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories)
                 .Where(p => !p.StartsWith(obj))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            List<MetadataReference> references = new(commonReferences);
+            List<MetadataReference> references = new(CommonReferences);
             CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, deterministic: true, nullableContextOptions: options.Nullable);
             XDocument document = XDocument.Load(csproj);
             sourceFiles.UnionWith(document.Root!.Elements("ItemGroup").Elements("Compile").Attributes("Include").Select(p => Path.GetFullPath(p.Value, folder)));
@@ -198,7 +198,7 @@ namespace Neo.Compiler
         private static MetadataReference? GetReference(string name, JObject package, JObject assets, string folder, Options options, CSharpCompilationOptions compilationOptions)
         {
             string assemblyName = Path.GetDirectoryName(name)!;
-            if (!metaReferences.TryGetValue(assemblyName, out var reference))
+            if (!MetaReferences.TryGetValue(assemblyName, out var reference))
             {
                 switch (assets["libraries"]![name]!["type"]!.GetString())
                 {
@@ -226,7 +226,7 @@ namespace Neo.Compiler
                         else
                         {
                             IEnumerable<SyntaxTree> st = files.OrderBy(p => p).Select(p => Path.Combine(packagesPath, namePath, p)).Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), path: p));
-                            CSharpCompilation cr = CSharpCompilation.Create(assemblyName, st, commonReferences, compilationOptions);
+                            CSharpCompilation cr = CSharpCompilation.Create(assemblyName, st, CommonReferences, compilationOptions);
                             reference = cr.ToMetadataReference();
                         }
                         break;
@@ -238,7 +238,7 @@ namespace Neo.Compiler
                     default:
                         throw new NotSupportedException();
                 }
-                metaReferences.Add(assemblyName, reference);
+                MetaReferences.Add(assemblyName, reference);
             }
             return reference;
         }
@@ -260,7 +260,7 @@ namespace Neo.Compiler
             {
                 Compiler = $"{titleAttribute.Title} {versionAttribute.InformationalVersion}",
                 Source = Source ?? string.Empty,
-                Tokens = methodTokens.ToArray(),
+                Tokens = _methodTokens.ToArray(),
                 Script = Script
             };
             nef.CheckSum = NefFile.ComputeChecksum(nef);
@@ -282,14 +282,14 @@ namespace Neo.Compiler
                 builder.AppendLine();
             }
             StringBuilder builder = new();
-            foreach (MethodConvert method in methodsConverted)
+            foreach (MethodConvert method in _methodsConverted)
             {
                 builder.Append("// ");
                 builder.AppendLine(method.Symbol.ToString());
                 builder.AppendLine();
                 WriteMethod(builder, method);
             }
-            foreach (MethodConvert method in methodsForward)
+            foreach (MethodConvert method in _methodsForward)
             {
                 builder.Append("// ");
                 builder.Append(method.Symbol.ToString());
@@ -307,10 +307,10 @@ namespace Neo.Compiler
                 ["name"] = ContractName,
                 ["groups"] = new JArray(),
                 ["features"] = new JObject(),
-                ["supportedstandards"] = supportedStandards.OrderBy(p => p).Select(p => (JString)p!).ToArray(),
+                ["supportedstandards"] = _supportedStandards.OrderBy(p => p).Select(p => (JString)p!).ToArray(),
                 ["abi"] = new JObject
                 {
-                    ["methods"] = methodsExported.Select(p => new JObject
+                    ["methods"] = _methodsExported.Select(p => new JObject
                     {
                         ["name"] = p.Name,
                         ["offset"] = GetAbiOffset(p.Symbol),
@@ -318,15 +318,15 @@ namespace Neo.Compiler
                         ["returntype"] = p.ReturnType,
                         ["parameters"] = p.Parameters.Select(p => p.ToJson()).ToArray()
                     }).ToArray(),
-                    ["events"] = eventsExported.Select(p => new JObject
+                    ["events"] = _eventsExported.Select(p => new JObject
                     {
                         ["name"] = p.Name,
                         ["parameters"] = p.Parameters.Select(p => p.ToJson()).ToArray()
                     }).ToArray()
                 },
-                ["permissions"] = permissions.ToJson(),
-                ["trusts"] = trusts.Contains("*") ? "*" : trusts.OrderBy(p => p.Length).ThenBy(p => p).Select(u => new JString(u)).ToArray(),
-                ["extra"] = manifestExtra
+                ["permissions"] = _permissions.ToJson(),
+                ["trusts"] = _trusts.Contains("*") ? "*" : _trusts.OrderBy(p => p.Length).ThenBy(p => p).Select(u => new JString(u)).ToArray(),
+                ["extra"] = _manifestExtra
             };
             // Ensure that is serializable
             return ContractManifest.Parse(json.ToString(false));
@@ -336,7 +336,7 @@ namespace Neo.Compiler
         {
             List<string> documents = new();
             List<JObject> methods = new();
-            foreach (var m in methodsConverted.Where(p => p.SyntaxNode is not null))
+            foreach (var m in _methodsConverted.Where(p => p.SyntaxNode is not null))
             {
                 List<JString> sequencePoints = new();
                 foreach (var ins in m.Instructions.Where(i => i.SourceLocation is not null))
@@ -381,9 +381,9 @@ namespace Neo.Compiler
                 ["hash"] = Script.ToScriptHash().ToString(),
                 ["documents"] = documents.Select(p => (JString)p!).ToArray(),
                 ["document-root"] = string.IsNullOrEmpty(folder) ? JToken.Null : folder,
-                ["static-variables"] = staticFields.OrderBy(p => p.Value).Select(p => ((JString)$"{p.Key.Name},{p.Key.Type.GetContractParameterType()},{p.Value}")!).ToArray(),
+                ["static-variables"] = _staticFields.OrderBy(p => p.Value).Select(p => ((JString)$"{p.Key.Name},{p.Key.Type.GetContractParameterType()},{p.Value}")!).ToArray(),
                 ["methods"] = methods.ToArray(),
-                ["events"] = eventsExported.Select(e => new JObject
+                ["events"] = _eventsExported.Select(e => new JObject
                 {
                     ["id"] = e.Name,
                     ["name"] = $"{e.Symbol.ContainingType},{e.Symbol.Name}",
@@ -422,36 +422,36 @@ namespace Neo.Compiler
             bool isSmartContract = isPublic && !isAbstract && isContractType;
             if (isSmartContract)
             {
-                if (scTypeFound) throw new CompilationException(DiagnosticId.MultiplyContracts, $"Only one smart contract is allowed.");
-                scTypeFound = true;
+                if (_scTypeFound) throw new CompilationException(DiagnosticId.MultiplyContracts, $"Only one smart contract is allowed.");
+                _scTypeFound = true;
                 foreach (var attribute in symbol.GetAttributesWithInherited())
                 {
                     switch (attribute.AttributeClass!.Name)
                     {
                         case nameof(DisplayNameAttribute):
-                            displayName = (string)attribute.ConstructorArguments[0].Value!;
+                            _displayName = (string)attribute.ConstructorArguments[0].Value!;
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ContractSourceCodeAttribute):
                             Source = (string)attribute.ConstructorArguments[0].Value!;
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ManifestExtraAttribute):
-                            manifestExtra[(string)attribute.ConstructorArguments[0].Value!] = (string)attribute.ConstructorArguments[1].Value!;
+                            _manifestExtra[(string)attribute.ConstructorArguments[0].Value!] = (string)attribute.ConstructorArguments[1].Value!;
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ContractPermissionAttribute):
-                            permissions.Add((string)attribute.ConstructorArguments[0].Value!, attribute.ConstructorArguments[1].Values.Select(p => (string)p.Value!).ToArray());
+                            _permissions.Add((string)attribute.ConstructorArguments[0].Value!, attribute.ConstructorArguments[1].Values.Select(p => (string)p.Value!).ToArray());
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.ContractTrustAttribute):
                             string trust = (string)attribute.ConstructorArguments[0].Value!;
                             if (!ValidateContractTrust(trust))
                                 throw new ArgumentException($"The value {trust} is not a valid one for ContractTrust");
-                            trusts.Add(trust);
+                            _trusts.Add(trust);
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.SupportedStandardsAttribute):
-                            supportedStandards.UnionWith(attribute.ConstructorArguments[0].Values.Select(p => (string)p.Value!));
+                            _supportedStandards.UnionWith(attribute.ConstructorArguments[0].Values.Select(p => (string)p.Value!));
                             break;
                     }
                 }
-                className = symbol.Name;
+                _className = symbol.Name;
             }
             foreach (ISymbol member in symbol.GetAllMembers())
             {
@@ -481,9 +481,9 @@ namespace Neo.Compiler
             if (!type.DelegateInvokeMethod!.ReturnsVoid)
                 throw new CompilationException(symbol, DiagnosticId.EventReturns, $"Event return value is not supported.");
             AbiEvent ev = new(symbol);
-            if (eventsExported.Any(u => u.Name == ev.Name))
+            if (_eventsExported.Any(u => u.Name == ev.Name))
                 throw new CompilationException(symbol, DiagnosticId.EventNameConflict, $"Duplicate event name: {ev.Name}.");
-            eventsExported.Add(ev);
+            _eventsExported.Add(ev);
         }
 
         private void ProcessMethod(SemanticModel model, IMethodSymbol symbol, bool export)
@@ -499,9 +499,9 @@ namespace Neo.Compiler
             if (export)
             {
                 AbiMethod method = new(symbol);
-                if (methodsExported.Any(u => u.Name == method.Name && u.Parameters.Length == method.Parameters.Length))
+                if (_methodsExported.Any(u => u.Name == method.Name && u.Parameters.Length == method.Parameters.Length))
                     throw new CompilationException(symbol, DiagnosticId.MethodNameConflict, $"Duplicate method key: {method.Name},{method.Parameters.Length}.");
-                methodsExported.Add(method);
+                _methodsExported.Add(method);
             }
 
             if (symbol.GetAttributesWithInherited()
@@ -519,16 +519,16 @@ namespace Neo.Compiler
             {
                 MethodConvert forward = new(this, symbol);
                 forward.ConvertForward(model, convert);
-                methodsForward.Add(forward);
+                _methodsForward.Add(forward);
             }
         }
 
         internal MethodConvert ConvertMethod(SemanticModel model, IMethodSymbol symbol)
         {
-            if (!methodsConverted.TryGetValue(symbol, out MethodConvert? method))
+            if (!_methodsConverted.TryGetValue(symbol, out MethodConvert? method))
             {
                 method = new MethodConvert(this, symbol);
-                methodsConverted.Add(method);
+                _methodsConverted.Add(method);
                 if (!symbol.DeclaringSyntaxReferences.IsEmpty)
                 {
                     ISourceAssemblySymbol assembly = (ISourceAssemblySymbol)symbol.ContainingAssembly;
@@ -541,9 +541,9 @@ namespace Neo.Compiler
 
         internal ushort AddMethodToken(UInt160 hash, string method, ushort parametersCount, bool hasReturnValue, CallFlags callFlags)
         {
-            int index = methodTokens.FindIndex(p => p.Hash == hash && p.Method == method && p.ParametersCount == parametersCount && p.HasReturnValue == hasReturnValue && p.CallFlags == callFlags);
+            int index = _methodTokens.FindIndex(p => p.Hash == hash && p.Method == method && p.ParametersCount == parametersCount && p.HasReturnValue == hasReturnValue && p.CallFlags == callFlags);
             if (index >= 0) return (ushort)index;
-            methodTokens.Add(new MethodToken
+            _methodTokens.Add(new MethodToken
             {
                 Hash = hash,
                 Method = method,
@@ -551,16 +551,16 @@ namespace Neo.Compiler
                 HasReturnValue = hasReturnValue,
                 CallFlags = callFlags
             });
-            permissions.Add(hash.ToString(), method);
-            return (ushort)(methodTokens.Count - 1);
+            _permissions.Add(hash.ToString(), method);
+            return (ushort)(_methodTokens.Count - 1);
         }
 
         internal byte AddStaticField(IFieldSymbol symbol)
         {
-            if (!staticFields.TryGetValue(symbol, out byte index))
+            if (!_staticFields.TryGetValue(symbol, out byte index))
             {
                 index = (byte)StaticFieldCount;
-                staticFields.Add(symbol, index);
+                _staticFields.Add(symbol, index);
             }
             return index;
         }
@@ -568,16 +568,16 @@ namespace Neo.Compiler
         internal byte AddAnonymousStaticField()
         {
             byte index = (byte)StaticFieldCount;
-            anonymousStaticFields.Add(index);
+            _anonymousStaticFields.Add(index);
             return index;
         }
 
         internal byte AddVTable(ITypeSymbol type)
         {
-            if (!vtables.TryGetValue(type, out byte index))
+            if (!_vTables.TryGetValue(type, out byte index))
             {
                 index = (byte)StaticFieldCount;
-                vtables.Add(type, index);
+                _vTables.Add(type, index);
             }
             return index;
         }

--- a/src/Neo.Compiler.CSharp/ExceptionHandling.cs
+++ b/src/Neo.Compiler.CSharp/ExceptionHandling.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -17,8 +17,8 @@ namespace Neo.Compiler
     class ExceptionHandling
     {
         public ExceptionHandlingState State;
-        public HashSet<ILabelSymbol> Labels = new(SymbolEqualityComparer.Default);
-        public List<Instruction> PendingGotoStatments = new();
+        public readonly HashSet<ILabelSymbol> Labels = new(SymbolEqualityComparer.Default);
+        public readonly List<Instruction> PendingGotoStatements = new();
         public int SwitchCount = 0;
         public int ContinueTargetCount = 0;
         public int BreakTargetCount = 0;

--- a/src/Neo.Compiler.CSharp/Options.cs
+++ b/src/Neo.Compiler.CSharp/Options.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -26,16 +26,16 @@ namespace Neo.Compiler
         public bool NoInline { get; set; }
         public byte AddressVersion { get; set; }
 
-        private CSharpParseOptions? parseOptions = null;
+        private CSharpParseOptions? _parseOptions;
         public CSharpParseOptions GetParseOptions()
         {
-            if (parseOptions is null)
+            if (_parseOptions is null)
             {
                 List<string> preprocessorSymbols = new();
                 if (Debug) preprocessorSymbols.Add("DEBUG");
-                parseOptions = new CSharpParseOptions(preprocessorSymbols: preprocessorSymbols);
+                _parseOptions = new CSharpParseOptions(preprocessorSymbols: preprocessorSymbols);
             }
-            return parseOptions;
+            return _parseOptions;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/PermissionBuilder.cs
+++ b/src/Neo.Compiler.CSharp/PermissionBuilder.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -16,10 +16,10 @@ namespace Neo.Compiler
 {
     class PermissionBuilder
     {
-        private readonly HashSet<(string Hash, string Method)> normalItems = new();
-        private readonly HashSet<string> wildcardHashes = new();
-        private readonly HashSet<string> wildcardMethods = new();
-        private bool isWildcard;
+        private readonly HashSet<(string Hash, string Method)> _normalItems = new();
+        private readonly HashSet<string> _wildcardHashes = new();
+        private readonly HashSet<string> _wildcardMethods = new();
+        private bool _isWildcard;
 
         public void Add(string hash, string[] methods)
         {
@@ -32,30 +32,30 @@ namespace Neo.Compiler
 
         public void Add(string hash, string method)
         {
-            if (isWildcard) return;
+            if (_isWildcard) return;
             if (hash == "*")
             {
                 if (method == "*")
                 {
-                    isWildcard = true;
+                    _isWildcard = true;
                 }
                 else
                 {
-                    if (wildcardMethods.Add(method))
-                        normalItems.RemoveWhere(p => p.Method == method);
+                    if (_wildcardMethods.Add(method))
+                        _normalItems.RemoveWhere(p => p.Method == method);
                 }
             }
             else
             {
                 if (method == "*")
                 {
-                    if (wildcardHashes.Add(hash))
-                        normalItems.RemoveWhere(p => p.Hash == hash);
+                    if (_wildcardHashes.Add(hash))
+                        _normalItems.RemoveWhere(p => p.Hash == hash);
                 }
                 else
                 {
-                    if (!wildcardHashes.Contains(hash) && !wildcardMethods.Contains(method))
-                        normalItems.Add((hash, method));
+                    if (!_wildcardHashes.Contains(hash) && !_wildcardMethods.Contains(method))
+                        _normalItems.Add((hash, method));
                 }
             }
         }
@@ -63,7 +63,7 @@ namespace Neo.Compiler
         public JArray ToJson()
         {
             JArray permissions = new();
-            if (isWildcard)
+            if (_isWildcard)
             {
                 permissions.Add(new JObject
                 {
@@ -73,23 +73,23 @@ namespace Neo.Compiler
             }
             else
             {
-                foreach (var group in normalItems.GroupBy(p => p.Hash, p => p.Method).OrderBy(p => p.Key))
+                foreach (var group in _normalItems.GroupBy(p => p.Hash, p => p.Method).OrderBy(p => p.Key))
                     permissions.Add(new JObject
                     {
                         ["contract"] = group.Key,
                         ["methods"] = new JArray(group.OrderBy(p => p).Select(p => (JString)p!))
                     });
-                foreach (string hash in wildcardHashes.OrderBy(p => p))
+                foreach (string hash in _wildcardHashes.OrderBy(p => p))
                     permissions.Add(new JObject
                     {
                         ["contract"] = hash,
                         ["methods"] = "*"
                     });
-                if (wildcardMethods.Count > 0)
+                if (_wildcardMethods.Count > 0)
                     permissions.Add(new JObject
                     {
                         ["contract"] = "*",
-                        ["methods"] = new JArray(wildcardMethods.OrderBy(p => p).Select(p => (JString)p!))
+                        ["methods"] = new JArray(_wildcardMethods.OrderBy(p => p).Select(p => (JString)p!))
                     });
             }
             return permissions;

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -181,11 +181,8 @@ namespace Neo.Compiler
                 Console.WriteLine("Compilation completed successfully.");
                 return 0;
             }
-            else
-            {
-                Console.Error.WriteLine("Compilation failed.");
-                return 1;
-            }
+            Console.Error.WriteLine("Compilation failed.");
+            return 1;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SequencePointInserter.cs
+++ b/src/Neo.Compiler.CSharp/SequencePointInserter.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -16,20 +16,20 @@ namespace Neo.Compiler
 {
     class SequencePointInserter : IDisposable
     {
-        private readonly IReadOnlyList<Instruction> instructions;
-        private readonly SyntaxNodeOrToken syntax;
-        private readonly int position;
+        private readonly IReadOnlyList<Instruction> _instructions;
+        private readonly SyntaxNodeOrToken _syntax;
+        private readonly int _position;
 
         public SequencePointInserter(IReadOnlyList<Instruction> instructions, SyntaxNodeOrToken syntax)
         {
-            this.instructions = instructions;
-            this.syntax = syntax;
-            this.position = instructions.Count;
+            _instructions = instructions;
+            _syntax = syntax;
+            _position = instructions.Count;
         }
         void IDisposable.Dispose()
         {
-            if (position < instructions.Count)
-                instructions[position].SourceLocation = syntax.GetLocation();
+            if (_position < _instructions.Count)
+                _instructions[_position].SourceLocation = _syntax.GetLocation();
         }
     }
 }


### PR DESCRIPTION
This pr fix the naming style.

The name of properties and variables is a mess, use the recommended C# style instead.