### PR TITLE
add comments to statements

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
@@ -731,62 +731,101 @@ namespace Neo.Compiler
         {
             switch (statement)
             {
+                // Converts a block statement, which is a series of statements enclosed in braces.
+                // Example: { int x = 1; Console.WriteLine(x); }
                 case BlockSyntax syntax:
                     ConvertBlockStatement(model, syntax);
                     break;
+                // Converts a break statement, typically used within loops or switch cases.
+                // Example: break;
                 case BreakStatementSyntax syntax:
                     ConvertBreakStatement(syntax);
                     break;
+                // Converts a checked statement, used for arithmetic operations with overflow checking.
+                // Example: checked { int x = int.MaxValue; }
                 case CheckedStatementSyntax syntax:
                     ConvertCheckedStatement(model, syntax);
                     break;
+                // Converts a continue statement, used to skip the current iteration of a loop.
+                // Example: continue;
                 case ContinueStatementSyntax syntax:
                     ConvertContinueStatement(syntax);
                     break;
+                // Converts a do-while loop statement.
+                // Example: do { /* actions */ } while (condition);
                 case DoStatementSyntax syntax:
                     ConvertDoStatement(model, syntax);
                     break;
+                // Converts an empty statement, which is typically just a standalone semicolon.
+                // Example: ;
                 case EmptyStatementSyntax syntax:
                     ConvertEmptyStatement(syntax);
                     break;
+                // Converts an expression statement, which is a statement consisting of a single expression.
+                // Example: Console.WriteLine("Hello");
                 case ExpressionStatementSyntax syntax:
                     ConvertExpressionStatement(model, syntax);
                     break;
+                // Converts a foreach loop statement.
+                // Example: foreach (var item in collection) { /* actions */ }
                 case ForEachStatementSyntax syntax:
                     ConvertForEachStatement(model, syntax);
                     break;
+                // Converts a foreach loop statement with variable declarations.
+                // Example: foreach (var (key, value) in dictionary) { /* actions */ }
                 case ForEachVariableStatementSyntax syntax:
                     ConvertForEachVariableStatement(model, syntax);
                     break;
+                // Converts a for loop statement.
+                // Example: for (int i = 0; i < 10; i++) { /* actions */ }
                 case ForStatementSyntax syntax:
                     ConvertForStatement(model, syntax);
                     break;
+                // Converts a goto statement, used for jumping to a labeled statement.
+                // Example: goto myLabel;
                 case GotoStatementSyntax syntax:
                     ConvertGotoStatement(model, syntax);
                     break;
+                // Converts an if statement, including any else or else if branches.
+                // Example: if (condition) { /* actions */ } else { /* actions */ }
                 case IfStatementSyntax syntax:
                     ConvertIfStatement(model, syntax);
                     break;
+                // Converts a labeled statement, used as a target for goto statements.
+                // Example: myLabel: /* actions */
                 case LabeledStatementSyntax syntax:
                     ConvertLabeledStatement(model, syntax);
                     break;
+                // Converts a local variable declaration statement.
+                // Example: int x = 5;
                 case LocalDeclarationStatementSyntax syntax:
                     ConvertLocalDeclarationStatement(model, syntax);
                     break;
+                // Currently, local function statements are not supported in this context.
                 case LocalFunctionStatementSyntax:
                     break;
+                // Converts a return statement, used to exit a method and optionally return a value.
+                // Example: return x + y;
                 case ReturnStatementSyntax syntax:
                     ConvertReturnStatement(model, syntax);
                     break;
+                // Converts a switch statement, including its cases and default case.
+                // Example: switch (variable) { case 1: /* actions */ break; default: /* actions */
                 case SwitchStatementSyntax syntax:
                     ConvertSwitchStatement(model, syntax);
                     break;
+                // Converts a throw statement, used for exception handling.
+                // Example: throw new Exception("Error");
                 case ThrowStatementSyntax syntax:
                     ConvertThrowStatement(model, syntax);
                     break;
+                // Converts a try-catch-finally statement, used for exception handling.
+                // Example: try { /* actions */ } catch (Exception e) { /* actions */ } finally { /* actions */ }
                 case TryStatementSyntax syntax:
                     ConvertTryStatement(model, syntax);
                     break;
+                // Converts a while loop statement.
+                // Example: while (condition) { /* actions */ }
                 case WhileStatementSyntax syntax:
                     ConvertWhileStatement(model, syntax);
                     break;

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/BlockStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/BlockStatement.cs
@@ -17,6 +17,31 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+        /// <summary>
+        /// Converts a block statement to a sequence of instructions. This method is used for parsing
+        /// the syntax of block statements within the context of a semantic model. A block statement
+        /// typically consists of a series of statements enclosed in braces `{}`.
+        /// </summary>
+        /// <param name="model">The semantic model that provides information about the block statement.</param>
+        /// <param name="syntax">The syntax of the block statement to be converted.</param>
+        /// <remarks>
+        /// This method starts by initializing a new list of local symbols for the current block.
+        /// It then iterates through each statement within the block, converting each to the appropriate
+        /// set of instructions. Local symbols are tracked and removed once the block is fully converted.
+        /// </remarks>
+        /// <example>
+        /// Here is an example of a block statement syntax:
+        ///
+        /// <code>
+        /// {
+        ///     string x = "Hello world.";
+        ///     Runtime.Log(x);
+        /// }
+        /// </code>
+        ///
+        /// In this example, the block contains two statements: a variable declaration and
+        /// a method call.
+        /// </example>
         private void ConvertBlockStatement(SemanticModel model, BlockSyntax syntax)
         {
             _blockSymbols.Push(new List<ILocalSymbol>());
@@ -29,5 +54,6 @@ namespace Neo.Compiler
             foreach (ILocalSymbol symbol in _blockSymbols.Pop())
                 RemoveLocalVariable(symbol);
         }
+
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/BlockStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/BlockStatement.cs
@@ -54,6 +54,5 @@ namespace Neo.Compiler
             foreach (ILocalSymbol symbol in _blockSymbols.Pop())
                 RemoveLocalVariable(symbol);
         }
-
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/BreakStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/BreakStatement.cs
@@ -15,6 +15,32 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+        /// <summary>
+        /// Converts a break statement into the corresponding jump instruction. This method handles
+        /// the parsing and translation of a break statement within loop or switch constructs, converting
+        /// it to an appropriate jump instruction in the neo vm language.
+        /// </summary>
+        /// <param name="syntax">The syntax of the break statement to be converted.</param>
+        /// <remarks>
+        /// This method determines the target of the break statement based on the current context. If the
+        /// break statement is within a try block with no specific break target, it generates an `ENDTRY_L`
+        /// jump instruction to exit the try block. Otherwise, it generates a `JMP_L` instruction to jump
+        /// to the standard break target. This ensures that break statements behave correctly in both
+        /// normal loops/switches and those within try-catch blocks.
+        /// </remarks>
+        /// <example>
+        /// An example of a break statement syntax in a loop:
+        ///
+        /// <code>
+        /// for (int i = 0; i < 10; i++)
+        /// {
+        ///     if (i == 5)
+        ///         break;
+        /// }
+        /// </code>
+        ///
+        /// In this example, the break statement exits the loop when `i` equals 5.
+        /// </example>
         private void ConvertBreakStatement(BreakStatementSyntax syntax)
         {
             using (InsertSequencePoint(syntax))

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/CheckedStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/CheckedStatement.cs
@@ -16,6 +16,34 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+        /// <summary>
+        /// Converts a checked statement to the corresponding operations. This method is used for parsing
+        /// the syntax of checked statements within the context of a semantic model. Checked statements
+        /// in C# are used to explicitly enable overflow checking for arithmetic operations and conversions.
+        /// </summary>
+        /// <param name="model">The semantic model that provides information about the checked statement.</param>
+        /// <param name="syntax">The syntax of the checked statement to be converted.</param>
+        /// <remarks>
+        /// This method begins by pushing the current state (checked or unchecked) onto a stack to keep
+        /// track of the context. It then processes the block of code within the checked statement.
+        /// After the block is processed, the previous state is restored by popping from the stack.
+        /// This ensures that arithmetic operations within the block are correctly handled according
+        /// to the overflow checking rules specified by the checked statement.
+        /// </remarks>
+        /// <example>
+        /// Here is an example of a checked statement syntax:
+        ///
+        /// <code>
+        /// checked
+        /// {
+        ///     int x = int.MaxValue;
+        ///     int y = x + 1; // This will cause an overflow exception
+        /// }
+        /// </code>
+        ///
+        /// In this example, arithmetic operations inside the checked block are performed with
+        /// overflow checking enabled.
+        /// </example>
         private void ConvertCheckedStatement(SemanticModel model, CheckedStatementSyntax syntax)
         {
             _checkedStack.Push(syntax.Keyword.IsKind(SyntaxKind.CheckedKeyword));

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/CommonForEachStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/CommonForEachStatement.cs
@@ -19,6 +19,22 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+        /// <summary>
+        /// Converts a 'foreach' statement based on the type of the collection being iterated over.
+        /// It delegates to 'ConvertIteratorForEachStatement' for iterators, and
+        /// 'ConvertArrayForEachStatement' for arrays.
+        /// </summary>
+        /// <param name="model">The semantic model providing context for the 'foreach' statement.</param>
+        /// <param name="syntax">The syntax of the 'foreach' statement.</param>
+        /// <example>
+        /// Example of 'foreach' statement syntax:
+        /// <code>
+        /// foreach (var item in collection)
+        /// {
+        ///     // Processing each item
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertForEachStatement(SemanticModel model, ForEachStatementSyntax syntax)
         {
             ITypeSymbol type = model.GetTypeInfo(syntax.Expression).Type!;
@@ -32,6 +48,21 @@ namespace Neo.Compiler
             }
         }
 
+        /// <summary>
+        /// Converts a 'foreach' statement that iterates over an iterator, handling control flow and
+        /// iterator management.
+        /// </summary>
+        /// <param name="model">The semantic model.</param>
+        /// <param name="syntax">The syntax of the 'foreach' statement.</param>
+        /// <example>
+        /// Example of 'foreach' over an iterator:
+        /// <code>
+        /// foreach (var item in iterator)
+        /// {
+        ///     // Processing each item
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertIteratorForEachStatement(SemanticModel model, ForEachStatementSyntax syntax)
         {
             ILocalSymbol elementSymbol = model.GetDeclaredSymbol(syntax)!;
@@ -68,6 +99,21 @@ namespace Neo.Compiler
             PopBreakTarget();
         }
 
+        /// <summary>
+        /// Converts a 'foreach' statement with variable declarations, determining the conversion
+        /// method based on the collection type.
+        /// </summary>
+        /// <param name="model">The semantic model.</param>
+        /// <param name="syntax">The syntax of the 'foreach' variable statement.</param>
+        /// <example>
+        /// Example of 'foreach' with variable declaration:
+        /// <code>
+        /// foreach (var (key, value) in dictionary)
+        /// {
+        ///     // Processing each key and value pair
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertForEachVariableStatement(SemanticModel model, ForEachVariableStatementSyntax syntax)
         {
             ITypeSymbol type = model.GetTypeInfo(syntax.Expression).Type!;
@@ -81,6 +127,21 @@ namespace Neo.Compiler
             }
         }
 
+        /// <summary>
+        /// Converts a 'foreach' statement (with variable declarations) that iterates over an iterator,
+        /// handling the unpacking of values into variables and managing loop control flow.
+        /// </summary>
+        /// <param name="model">The semantic model.</param>
+        /// <param name="syntax">The syntax of the 'foreach' variable statement.</param>
+        /// <example>
+        /// Example of 'foreach' over an iterator with variable declaration:
+        /// <code>
+        /// foreach (var (key, value) in iterator)
+        /// {
+        ///     // Processing each key and value
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertIteratorForEachVariableStatement(SemanticModel model, ForEachVariableStatementSyntax syntax)
         {
             ILocalSymbol[] symbols = ((ParenthesizedVariableDesignationSyntax)((DeclarationExpressionSyntax)syntax.Variable).Designation).Variables.Select(p => (ILocalSymbol)model.GetDeclaredSymbol(p)!).ToArray();
@@ -131,6 +192,21 @@ namespace Neo.Compiler
             PopBreakTarget();
         }
 
+        /// <summary>
+        /// Converts a 'foreach' statement that iterates over an array, managing array indices and
+        /// loop control flow.
+        /// </summary>
+        /// <param name="model">The semantic model.</param>
+        /// <param name="syntax">The syntax of the 'foreach' statement.</param>
+        /// <example>
+        /// Example of 'foreach' over an array:
+        /// <code>
+        /// foreach (var item in array)
+        /// {
+        ///     // Processing each array item
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertArrayForEachStatement(SemanticModel model, ForEachStatementSyntax syntax)
         {
             ILocalSymbol elementSymbol = model.GetDeclaredSymbol(syntax)!;
@@ -180,6 +256,22 @@ namespace Neo.Compiler
             PopContinueTarget();
             PopBreakTarget();
         }
+
+        /// <summary>
+        /// Converts a 'foreach' statement (with variable declarations) that iterates over an array,
+        /// including logic for unpacking array elements into variables.
+        /// </summary>
+        /// <param name="model">The semantic model.</param>
+        /// <param name="syntax">The syntax of the 'foreach' variable statement.</param>
+        /// <example>
+        /// Example of 'foreach' over an array with variable declaration:
+        /// <code>
+        /// foreach (var (first, second) in arrayOfPairs)
+        /// {
+        ///     // Processing each pair of elements
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertArrayForEachVariableStatement(SemanticModel model, ForEachVariableStatementSyntax syntax)
         {
             ILocalSymbol[] symbols = ((ParenthesizedVariableDesignationSyntax)((DeclarationExpressionSyntax)syntax.Variable).Designation).Variables.Select(p => (ILocalSymbol)model.GetDeclaredSymbol(p)!).ToArray();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ContinueStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ContinueStatement.cs
@@ -15,6 +15,31 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'continue' statement into a corresponding jump instruction in the intermediate language.
+        /// This method handles the conversion of the 'continue' keyword within loops, particularly
+        /// considering its behavior in try-catch blocks.
+        /// </summary>
+        /// <param name="syntax">The syntax representation of the 'continue' statement being converted.</param>
+        /// <remarks>
+        /// The method checks if the 'continue' statement is within a try-catch block. If it is and the
+        /// continue target count is zero, it generates an `ENDTRY_L` opcode to properly handle the loop
+        /// continuation within the try block. Otherwise, a standard jump (`JMP_L`) is used to continue
+        /// the loop.
+        /// </remarks>
+        /// <example>
+        /// Example of a 'continue' statement in a loop:
+        /// <code>
+        /// for (int i = 0; i < 10; i++)
+        /// {
+        ///     if (i % 2 == 0)
+        ///         continue; // Skips the current iteration for even numbers
+        ///     // Other processing
+        /// }
+        /// </code>
+        /// In this example, 'continue' is used to skip the current iteration for even values of 'i'.
+        /// </example>
         private void ConvertContinueStatement(ContinueStatementSyntax syntax)
         {
             using (InsertSequencePoint(syntax))

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ContinueStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ContinueStatement.cs
@@ -15,7 +15,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'continue' statement into a corresponding jump instruction in the intermediate language.
         /// This method handles the conversion of the 'continue' keyword within loops, particularly

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/DoStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/DoStatement.cs
@@ -16,6 +16,32 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'do-while' loop statement into a corresponding set of instructions.
+        /// This method handles the parsing and translation of the 'do-while' loop construct,
+        /// creating the necessary control flow for the loop's execution.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the 'do-while' statement.</param>
+        /// <param name="syntax">The syntax representation of the 'do-while' statement being converted.</param>
+        /// <remarks>
+        /// The method sets up jump targets for the start, continue, and break points of the loop.
+        /// It then converts the loop's statement body and condition. The loop continues if the condition
+        /// is true, jumping back to the start. If the condition is false, the loop exits, and the control
+        /// flow moves to the break target.
+        /// </remarks>
+        /// <example>
+        /// Example of a 'do-while' loop syntax:
+        /// <code>
+        /// do
+        /// {
+        ///     // Loop body
+        /// }
+        /// while (condition);
+        /// </code>
+        /// This example shows a 'do-while' loop where the loop body is executed at least once
+        /// before evaluating the condition.
+        /// </example>
         private void ConvertDoStatement(SemanticModel model, DoStatementSyntax syntax)
         {
             JumpTarget startTarget = new();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/DoStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/DoStatement.cs
@@ -16,7 +16,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'do-while' loop statement into a corresponding set of instructions.
         /// This method handles the parsing and translation of the 'do-while' loop construct,

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/EmptyStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/EmptyStatement.cs
@@ -15,6 +15,24 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+        /// <summary>
+        /// Converts an empty statement into a OpCode.NOP instruction.
+        /// This method is used for handling empty statements in the code, which have no effect on the program execution.
+        /// </summary>
+        /// <param name="syntax">The syntax representation of the empty statement being converted.</param>
+        /// <remarks>
+        /// An empty statement in programming is typically represented by a standalone semicolon (;).
+        /// This method inserts a NOP (no-operation) instruction for such statements,
+        /// which effectively means 'do nothing'. This is useful in scenarios where the syntax requires
+        /// a statement but the logic does not require any action.
+        /// </remarks>
+        /// <example>
+        /// Example of an empty statement syntax:
+        /// <code>
+        /// ;
+        /// </code>
+        /// In this example, the semicolon represents an empty statement, requiring no action.
+        /// </example>
         private void ConvertEmptyStatement(EmptyStatementSyntax syntax)
         {
             using (InsertSequencePoint(syntax))

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ExpressionStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ExpressionStatement.cs
@@ -17,7 +17,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts an expression statement into a sequence of instructions.
         /// This method handles the translation of a given expression within a statement,

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ExpressionStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ExpressionStatement.cs
@@ -17,6 +17,28 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts an expression statement into a sequence of instructions.
+        /// This method handles the translation of a given expression within a statement,
+        /// considering the type of the expression to determine the necessary instructions.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the expression.</param>
+        /// <param name="syntax">The syntax representation of the expression statement being converted.</param>
+        /// <remarks>
+        /// The method evaluates the type of the expression to decide if a 'DROP' instruction
+        /// is needed. This is particularly important for expressions that leave a value on the stack,
+        /// which might not be needed. For example, a method call that returns a value but
+        /// whose return value is not used in the surrounding code.
+        /// </remarks>
+        /// <example>
+        /// Example of an expression statement syntax:
+        /// <code>
+        /// CalculateSum(10, 20);
+        /// </code>
+        /// In this example, the expression is a method call to 'CalculateSum'.
+        /// If 'CalculateSum' returns a value and it is not used, a 'DROP' instruction will be added.
+        /// </example>
         private void ConvertExpressionStatement(SemanticModel model, ExpressionStatementSyntax syntax)
         {
             ITypeSymbol type = model.GetTypeInfo(syntax.Expression).Type!;

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ForStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ForStatement.cs
@@ -18,7 +18,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'for' loop statement into a sequence of instructions. This method handles the parsing
         /// and translation of the 'for' loop construct, including its initialization, condition, and

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ForStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ForStatement.cs
@@ -18,6 +18,32 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'for' loop statement into a sequence of instructions. This method handles the parsing
+        /// and translation of the 'for' loop construct, including its initialization, condition, and
+        /// increment expressions, as well as the loop body.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the 'for' loop statement.</param>
+        /// <param name="syntax">The syntax representation of the 'for' loop statement being converted.</param>
+        /// <remarks>
+        /// The method starts by handling variable declarations and initializations. It then sets up
+        /// jump targets for managing the loop's control flow: start, continue, condition, and break.
+        /// The loop's body, condition, and increment expressions are then converted into appropriate
+        /// instructions. The method also ensures any non-void expressions that leave a value on the stack
+        /// are appropriately dropped.
+        /// </remarks>
+        /// <example>
+        /// Example of a 'for' loop syntax:
+        /// <code>
+        /// for (int i = 0; i < 10; i++)
+        /// {
+        ///     // Loop body
+        /// }
+        /// </code>
+        /// This example shows a 'for' loop where 'i' is initialized to 0, the loop continues as long
+        /// as 'i' is less than 10, and 'i' is incremented by 1 after each iteration.
+        /// </example>
         private void ConvertForStatement(SemanticModel model, ForStatementSyntax syntax)
         {
             var variables = (syntax.Declaration?.Variables ?? Enumerable.Empty<VariableDeclaratorSyntax>())

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/GotoStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/GotoStatement.cs
@@ -18,6 +18,43 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'goto' statement into a jump instruction. This method handles both simple
+        /// 'goto' statements and those used in the context of a switch statement, including 'goto case'
+        /// and 'goto default'.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the 'goto' statement.</param>
+        /// <param name="syntax">The syntax representation of the 'goto' statement being converted.</param>
+        /// <remarks>
+        /// For a standard 'goto', it finds the target label and adds a jump instruction to it. In
+        /// a switch statement, it identifies the correct case or default label to jump to based on
+        /// the provided expression. The method also handles jumps out of 'try' blocks by adding
+        /// necessary instructions to maintain valid control flow.
+        /// </remarks>
+        /// <example>
+        /// Example of a 'goto' statement syntax:
+        /// <code>
+        /// goto myLabel;
+        /// myLabel:
+        ///     // Code to execute after the jump
+        /// </code>
+        /// Example of 'goto case' in a switch statement:
+        /// <code>
+        /// switch (value)
+        /// {
+        ///     case 1:
+        ///         // ...
+        ///         goto case 2;
+        ///     case 2:
+        ///         // ...
+        ///         break;
+        ///     default:
+        ///         // ...
+        ///         goto default;
+        /// }
+        /// </code>
+        /// </example>
         private void ConvertGotoStatement(SemanticModel model, GotoStatementSyntax syntax)
         {
             using (InsertSequencePoint(syntax))

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/GotoStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/GotoStatement.cs
@@ -18,7 +18,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'goto' statement into a jump instruction. This method handles both simple
         /// 'goto' statements and those used in the context of a switch statement, including 'goto case'

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/IfStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/IfStatement.cs
@@ -16,6 +16,34 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+        /// <summary>
+        /// Converts an 'if' statement into a series of jump instructions and conditional logic.
+        /// This method handles the translation of the 'if' condition and its corresponding 'else'
+        /// branch (if present) into executable instructions.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the 'if' statement.</param>
+        /// <param name="syntax">The syntax representation of the 'if' statement being converted.</param>
+        /// <remarks>
+        /// The method first evaluates the condition of the 'if' statement. Based on the condition,
+        /// it either executes the 'if' block or jumps to the 'else' block (if it exists). In the case
+        /// of an 'else if' chain, this logic is applied recursively. The method adds appropriate jump
+        /// instructions to ensure correct control flow between the 'if' and 'else' blocks.
+        /// </remarks>
+        /// <example>
+        /// Example of an 'if-else' statement syntax:
+        /// <code>
+        /// if (condition)
+        /// {
+        ///     // Code to execute if the condition is true
+        /// }
+        /// else
+        /// {
+        ///     // Code to execute if the condition is false
+        /// }
+        /// </code>
+        /// This example shows an 'if' statement with a corresponding 'else' block. Depending on
+        /// the evaluation of 'condition', either the 'if' block or the 'else' block will be executed.
+        /// </example>
         private void ConvertIfStatement(SemanticModel model, IfStatementSyntax syntax)
         {
             JumpTarget elseTarget = new();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/LabeledStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/LabeledStatement.cs
@@ -17,6 +17,31 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a labeled statement into a jump target and its associated instructions.
+        /// This method is used for handling labeled statements, creating a target for 'goto' statements
+        /// to jump to and processing the subsequent statement after the label.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the labeled statement.</param>
+        /// <param name="syntax">The syntax representation of the labeled statement being converted.</param>
+        /// <remarks>
+        /// The method first declares a new jump target for the label. If the label is referenced in
+        /// any pending 'goto' statements within a try block, it updates those 'goto' instructions
+        /// to jump to the newly created label. Then, it converts the statement following the label.
+        /// This is essential in implementing the label and goto mechanism found in many programming languages.
+        /// </remarks>
+        /// <example>
+        /// Example of a labeled statement syntax:
+        /// <code>
+        /// myLabel:
+        ///     // Code to execute after jumping to this label
+        ///
+        /// // Elsewhere in the code
+        /// goto myLabel;
+        /// </code>
+        /// This example shows a labeled statement 'myLabel' and a 'goto' statement that jumps to it.
+        /// </example>
         private void ConvertLabeledStatement(SemanticModel model, LabeledStatementSyntax syntax)
         {
             ILabelSymbol symbol = model.GetDeclaredSymbol(syntax)!;

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/LabeledStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/LabeledStatement.cs
@@ -17,7 +17,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a labeled statement into a jump target and its associated instructions.
         /// This method is used for handling labeled statements, creating a target for 'goto' statements

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/LocalDeclarationStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/LocalDeclarationStatement.cs
@@ -17,6 +17,27 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a local variable declaration statement into a series of instructions.
+        /// This method is used for processing variable declarations, excluding those marked as 'const'.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the local declaration statement.</param>
+        /// <param name="syntax">The syntax representation of the local declaration statement being converted.</param>
+        /// <remarks>
+        /// For each variable in the declaration, the method checks if it has an initializer. If it does,
+        /// the method converts the initializer expression and stores the result in the newly declared
+        /// variable. This process involves adding a local variable to the current context and
+        /// generating the necessary instructions to initialize it. Constants are not processed by this method.
+        /// </remarks>
+        /// <example>
+        /// Example of a local variable declaration statement syntax:
+        /// <code>
+        /// int x = 5;
+        /// long y;
+        /// </code>
+        /// In this example, 'x' is initialized with the value 5, while 'y' is declared without an initializer.
+        /// </example>
         private void ConvertLocalDeclarationStatement(SemanticModel model, LocalDeclarationStatementSyntax syntax)
         {
             if (syntax.IsConst) return;

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/LocalDeclarationStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/LocalDeclarationStatement.cs
@@ -17,7 +17,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a local variable declaration statement into a series of instructions.
         /// This method is used for processing variable declarations, excluding those marked as 'const'.

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ReturnStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ReturnStatement.cs
@@ -16,7 +16,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'return' statement into the corresponding jump instructions.
         /// This method handles the conversion of return statements, including those with a return value,

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ReturnStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ReturnStatement.cs
@@ -16,6 +16,28 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'return' statement into the corresponding jump instructions.
+        /// This method handles the conversion of return statements, including those with a return value,
+        /// within the context of try blocks and normal execution flow.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the return statement.</param>
+        /// <param name="syntax">The syntax representation of the return statement being converted.</param>
+        /// <remarks>
+        /// If the return statement includes an expression, the method converts this expression.
+        /// Depending on whether the return is within a try block, it generates different jump
+        /// instructions to handle the control flow properly. This ensures that the function exits
+        /// correctly, either by leaving the try block first or by jumping directly to the return target.
+        /// </remarks>
+        /// <example>
+        /// Example of a return statement syntax:
+        /// <code>
+        /// return x + y;
+        /// </code>
+        /// In this example, the method will convert the expression 'x + y' and then jump to
+        /// the return target, handling any try block logic if necessary.
+        /// </example>
         private void ConvertReturnStatement(SemanticModel model, ReturnStatementSyntax syntax)
         {
             using (InsertSequencePoint(syntax))

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/SwitchStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/SwitchStatement.cs
@@ -17,6 +17,39 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'switch' statement into a set of conditional jump instructions and targets.
+        /// This method handles the translation of 'switch' statements, including various forms of
+        /// case labels (like pattern matching cases and default cases) into executable instructions.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the switch statement.</param>
+        /// <param name="syntax">The syntax representation of the switch statement being converted.</param>
+        /// <remarks>
+        /// The method first evaluates the switch expression and then iterates over the different cases,
+        /// generating conditional jumps based on the case labels. It supports pattern matching,
+        /// value comparison, and default cases. The method ensures the correct control flow between
+        /// different cases and handles the 'break' statement logic for exiting the switch.
+        /// </remarks>
+        /// <example>
+        /// Example of a switch statement syntax:
+        /// <code>
+        /// switch (expression)
+        /// {
+        ///     case 1:
+        ///         // Code for case 1
+        ///         break;
+        ///     case 2 when condition:
+        ///         // Code for case 2 with condition
+        ///         break;
+        ///     default:
+        ///         // Default case code
+        ///         break;
+        /// }
+        /// </code>
+        /// In this example, the switch statement includes different case scenarios, including a
+        /// conditional case and a default case.
+        /// </example>
         private void ConvertSwitchStatement(SemanticModel model, SwitchStatementSyntax syntax)
         {
             var sections = syntax.Sections.Select(p => (p.Labels, p.Statements, Target: new JumpTarget())).ToArray();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/SwitchStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/SwitchStatement.cs
@@ -17,7 +17,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'switch' statement into a set of conditional jump instructions and targets.
         /// This method handles the translation of 'switch' statements, including various forms of

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ThrowStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ThrowStatement.cs
@@ -13,6 +13,27 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Neo.Compiler
 {
+
+    /// <summary>
+    /// Converts a 'throw' statement into the corresponding throw instruction.
+    /// This method handles the translation of a throw statement, typically used for exception handling,
+    /// into an intermediate language instruction.
+    /// </summary>
+    /// <param name="model">The semantic model providing context and information about the throw statement.</param>
+    /// <param name="syntax">The syntax representation of the throw statement being converted.</param>
+    /// <remarks>
+    /// The method takes a throw statement and converts the expression being thrown into
+    /// an appropriate throw instruction in the target language or intermediate representation.
+    /// This is essential for implementing exception handling in the converted code.
+    /// </remarks>
+    /// <example>
+    /// Example of a throw statement syntax:
+    /// <code>
+    /// throw new Exception("Error message");
+    /// </code>
+    /// This example demonstrates a throw statement that creates and throws a new exception
+    /// with a specified error message.
+    /// </example>
     partial class MethodConvert
     {
         private void ConvertThrowStatement(SemanticModel model, ThrowStatementSyntax syntax)

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/ThrowStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/ThrowStatement.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Neo.Compiler
 {
-
     /// <summary>
     /// Converts a 'throw' statement into the corresponding throw instruction.
     /// This method handles the translation of a throw statement, typically used for exception handling,

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/TryStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/TryStatement.cs
@@ -17,7 +17,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'try-catch-finally' statement into a set of instructions for exception handling.
         /// This method handles the translation of try blocks, catch clauses, and finally blocks

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/TryStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/TryStatement.cs
@@ -17,6 +17,38 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'try-catch-finally' statement into a set of instructions for exception handling.
+        /// This method handles the translation of try blocks, catch clauses, and finally blocks
+        /// into an intermediate language.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the try statement.</param>
+        /// <param name="syntax">The syntax representation of the try statement being converted.</param>
+        /// <remarks>
+        /// The method sets up the necessary structure for a try block, including jump targets for catch
+        /// and finally blocks. It handles the conversion of each part of the try statement, including
+        /// any exception handling logic. The method currently supports only one catch block and
+        /// throws a compilation exception if multiple catches or catch filters are present.
+        /// </remarks>
+        /// <example>
+        /// Example of a 'try-catch-finally' statement syntax:
+        /// <code>
+        /// try
+        /// {
+        ///     // Try block code
+        /// }
+        /// catch (Exception e)
+        /// {
+        ///     // Catch block code
+        /// }
+        /// finally
+        /// {
+        ///     // Finally block code
+        /// }
+        /// </code>
+        /// This example demonstrates a typical try statement with one catch block and a finally block.
+        /// </example>
         private void ConvertTryStatement(SemanticModel model, TryStatementSyntax syntax)
         {
             JumpTarget catchTarget = new();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/WhileStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/WhileStatement.cs
@@ -16,6 +16,30 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
+
+        /// <summary>
+        /// Converts a 'while' loop statement into a series of instructions for loop control.
+        /// This method handles the translation of the 'while' loop's condition and body into an
+        /// intermediate language, managing the loop's execution flow.
+        /// </summary>
+        /// <param name="model">The semantic model providing context and information about the while statement.</param>
+        /// <param name="syntax">The syntax representation of the while statement being converted.</param>
+        /// <remarks>
+        /// The method sets up jump targets for the loop's continue and break points. It evaluates the
+        /// loop's condition and generates a conditional jump based on this condition. If the condition
+        /// is true, the loop's body is executed; otherwise, control jumps to the end of the loop.
+        /// The method ensures proper loop continuation and exit behavior.
+        /// </remarks>
+        /// <example>
+        /// Example of a while loop syntax:
+        /// <code>
+        /// while (condition)
+        /// {
+        ///     // Loop body code
+        /// }
+        /// </code>
+        /// In this example, the loop continues to execute as long as the 'condition' evaluates to true.
+        /// </example>
         private void ConvertWhileStatement(SemanticModel model, WhileStatementSyntax syntax)
         {
             JumpTarget continueTarget = new();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/WhileStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/WhileStatement.cs
@@ -16,7 +16,6 @@ namespace Neo.Compiler
 {
     partial class MethodConvert
     {
-
         /// <summary>
         /// Converts a 'while' loop statement into a series of instructions for loop control.
         /// This method handles the translation of the 'while' loop's condition and body into an


### PR DESCRIPTION
This pr adds comments to the statements convert. Part of my plan to comment the compiler.

This one is much easier cause statements are easy to understand, but will reach to the point where expressions are not easy to understand, for instance `ConvertElementAccessCoalesceAssignment`.

