### PR TITLE
[Framework: Add] Define Standard Enum

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -30,7 +30,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml.Linq;
-using scfx::Neo.SmartContract.Framework.ContractTypes;
 using Diagnostic = Microsoft.CodeAnalysis.Diagnostic;
 
 namespace Neo.Compiler

--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -30,6 +30,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml.Linq;
+using scfx::Neo.SmartContract.Framework.Attributes;
 using Diagnostic = Microsoft.CodeAnalysis.Diagnostic;
 
 namespace Neo.Compiler

--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -30,6 +30,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml.Linq;
+using scfx::Neo.SmartContract.Framework.ContractTypes;
 using Diagnostic = Microsoft.CodeAnalysis.Diagnostic;
 
 namespace Neo.Compiler
@@ -447,7 +448,16 @@ namespace Neo.Compiler
                             trusts.Add(trust);
                             break;
                         case nameof(scfx.Neo.SmartContract.Framework.Attributes.SupportedStandardsAttribute):
-                            supportedStandards.UnionWith(attribute.ConstructorArguments[0].Values.Select(p => (string)p.Value!));
+                            supportedStandards.UnionWith(
+                                attribute.ConstructorArguments[0].Values
+                                    .Select(p => p.Value)
+                                    .Select(p =>
+                                        p is int ip && Enum.IsDefined(typeof(NEPStandard), ip)
+                                            ? ((NEPStandard)ip).ToStandard()
+                                            : p as string
+                                    )
+                                    .Where(v => v != null)! // Ensure null values are not added
+                            );
                             break;
                     }
                 }

--- a/src/Neo.SmartContract.Framework/Attributes/NEPStandard.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/NEPStandard.cs
@@ -1,0 +1,24 @@
+namespace Neo.SmartContract.Framework.Attributes
+{
+    public enum NEPStandard
+    {
+        NEP11,
+        NEP17,
+    }
+
+    public static class NEPStandardExtensions
+    {
+        public static string ToStandard(this NEPStandard standard)
+        {
+            switch (standard)
+            {
+                case NEPStandard.NEP11:
+                    return "NEP-11";
+                case NEPStandard.NEP17:
+                    return "NEP-17";
+                default:
+                    return standard.ToString();
+            }
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/Attributes/SupportedStandardsAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/SupportedStandardsAttribute.cs
@@ -9,7 +9,6 @@
 // modifications are permitted.
 
 using System;
-using Neo.SmartContract.Framework.ContractTypes;
 
 namespace Neo.SmartContract.Framework.Attributes
 {

--- a/src/Neo.SmartContract.Framework/Attributes/SupportedStandardsAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/SupportedStandardsAttribute.cs
@@ -1,14 +1,15 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.SmartContract.Framework is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.SmartContract.Framework is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
 using System;
+using Neo.SmartContract.Framework.ContractTypes;
 
 namespace Neo.SmartContract.Framework.Attributes
 {
@@ -16,6 +17,10 @@ namespace Neo.SmartContract.Framework.Attributes
     public class SupportedStandardsAttribute : Attribute
     {
         public SupportedStandardsAttribute(params string[] supportedStandards)
+        {
+        }
+
+        public SupportedStandardsAttribute(params NEPStandard[] supportedStandards)
         {
         }
     }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandardsEnum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandardsEnum.cs
@@ -1,5 +1,4 @@
 using Neo.SmartContract.Framework.Attributes;
-using Neo.SmartContract.Framework.ContractTypes;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandardsEnum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandardsEnum.cs
@@ -1,10 +1,10 @@
 using Neo.SmartContract.Framework.Attributes;
-using Neo.SmartContract.Framework.Services;
+using Neo.SmartContract.Framework.ContractTypes;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
-    [SupportedStandards("NEP-10", "NEP-5")]
-    public class Contract_SupportedStandards : SmartContract
+    [SupportedStandards(NEPStandard.NEP11, NEPStandard.NEP17)]
+    public class ContractSupportedStandardsEnum : SmartContract
     {
         public static bool TestStandard()
         {

--- a/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
@@ -12,5 +12,13 @@ namespace Neo.SmartContract.Framework.UnitTests
             testengine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_SupportedStandards.cs");
             CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP10", "NEP5" });
         }
+
+        [TestMethod]
+        public void TestStandardAttributeEnum()
+        {
+            var testengine = new TestEngine.TestEngine();
+            testengine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_SupportedStandardsEnum.cs");
+            CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP-11", "NEP-17" });
+        }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
@@ -10,7 +10,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             var testengine = new TestEngine.TestEngine();
             testengine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_SupportedStandards.cs");
-            CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP10", "NEP5" });
+            CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP-10", "NEP-5" });
         }
 
         [TestMethod]


### PR DESCRIPTION
This pr defines a contract standard enumration, allowing user to use NEPStandard.NEP11 instead of "NEP-11" string when declare the supported standards.