### PR TITLE
Add: add more Biginteger methods

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -4241,7 +4241,6 @@ namespace Neo.Compiler
                 case "System.Numerics.BigInteger.GreatestCommonDivisor(System.Numerics.BigInteger, System.Numerics.BigInteger)":
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    // JumpTarget whileTarget = new();
                     JumpTarget gcdTarget = new();
                     gcdTarget.Instruction = AddInstruction(OpCode.DUP);
                     AddInstruction(OpCode.REVERSE3);
@@ -4249,7 +4248,7 @@ namespace Neo.Compiler
                     AddInstruction(OpCode.MOD);
                     AddInstruction(OpCode.DUP);
                     AddInstruction(OpCode.PUSH0);
-                    AddInstruction(OpCode.EQUAL);
+                    AddInstruction(OpCode.NUMEQUAL);
                     Jump(OpCode.JMPIFNOT, gcdTarget);
                     AddInstruction(OpCode.DROP);
                     AddInstruction(OpCode.ABS);

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -4238,6 +4238,24 @@ namespace Neo.Compiler
                     AddInstruction(OpCode.SUB);
                     AddInstruction(OpCode.SIGN);
                     return true;
+                case "System.Numerics.BigInteger.GreatestCommonDivisor(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    JumpTarget whileTarget = new();
+                    JumpTarget gcdTarget = new();
+                    whileTarget.Instruction = AddInstruction(OpCode.DUP);
+                    AddInstruction(OpCode.PUSH0);
+                    AddInstruction(OpCode.EQUAL);
+                    Jump(OpCode.JMPIF, gcdTarget);
+                    AddInstruction(OpCode.DUP);
+                    AddInstruction(OpCode.REVERSE3);
+                    AddInstruction(OpCode.SWAP);
+                    AddInstruction(OpCode.MOD);
+                    Jump(OpCode.JMP, whileTarget);
+                    gcdTarget.Instruction = AddInstruction(OpCode.NOP);
+                    AddInstruction(OpCode.DROP);
+                    AddInstruction(OpCode.ABS);
+                    return true;
                 case "System.Numerics.BigInteger.ToByteArray()":
                     if (instanceExpression is not null)
                         ConvertExpression(model, instanceExpression);

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -4199,6 +4199,45 @@ namespace Neo.Compiler
                         PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.MODPOW);
                     return true;
+                case "System.Numerics.BigInteger.Add(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.ADD);
+                    return true;
+                case "System.Numerics.BigInteger.Subtract(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.SUB);
+                    return true;
+                case "System.Numerics.BigInteger.Negate(System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.NEGATE);
+                    return true;
+                case "System.Numerics.BigInteger.Multiply(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.MUL);
+                    return true;
+                case "System.Numerics.BigInteger.Divide(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.DIV);
+                    return true;
+                case "System.Numerics.BigInteger.Remainder(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.MOD);
+                    return true;
+                case "System.Numerics.BigInteger.Compare(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    // if left < right return -1;
+                    // if left = right return 0;
+                    // if left > right return 1;
+                    AddInstruction(OpCode.SUB);
+                    AddInstruction(OpCode.SIGN);
+                    return true;
                 case "System.Numerics.BigInteger.ToByteArray()":
                     if (instanceExpression is not null)
                         ConvertExpression(model, instanceExpression);

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -4241,18 +4241,16 @@ namespace Neo.Compiler
                 case "System.Numerics.BigInteger.GreatestCommonDivisor(System.Numerics.BigInteger, System.Numerics.BigInteger)":
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    JumpTarget whileTarget = new();
+                    // JumpTarget whileTarget = new();
                     JumpTarget gcdTarget = new();
-                    whileTarget.Instruction = AddInstruction(OpCode.DUP);
-                    AddInstruction(OpCode.PUSH0);
-                    AddInstruction(OpCode.EQUAL);
-                    Jump(OpCode.JMPIF, gcdTarget);
-                    AddInstruction(OpCode.DUP);
+                    gcdTarget.Instruction = AddInstruction(OpCode.DUP);
                     AddInstruction(OpCode.REVERSE3);
                     AddInstruction(OpCode.SWAP);
                     AddInstruction(OpCode.MOD);
