### PR TITLE
Fix: Code Reuse.

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert.Integer.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.Integer.cs
@@ -1,0 +1,248 @@
+// Copyright (C) 2015-2023 The Neo Project.
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace Neo.Compiler
+{
+    partial class MethodConvert
+    {
+        #region Convert Integer Handlers
+
+        private bool HandleIntegerConversion(SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
+        {
+            return symbol.ToString() switch
+            {
+                "sbyte.Parse(string)" => HandleParseConversion(model, symbol, arguments, sbyte.MinValue, sbyte.MaxValue),
+                "byte.Parse(string)" => HandleParseConversion(model, symbol, arguments, byte.MinValue, byte.MaxValue),
+                "short.Parse(string)" => HandleParseConversion(model, symbol, arguments, short.MinValue, short.MaxValue),
+                "ushort.Parse(string)" => HandleParseConversion(model, symbol, arguments, ushort.MinValue, ushort.MaxValue),
+                "int.Parse(string)" => HandleParseConversion(model, symbol, arguments, int.MinValue, int.MaxValue),
+                "uint.Parse(string)" => HandleParseConversion(model, symbol, arguments, uint.MinValue, uint.MaxValue),
+                "long.Parse(string)" => HandleParseConversion(model, symbol, arguments, long.MinValue, long.MaxValue),
+                "ulong.Parse(string)" => HandleParseConversion(model, symbol, arguments, ulong.MinValue, ulong.MaxValue),
+                "sbyte.ToString()" or "byte.ToString()" or "short.ToString()" or "ushort.ToString()" or "int.ToString()" or "uint.ToString()" or "long.ToString()" or "ulong.ToString()" => HandleToStringConversion(model, instanceExpression),
+                _ => HandleBigIntegerConversion(model, symbol, instanceExpression, arguments),
+            };
+        }
+
+        private bool HandleToStringConversion(SemanticModel model, ExpressionSyntax? instanceExpression)
+        {
+            if (instanceExpression is not null)
+                ConvertExpression(model, instanceExpression);
+            Call(NativeContract.StdLib.Hash, "itoa", 1, true);
+            return true;
+        }
+        private bool HandleBigIntegerConversion(SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
+        {
+            switch (symbol.ToString())
+            {
+                case "System.Numerics.BigInteger.One.get":
+                    Push(1); return true;
+                case "System.Numerics.BigInteger.MinusOne.get":
+                    Push(-1); return true;
+                case "System.Numerics.BigInteger.Zero.get": Push(0); return true;
+                case "System.Numerics.BigInteger.IsZero.get":
+                    {
+                        if (instanceExpression is not null)
+                            ConvertExpression(model, instanceExpression);
+                        Push(0);
+                        AddInstruction(OpCode.NUMEQUAL);
+                        return true;
+                    }
+                case "System.Numerics.BigInteger.IsOne.get":
+                    {
+                        if (instanceExpression is not null)
+                            ConvertExpression(model, instanceExpression);
+                        Push(1);
+                        AddInstruction(OpCode.NUMEQUAL);
+                        return true;
+                    }
+                case "System.Numerics.BigInteger.IsEven.get":
+                    {
+                        if (instanceExpression is not null)
+                            ConvertExpression(model, instanceExpression);
+                        Push(1);
+                        AddInstruction(OpCode.AND);
+                        Push(0);
+                        AddInstruction(OpCode.NUMEQUAL);
+                        return true;
+                    }
+                case "System.Numerics.BigInteger.Sign.get":
+                    {
+                        if (instanceExpression is not null)
+                            ConvertExpression(model, instanceExpression);
+                        AddInstruction(OpCode.SIGN);
+                        return true;
+                    }
+                case "System.Numerics.BigInteger.Pow(System.Numerics.BigInteger, int)":
+                    {
+                        if (arguments is not null)
+                            PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                        AddInstruction(OpCode.POW);
+                        return true;
+                    }
+                case "System.Numerics.BigInteger.ModPow(System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    {
+                        if (arguments is not null)
+                            PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                        AddInstruction(OpCode.MODPOW);
+                        return true;
+                    }
+                case "System.Numerics.BigInteger.Add(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.ADD);
+                    return true;
+                case "System.Numerics.BigInteger.Subtract(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.SUB);
+                    return true;
+                case "System.Numerics.BigInteger.Negate(System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.NEGATE);
+                    return true;
+                case "System.Numerics.BigInteger.Multiply(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.MUL);
+                    return true;
+                case "System.Numerics.BigInteger.Divide(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.DIV);
+                    return true;
+                case "System.Numerics.BigInteger.Remainder(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.MOD);
+                    return true;
+                case "System.Numerics.BigInteger.Compare(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.SUB);
+                    AddInstruction(OpCode.SIGN);
+                    return true;
+                case "System.Numerics.BigInteger.GreatestCommonDivisor(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    JumpTarget gcdTarget = new();
+                    gcdTarget.Instruction = AddInstruction(OpCode.DUP);
+                    AddInstruction(OpCode.REVERSE3);
+                    AddInstruction(OpCode.SWAP);
+                    AddInstruction(OpCode.MOD);
+                    AddInstruction(OpCode.DUP);
+                    AddInstruction(OpCode.PUSH0);
+                    AddInstruction(OpCode.NUMEQUAL);
+                    Jump(OpCode.JMPIFNOT, gcdTarget);
+                    AddInstruction(OpCode.DROP);
+                    AddInstruction(OpCode.ABS);
+                    return true;
+                case "System.Numerics.BigInteger.ToByteArray()":
+                    if (instanceExpression is not null)
+                        ConvertExpression(model, instanceExpression);
+                    ChangeType(VM.Types.StackItemType.Buffer);
+                    return true;
+                case "System.Numerics.BigInteger.explicit operator char(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, char.MinValue, char.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator sbyte(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, sbyte.MinValue, sbyte.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator byte(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, byte.MinValue, byte.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator short(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, short.MinValue, short.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator ushort(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, ushort.MinValue, ushort.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator int(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, int.MinValue, int.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator uint(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, uint.MinValue, uint.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator long(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, long.MinValue, long.MaxValue);
+                case "System.Numerics.BigInteger.explicit operator ulong(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, ulong.MinValue, ulong.MaxValue);
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(char)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(sbyte)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(byte)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(short)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(ushort)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(int)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(uint)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(long)":
+                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(ulong)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    return true;
+                case "System.Numerics.BigInteger.ToString()": return HandleToStringConversion(model, instanceExpression);
+                case "System.Numerics.BigInteger.Equals(long)":
+                case "System.Numerics.BigInteger.Equals(ulong)":
+                case "System.Numerics.BigInteger.Equals(System.Numerics.BigInteger)":
+                    if (instanceExpression is not null)
+                        ConvertExpression(model, instanceExpression);
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    AddInstruction(OpCode.NUMEQUAL);
+                    return true;
+                case "System.Numerics.BigInteger.Abs(System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    AddInstruction(OpCode.ABS);
+                    return true;
+                case "System.Numerics.BigInteger.Max(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    AddInstruction(OpCode.MAX);
+                    return true;
+                case "System.Numerics.BigInteger.Min(System.Numerics.BigInteger, System.Numerics.BigInteger)":
+                    if (arguments is not null)
+                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    AddInstruction(OpCode.MIN);
+                    return true;
+                case "System.Numerics.BigInteger.Parse(string)": return HandleParseConversion(model, symbol, arguments, null, null);
+                default:
+                    return false;
+            }
+        }
+
+        private bool HandleExplicitConversion(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode>? arguments, BigInteger minValue, BigInteger maxValue)
+        {
+            if (arguments is not null)
+                PrepareArgumentsForMethod(model, symbol, arguments);
+            JumpTarget endTarget = new();
+            AddInstruction(OpCode.DUP);
+            Push(minValue);
+            Push(maxValue + 1);
+            AddInstruction(OpCode.WITHIN);
+            Jump(OpCode.JMPIF, endTarget);
+            AddInstruction(OpCode.THROW);
+            endTarget.Instruction = AddInstruction(OpCode.NOP);
+            return true;
+        }
+
+        private bool HandleParseConversion(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode>? arguments, BigInteger? minValue, BigInteger? maxValue)
+        {
+            if (arguments is not null)
+                PrepareArgumentsForMethod(model, symbol, arguments);
+            Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+            if (minValue == null || maxValue == null) return true;
+            JumpTarget endTarget = new();
+            AddInstruction(OpCode.DUP);
+            Push(minValue);
+            Push(maxValue + 1);
+            AddInstruction(OpCode.WITHIN);
+            Jump(OpCode.JMPIF, endTarget);
+            AddInstruction(OpCode.THROW);
+            endTarget.Instruction = AddInstruction(OpCode.NOP);
+            return true;
+        }
+        #endregion
+    }
+
+}

--- a/src/Neo.Compiler.CSharp/MethodConvert.Integer.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.Integer.cs
@@ -41,8 +41,7 @@ namespace Neo.Compiler
 
         private bool HandleToStringConversion(SemanticModel model, ExpressionSyntax? instanceExpression)
         {
-            if (instanceExpression is not null)
-                ConvertExpression(model, instanceExpression);
+            ConvertExpression(model, instanceExpression);
             Call(NativeContract.StdLib.Hash, "itoa", 1, true);
             return true;
         }
@@ -56,92 +55,66 @@ namespace Neo.Compiler
                     Push(-1); return true;
                 case "System.Numerics.BigInteger.Zero.get": Push(0); return true;
                 case "System.Numerics.BigInteger.IsZero.get":
-                    {
-                        if (instanceExpression is not null)
-                            ConvertExpression(model, instanceExpression);
-                        Push(0);
-                        AddInstruction(OpCode.NUMEQUAL);
-                        return true;
-                    }
+                    ConvertExpression(model, instanceExpression);
+                    Push(0);
+                    AddInstruction(OpCode.NUMEQUAL);
+                    return true;
                 case "System.Numerics.BigInteger.IsOne.get":
-                    {
-                        if (instanceExpression is not null)
-                            ConvertExpression(model, instanceExpression);
-                        Push(1);
-                        AddInstruction(OpCode.NUMEQUAL);
-                        return true;
-                    }
+                    ConvertExpression(model, instanceExpression);
+                    Push(1);
+                    AddInstruction(OpCode.NUMEQUAL);
+                    return true;
                 case "System.Numerics.BigInteger.IsEven.get":
-                    {
-                        if (instanceExpression is not null)
-                            ConvertExpression(model, instanceExpression);
-                        Push(1);
-                        AddInstruction(OpCode.AND);
-                        Push(0);
-                        AddInstruction(OpCode.NUMEQUAL);
-                        return true;
-                    }
+                    ConvertExpression(model, instanceExpression);
+                    Push(1);
+                    AddInstruction(OpCode.AND);
+                    Push(0);
+                    AddInstruction(OpCode.NUMEQUAL);
+                    return true;
                 case "System.Numerics.BigInteger.Sign.get":
-                    {
-                        if (instanceExpression is not null)
-                            ConvertExpression(model, instanceExpression);
-                        AddInstruction(OpCode.SIGN);
-                        return true;
-                    }
+                    if (instanceExpression is not null)
+                        ConvertExpression(model, instanceExpression);
+                    AddInstruction(OpCode.SIGN);
+                    return true;
                 case "System.Numerics.BigInteger.Pow(System.Numerics.BigInteger, int)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                        AddInstruction(OpCode.POW);
-                        return true;
-                    }
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.POW);
+                    return true;
                 case "System.Numerics.BigInteger.ModPow(System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                        AddInstruction(OpCode.MODPOW);
