### PR TITLE
Fix: fix bug in the compiler version

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -258,7 +258,7 @@ namespace Neo.Compiler
             var versionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!;
             NefFile nef = new()
             {
-                Compiler = $"{titleAttribute.Title} {versionAttribute.InformationalVersion}",
+                Compiler = $"{titleAttribute.Title} {versionAttribute.InformationalVersion.GetVersion()}",
                 Source = Source ?? string.Empty,
                 Tokens = methodTokens.ToArray(),
                 Script = Script

--- a/src/Neo.Compiler.CSharp/Helper.cs
+++ b/src/Neo.Compiler.CSharp/Helper.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 
 namespace Neo.Compiler
 {
@@ -380,6 +381,13 @@ namespace Neo.Compiler
                     }
                 }
             }
+        }
+
+        private static bool IsOsx => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        public static string GetVersion(this string version)
+        {
+            return IsOsx && version.Contains('+') ? version.Split('+')[0] : version;
         }
     }
 }


### PR DESCRIPTION
This pr fix the bug that in mac platform, the compiler can get a version attached with commit number, which will make the compiler version longer than 64.