-                    Jump(OpCode.JMP, whileTarget);
-                    gcdTarget.Instruction = AddInstruction(OpCode.NOP);
+                    AddInstruction(OpCode.DUP);
+                    AddInstruction(OpCode.PUSH0);
+                    AddInstruction(OpCode.EQUAL);
+                    Jump(OpCode.JMPIFNOT, gcdTarget);
                     AddInstruction(OpCode.DROP);
                     AddInstruction(OpCode.ABS);
                     return true;

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_BigInteger.cs
@@ -123,5 +123,42 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
         {
             return input.IsEven;
         }
+
+        public static BigInteger TestAdd(BigInteger x, BigInteger y)
+        {
+            return BigInteger.Add(x, y);
+        }
+
+        public static BigInteger TestSubtract(BigInteger x, BigInteger y)
+        {
+            return BigInteger.Subtract(x, y);
+        }
+
+        public static BigInteger TestNegate(BigInteger x)
+        {
+            return BigInteger.Negate(x);
+        }
+
+        public static BigInteger TestMultiply(BigInteger x, BigInteger y)
+        {
+            return BigInteger.Multiply(x, y);
+        }
+
+        public static BigInteger TestDivide(BigInteger x, BigInteger y)
+        {
+            return BigInteger.Divide(x, y);
+        }
+
+        public static BigInteger TestRemainder(BigInteger x, BigInteger y)
+        {
+            return BigInteger.Remainder(x, y);
+        }
+
+        public static int TestCompare(BigInteger x, BigInteger y)
+        {
+            return BigInteger.Compare(x, y);
+        }
+
+
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_BigInteger.cs
@@ -159,7 +159,7 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
             return BigInteger.Compare(x, y);
         }
 
-        public static BigInteger GreatestCommonDivisor(BigInteger x, BigInteger y)
+        public static BigInteger TestGreatestCommonDivisor(BigInteger x, BigInteger y)
         {
             return BigInteger.GreatestCommonDivisor(x, y);
         }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestClasses/Contract_BigInteger.cs
@@ -159,6 +159,10 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
             return BigInteger.Compare(x, y);
         }
 
+        public static BigInteger GreatestCommonDivisor(BigInteger x, BigInteger y)
+        {
+            return BigInteger.GreatestCommonDivisor(x, y);
+        }
 
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
@@ -342,17 +342,17 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_GreatestCommonDivisor()
         {
             testengine.Reset();
-            var result = testengine.ExecuteTestCaseStandard("testCompare", 48, 18);
+            var result = testengine.ExecuteTestCaseStandard("testGreatestCommonDivisor", 48, 18);
             var value = result.Pop().GetInteger();
             Assert.AreEqual(BigInteger.GreatestCommonDivisor(48, 18), value);
 
             testengine.Reset();
-            result = testengine.ExecuteTestCaseStandard("testCompare", -48, -18);
+            result = testengine.ExecuteTestCaseStandard("testGreatestCommonDivisor", -48, -18);
             value = result.Pop().GetInteger();
             Assert.AreEqual(BigInteger.GreatestCommonDivisor(-48, -18), value);
 
             testengine.Reset();
-            result = testengine.ExecuteTestCaseStandard("testCompare", 24, 12);
+            result = testengine.ExecuteTestCaseStandard("testGreatestCommonDivisor", 24, 12);
             value = result.Pop().GetInteger();
             Assert.AreEqual(BigInteger.GreatestCommonDivisor(24, 12), value);
         }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
@@ -337,5 +337,24 @@ namespace Neo.Compiler.CSharp.UnitTests
             var value = result.Pop().GetInteger();
             Assert.AreEqual(BigInteger.Compare(123, 321), value);
         }