-                        return true;
-                    }
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    AddInstruction(OpCode.MODPOW);
+                    return true;
                 case "System.Numerics.BigInteger.Add(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.ADD);
                     return true;
                 case "System.Numerics.BigInteger.Subtract(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.SUB);
                     return true;
                 case "System.Numerics.BigInteger.Negate(System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.NEGATE);
                     return true;
                 case "System.Numerics.BigInteger.Multiply(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.MUL);
                     return true;
                 case "System.Numerics.BigInteger.Divide(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.DIV);
                     return true;
                 case "System.Numerics.BigInteger.Remainder(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.MOD);
                     return true;
                 case "System.Numerics.BigInteger.Compare(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     AddInstruction(OpCode.SUB);
                     AddInstruction(OpCode.SIGN);
                     return true;
                 case "System.Numerics.BigInteger.GreatestCommonDivisor(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
+                    PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
                     JumpTarget gcdTarget = new();
                     gcdTarget.Instruction = AddInstruction(OpCode.DUP);
                     AddInstruction(OpCode.REVERSE3);
@@ -155,8 +128,7 @@ namespace Neo.Compiler
                     AddInstruction(OpCode.ABS);
                     return true;
                 case "System.Numerics.BigInteger.ToByteArray()":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
+                    ConvertExpression(model, instanceExpression);
                     ChangeType(VM.Types.StackItemType.Buffer);
                     return true;
                 case "System.Numerics.BigInteger.explicit operator char(System.Numerics.BigInteger)": return HandleExplicitConversion(model, symbol, arguments, char.MinValue, char.MaxValue);