+
+        [TestMethod]
+        public void Test_GreatestCommonDivisor()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testCompare", 48, 18);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(BigInteger.GreatestCommonDivisor(48, 18), value);
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("testCompare", -48, -18);
+            value = result.Pop().GetInteger();
+            Assert.AreEqual(BigInteger.GreatestCommonDivisor(-48, -18), value);
+
+            testengine.Reset();
+            result = testengine.ExecuteTestCaseStandard("testCompare", 24, 12);
+            value = result.Pop().GetInteger();
+            Assert.AreEqual(BigInteger.GreatestCommonDivisor(24, 12), value);
+        }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
@@ -9,11 +9,20 @@ namespace Neo.Compiler.CSharp.UnitTests
     [TestClass]
     public class UnitTest_BigInteger
     {
+
+        private TestEngine testengine;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            testengine = new TestEngine();
+            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
+        }
+
         [TestMethod]
         public void Test_Pow()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
+            testengine.Reset();
             var result = testengine.ExecuteTestCaseStandard("testPow", 2, 3);
 
             var value = result.Pop().GetInteger();
@@ -23,8 +32,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_Sqrt()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
+            testengine.Reset();
             var result = testengine.ExecuteTestCaseStandard("testSqrt", 4);
 
             var value = result.Pop().GetInteger();
@@ -34,29 +42,25 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_Sbyte()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
+            testengine.Reset();
             var result = testengine.ExecuteTestCaseStandard("testsbyte", 127);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(127, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testsbyte", -128);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(-128, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testsbyte", 128);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
             Assert.IsNotNull(testengine.FaultException);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testsbyte", -129);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -66,29 +70,24 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_byte()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testbyte", 0);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(0, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testbyte", 255);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(255, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testbyte", -1);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
             Assert.IsNotNull(testengine.FaultException);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testbyte", 256);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -99,29 +98,24 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_short()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testshort", 32767);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(32767, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testshort", -32768);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(-32768, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testshort", 32768);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
             Assert.IsNotNull(testengine.FaultException);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testshort", -32769);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -131,29 +125,24 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_ushort()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testushort", 0);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(0, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testushort", 65535);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(65535, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testushort", -1);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
             Assert.IsNotNull(testengine.FaultException);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testushort", 65536);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -163,29 +152,24 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_int()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testint", -2147483648);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(-2147483648, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testint", 2147483647);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(2147483647, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testint", -2147483649);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
             Assert.IsNotNull(testengine.FaultException);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testint", 2147483648);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -195,29 +179,24 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_uint()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testuint", 0);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(0, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testuint", 4294967295);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(4294967295, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testuint", -1);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
             Assert.IsNotNull(testengine.FaultException);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testuint", 4294967296);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -227,22 +206,18 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_long()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testlong", -9223372036854775808);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(-9223372036854775808, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testlong", 9223372036854775807);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(9223372036854775807, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testlong", 9223372036854775808);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -252,22 +227,18 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_ulong()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             var result = testengine.ExecuteTestCaseStandard("testulong", 0);
 
             var value = result.Pop().GetInteger();
             Assert.AreEqual(0, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testulong", 18446744073709551615);
 
             value = result.Pop().GetInteger();
             Assert.AreEqual(18446744073709551615, value);
 
             testengine.Reset();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             result = testengine.ExecuteTestCaseStandard("testulong", -1);
 
             Assert.AreEqual(VMState.FAULT, testengine.State);
@@ -276,8 +247,6 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_IsEven()
         {
-            var testengine = new TestEngine();
-            testengine.AddEntryScript("./TestClasses/Contract_BigInteger.cs");
             // Test 0
             var result = testengine.ExecuteTestCaseStandard("testIsEven", 0);
             var value = result.Pop().GetBoolean();
@@ -303,6 +272,70 @@ namespace Neo.Compiler.CSharp.UnitTests
             value = result.Pop().GetBoolean();
             Assert.AreEqual(new BigInteger(-2).IsEven, value);
             testengine.Reset();
+        }
+
+
+        [TestMethod]
+        public void Test_Add()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testAdd", 123456789, 987654321);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(new BigInteger(1111111110), value);
+        }
+
+        [TestMethod]
+        public void Test_Subtract()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testSubtract", 123456789, 987654321);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(new BigInteger(-864197532), value);
+        }
+
+        [TestMethod]
+        public void Test_Multiply()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testMultiply", 123, 321);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(new BigInteger(39483), value);
+        }
+
+        [TestMethod]
+        public void Test_Divide()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testDivide", 123456, 123);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(BigInteger.Divide(123456, 123), value);
+        }
+
+        [TestMethod]
+        public void Test_Negate()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testNegate", 123456);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(new BigInteger(-123456), value);
+        }
+
+        [TestMethod]
+        public void Test_Remainder()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testRemainder", 123456, 123);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(BigInteger.Remainder(123456, 123), value);
+        }
+
+        [TestMethod]
+        public void Test_Compare()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("testCompare", 123, 321);
+            var value = result.Pop().GetInteger();
+            Assert.AreEqual(BigInteger.Compare(123, 321), value);
         }
     }
 }


### PR DESCRIPTION
This pr adds more BigInteger methods:

- Add
- Subtract
- Multiply
- Divide
- Negate
- Remainder
- Compare

Methods check list:

- [x] BigInteger.Add(BigInteger, BigInteger)
- [x] BigInteger.Compare(BigInteger, BigInteger)
- [x] BigInteger.Divide(BigInteger, BigInteger)
- [ ] BigInteger.DivRem(BigInteger, BigInteger, out BigInteger)
- [ ] BigInteger.Equals(object)
- [x] BigInteger.Equals(BigInteger)
- [x] BigInteger.Explicit(BigInteger to byte)
- [ ] BigInteger.Explicit(BigInteger to decimal)
- [ ] BigInteger.Explicit(BigInteger to double)
- [x] BigInteger.Explicit(BigInteger to short)
- [x] BigInteger.Explicit(BigInteger to int)
- [x] BigInteger.Explicit(BigInteger to long)
- [x] BigInteger.Explicit(BigInteger to sbyte)
- [ ] BigInteger.Explicit(BigInteger to float)
- [x] BigInteger.Explicit(BigInteger to ushort)
- [x] BigInteger.Explicit(BigInteger to uint)
- [x] BigInteger.Explicit(BigInteger to ulong)
- [x] BigInteger.GreatestCommonDivisor(BigInteger, BigInteger)
- [ ] BigInteger.GetHashCode()
- [ ] BigInteger.GetType()
- [x] BigInteger.Implicit(byte to BigInteger)
- [x] BigInteger.Implicit(decimal to BigInteger)
- [ ] BigInteger.Implicit(double to BigInteger)
- [x] BigInteger.Implicit(short to BigInteger)
- [x] BigInteger.Implicit(int to BigInteger)
- [x] BigInteger.Implicit(long to BigInteger)
- [x] BigInteger.Implicit(sbyte to BigInteger)
- [ ] BigInteger.Implicit(float to BigInteger)
- [x] BigInteger.Implicit(ushort to BigInteger)
- [x] BigInteger.Implicit(uint to BigInteger)
- [x] BigInteger.Implicit(ulong to BigInteger)
- [x] BigInteger.Max(BigInteger, BigInteger)
- [x] BigInteger.Min(BigInteger, BigInteger)
- [x] BigInteger.ModPow(BigInteger, BigInteger, BigInteger)
- [x] BigInteger.Multiply(BigInteger, BigInteger)
- [x] BigInteger.Negate(BigInteger)
- [ ] BigInteger.OnesComplement(BigInteger)
- [x] BigInteger.Parse(string)
- [ ] BigInteger.Parse(string, IFormatProvider)
- [ ] BigInteger.Parse(string, NumberStyles)
- [ ] BigInteger.Parse(string, NumberStyles, IFormatProvider)
- [x] BigInteger.Pow(BigInteger, int)
- [x] BigInteger.Remainder(BigInteger, BigInteger)
- [x] BigInteger.Subtract(BigInteger, BigInteger)
- [x] BigInteger.ToString()
- [ ] BigInteger.ToString(IFormatProvider)
- [ ] BigInteger.ToString(string)
- [ ] BigInteger.ToString(string, IFormatProvider)
- [ ] BigInteger.TryParse(string, out BigInteger)
- [ ] BigInteger.TryParse(string, NumberStyles, IFormatProvider, out BigInteger)