@@ -177,32 +149,26 @@ namespace Neo.Compiler
                 case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(uint)":
                 case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(long)":
                 case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(ulong)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    PrepareArgumentsForMethod(model, symbol, arguments);
                     return true;
                 case "System.Numerics.BigInteger.ToString()": return HandleToStringConversion(model, instanceExpression);
                 case "System.Numerics.BigInteger.Equals(long)":
                 case "System.Numerics.BigInteger.Equals(ulong)":
                 case "System.Numerics.BigInteger.Equals(System.Numerics.BigInteger)":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    ConvertExpression(model, instanceExpression);
+                    PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.NUMEQUAL);
                     return true;
                 case "System.Numerics.BigInteger.Abs(System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.ABS);
                     return true;
                 case "System.Numerics.BigInteger.Max(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.MAX);
                     return true;
                 case "System.Numerics.BigInteger.Min(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
+                    PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.MIN);
                     return true;
                 case "System.Numerics.BigInteger.Parse(string)": return HandleParseConversion(model, symbol, arguments, null, null);
@@ -213,8 +179,7 @@ namespace Neo.Compiler
 
         private bool HandleExplicitConversion(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode>? arguments, BigInteger minValue, BigInteger maxValue)
         {
-            if (arguments is not null)
-                PrepareArgumentsForMethod(model, symbol, arguments);
+            PrepareArgumentsForMethod(model, symbol, arguments);
             JumpTarget endTarget = new();
             AddInstruction(OpCode.DUP);
             Push(minValue);
@@ -228,8 +193,7 @@ namespace Neo.Compiler
 
         private bool HandleParseConversion(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode>? arguments, BigInteger? minValue, BigInteger? maxValue)
         {
-            if (arguments is not null)
-                PrepareArgumentsForMethod(model, symbol, arguments);
+            PrepareArgumentsForMethod(model, symbol, arguments);
             Call(NativeContract.StdLib.Hash, "atoi", 1, true);
             if (minValue == null || maxValue == null) return true;
             JumpTarget endTarget = new();

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -25,6 +25,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.CommandLine;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -33,7 +34,7 @@ using System.Text;
 
 namespace Neo.Compiler
 {
-    class MethodConvert
+    partial class MethodConvert
     {
 
         #region Fields
@@ -4155,369 +4156,16 @@ namespace Neo.Compiler
             }
             switch (symbol.ToString())
             {
-                case "System.Numerics.BigInteger.One.get":
-                    Push(1);
-                    return true;
-                case "System.Numerics.BigInteger.MinusOne.get":
-                    Push(-1);
-                    return true;
-                case "System.Numerics.BigInteger.Zero.get":
-                    Push(0);
-                    return true;
-                case "System.Numerics.BigInteger.IsZero.get":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    Push(0);
-                    AddInstruction(OpCode.NUMEQUAL);
-                    return true;
-                case "System.Numerics.BigInteger.IsOne.get":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    Push(1);
-                    AddInstruction(OpCode.NUMEQUAL);
-                    return true;
-                case "System.Numerics.BigInteger.IsEven.get":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    Push(1);
-                    AddInstruction(OpCode.AND);
-                    Push(0);
-                    AddInstruction(OpCode.NUMEQUAL);
-                    return true;
-                case "System.Numerics.BigInteger.Sign.get":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    AddInstruction(OpCode.SIGN);
-                    return true;
-                case "System.Numerics.BigInteger.Pow(System.Numerics.BigInteger, int)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.POW);
-                    return true;
-                case "System.Numerics.BigInteger.ModPow(System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.MODPOW);
-                    return true;
-                case "System.Numerics.BigInteger.Add(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.ADD);
-                    return true;
-                case "System.Numerics.BigInteger.Subtract(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.SUB);
-                    return true;
-                case "System.Numerics.BigInteger.Negate(System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.NEGATE);
-                    return true;
-                case "System.Numerics.BigInteger.Multiply(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.MUL);
-                    return true;
-                case "System.Numerics.BigInteger.Divide(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.DIV);
-                    return true;
-                case "System.Numerics.BigInteger.Remainder(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    AddInstruction(OpCode.MOD);
-                    return true;
-                case "System.Numerics.BigInteger.Compare(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    // if left < right return -1;
-                    // if left = right return 0;
-                    // if left > right return 1;
-                    AddInstruction(OpCode.SUB);
-                    AddInstruction(OpCode.SIGN);
-                    return true;
-                case "System.Numerics.BigInteger.GreatestCommonDivisor(System.Numerics.BigInteger, System.Numerics.BigInteger)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
-                    JumpTarget gcdTarget = new();
-                    gcdTarget.Instruction = AddInstruction(OpCode.DUP);
-                    AddInstruction(OpCode.REVERSE3);
-                    AddInstruction(OpCode.SWAP);
-                    AddInstruction(OpCode.MOD);
-                    AddInstruction(OpCode.DUP);
-                    AddInstruction(OpCode.PUSH0);
-                    AddInstruction(OpCode.NUMEQUAL);
-                    Jump(OpCode.JMPIFNOT, gcdTarget);
-                    AddInstruction(OpCode.DROP);
-                    AddInstruction(OpCode.ABS);
-                    return true;
-                case "System.Numerics.BigInteger.ToByteArray()":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    ChangeType(VM.Types.StackItemType.Buffer);
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator sbyte(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(sbyte.MinValue);
-                        Push(sbyte.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator byte(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(byte.MinValue);
-                        Push(byte.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator short(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(short.MinValue);
-                        Push(short.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator ushort(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(ushort.MinValue);
-                        Push(ushort.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator int(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(int.MinValue);
-                        Push(new BigInteger(int.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator uint(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(uint.MinValue);
-                        Push(new BigInteger(uint.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator long(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(long.MinValue);
-                        Push(new BigInteger(long.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.explicit operator ulong(System.Numerics.BigInteger)":
-                    {
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        JumpTarget endTarget = new();
-                        AddInstruction(OpCode.DUP);
-                        Push(ulong.MinValue);
-                        Push(new BigInteger(ulong.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(char)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(sbyte)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(byte)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(short)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(ushort)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(int)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(uint)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(long)":
-                case "System.Numerics.BigInteger.implicit operator System.Numerics.BigInteger(ulong)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
-                    return true;
                 case "System.Array.Length.get":
                 case "string.Length.get":
                     if (instanceExpression is not null)
                         ConvertExpression(model, instanceExpression);
                     AddInstruction(OpCode.SIZE);
                     return true;
-                case "sbyte.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(sbyte.MinValue);
-                        Push(sbyte.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "byte.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(byte.MinValue);
-                        Push(byte.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "short.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(short.MinValue);
-                        Push(short.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "ushort.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(ushort.MinValue);
-                        Push(ushort.MaxValue + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "int.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(int.MinValue);
-                        Push(new BigInteger(int.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "uint.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(uint.MinValue);
-                        Push(new BigInteger(uint.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "long.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(long.MinValue);
-                        Push(new BigInteger(long.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "ulong.Parse(string)":
-                    {
-                        JumpTarget endTarget = new();
-                        if (arguments is not null)
-                            PrepareArgumentsForMethod(model, symbol, arguments);
-                        Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                        AddInstruction(OpCode.DUP);
-                        Push(ulong.MinValue);
-                        Push(new BigInteger(ulong.MaxValue) + 1);
-                        AddInstruction(OpCode.WITHIN);
-                        Jump(OpCode.JMPIF, endTarget);
-                        AddInstruction(OpCode.THROW);
-                        endTarget.Instruction = AddInstruction(OpCode.NOP);
-                    }
-                    return true;
-                case "System.Numerics.BigInteger.Parse(string)":
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
-                    return true;
                 case "System.Math.Abs(sbyte)":
                 case "System.Math.Abs(short)":
                 case "System.Math.Abs(int)":
                 case "System.Math.Abs(long)":
-                case "System.Numerics.BigInteger.Abs(System.Numerics.BigInteger)":
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.ABS);
@@ -4538,7 +4186,6 @@ namespace Neo.Compiler
                 case "System.Math.Max(uint, uint)":
                 case "System.Math.Max(long, long)":
                 case "System.Math.Max(ulong, ulong)":
-                case "System.Numerics.BigInteger.Max(System.Numerics.BigInteger, System.Numerics.BigInteger)":
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.MAX);
@@ -4551,7 +4198,6 @@ namespace Neo.Compiler
                 case "System.Math.Min(uint, uint)":
                 case "System.Math.Min(long, long)":
                 case "System.Math.Min(ulong, ulong)":
-                case "System.Numerics.BigInteger.Min(System.Numerics.BigInteger, System.Numerics.BigInteger)":
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
                     AddInstruction(OpCode.MIN);
@@ -4567,28 +4213,6 @@ namespace Neo.Compiler
                         trueTarget.Instruction = Push("True");
                         endTarget.Instruction = AddInstruction(OpCode.NOP);
                     }
-                    return true;
-                case "sbyte.ToString()":
-                case "byte.ToString()":
-                case "short.ToString()":
-                case "ushort.ToString()":
-                case "int.ToString()":
-                case "uint.ToString()":
-                case "long.ToString()":
-                case "ulong.ToString()":
-                case "System.Numerics.BigInteger.ToString()":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    Call(NativeContract.StdLib.Hash, "itoa", 1, true);
-                    return true;
-                case "System.Numerics.BigInteger.Equals(long)":
-                case "System.Numerics.BigInteger.Equals(ulong)":
-                case "System.Numerics.BigInteger.Equals(System.Numerics.BigInteger)":
-                    if (instanceExpression is not null)
-                        ConvertExpression(model, instanceExpression);
-                    if (arguments is not null)
-                        PrepareArgumentsForMethod(model, symbol, arguments);
-                    AddInstruction(OpCode.NUMEQUAL);
                     return true;
                 case "object.Equals(object?)":
                 case "string.Equals(string?)":
@@ -4624,7 +4248,7 @@ namespace Neo.Compiler
                     AddInstruction(OpCode.SUBSTR);
                     return true;
                 default:
-                    return false;
+                    return HandleIntegerConversion(model, symbol, instanceExpression, arguments);
             }
         }
 

--- a/src/Neo.Compiler.CSharp/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert.cs
@@ -1399,8 +1399,9 @@ namespace Neo.Compiler
 
         #region ConvertExpression
 
-        private void ConvertExpression(SemanticModel model, ExpressionSyntax syntax)
+        private void ConvertExpression(SemanticModel model, ExpressionSyntax? syntax)
         {
+            if (syntax is null) return;
             Optional<object?> constant = model.GetConstantValue(syntax);
             if (constant.HasValue)
             {
@@ -4057,8 +4058,9 @@ namespace Neo.Compiler
             return true;
         }
 
-        private void PrepareArgumentsForMethod(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode> arguments, CallingConvention callingConvention = CallingConvention.Cdecl)
+        private void PrepareArgumentsForMethod(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode>? arguments, CallingConvention callingConvention = CallingConvention.Cdecl)
         {
+            if (arguments == null) return;
             var namedArguments = arguments.OfType<ArgumentSyntax>().Where(p => p.NameColon is not null).Select(p => (Symbol: (IParameterSymbol)model.GetSymbolInfo(p.NameColon!.Name).Symbol!, p.Expression)).ToDictionary(p => p.Symbol, p => p.Expression, (IEqualityComparer<IParameterSymbol>)SymbolEqualityComparer.Default);
             IEnumerable<IParameterSymbol> parameters = symbol.Parameters;
             if (callingConvention == CallingConvention.Cdecl)

--- a/src/Neo.SmartContract.Framework/BigInteger.cs
+++ b/src/Neo.SmartContract.Framework/BigInteger.cs
@@ -1,0 +1,6 @@
+namespace Neo.SmartContract.Framework;
+
+public class BigInteger
+{
+    
+}

--- a/src/Neo.SmartContract.Framework/BigInteger.cs
+++ b/src/Neo.SmartContract.Framework/BigInteger.cs
@@ -1,6 +1,0 @@
-namespace Neo.SmartContract.Framework;
-
-public class BigInteger
-{
-    
-}


### PR DESCRIPTION
This pr trys to shrink the size of the methodconvert.

This pr saves 400 lines of code in methodconvert.

1. reuse the existing code. 
3. move all integer system methods into MerhodConvert.Integer