### PR TITLE
[Compiler: Add]verify the NEP11 and NEP17 standards while compile them.

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -330,7 +330,7 @@ namespace Neo.Compiler
                 ["extra"] = manifestExtra
             };
             // Ensure that is serializable
-            return ContractManifest.Parse(json.ToString(false)).VerifyStandards();
+            return ContractManifest.Parse(json.ToString(false)).CheckStandards();
         }
 
         public JObject CreateDebugInformation(string folder = "")

--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -330,7 +330,7 @@ namespace Neo.Compiler
                 ["extra"] = manifestExtra
             };
             // Ensure that is serializable
-            return ContractManifest.Parse(json.ToString(false));
+            return ContractManifest.Parse(json.ToString(false)).VerifyStandards();
         }
 
         public JObject CreateDebugInformation(string folder = "")

--- a/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
+++ b/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
@@ -161,7 +161,7 @@ namespace Neo.Compiler
             }
         }
 
-        internal static ContractManifest VerifyStandards(this ContractManifest manifest)
+        internal static ContractManifest CheckStandards(this ContractManifest manifest)
         {
             if (manifest.SupportedStandards.Contains(NEPStandard.NEP11.ToStandard()))
             {

--- a/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
+++ b/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
@@ -22,7 +22,7 @@ namespace Neo.Compiler
 {
     internal static class ContractManifestExtensions
     {
-        private static void IsNep11Compliant(this ContractManifest manifest)
+        private static void CheckNep11Compliant(this ContractManifest manifest)
         {
             try
             {
@@ -112,7 +112,7 @@ namespace Neo.Compiler
             }
         }
 
-        private static void IsNep17Compliant(this ContractManifest manifest)
+        private static void CheckNep17Compliant(this ContractManifest manifest)
         {
             try
             {
@@ -165,12 +165,12 @@ namespace Neo.Compiler
         {
             if (manifest.SupportedStandards.Contains(NEPStandard.NEP11.ToStandard()))
             {
-                manifest.IsNep11Compliant();
+                manifest.CheckNep11Compliant();
             }
 
             if (manifest.SupportedStandards.Contains(NEPStandard.NEP17.ToStandard()))
             {
-                manifest.IsNep17Compliant();
+                manifest.CheckNep17Compliant();
             }
 
             return manifest;

--- a/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
+++ b/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
@@ -22,7 +22,7 @@ namespace Neo.Compiler
 {
     internal static class ContractManifestExtensions
     {
-        private static ContractManifest IsNep11Compliant(this ContractManifest manifest)
+        private static void IsNep11Compliant(this ContractManifest manifest)
         {
             try
             {
@@ -110,11 +110,9 @@ namespace Neo.Compiler
                 throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: Unidentified issue.");
             }
-
-            return manifest;
         }
 
-        private static ContractManifest IsNep17Compliant(this ContractManifest manifest)
+        private static void IsNep17Compliant(this ContractManifest manifest)
         {
             try
             {
@@ -161,20 +159,18 @@ namespace Neo.Compiler
             {
                 throw new CompilationException(DiagnosticId.IncorrectNEPStandard, $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: Unidentified issue.");
             }
-
-            return manifest;
         }
 
         internal static ContractManifest VerifyStandards(this ContractManifest manifest)
         {
             if (manifest.SupportedStandards.Contains(NEPStandard.NEP11.ToStandard()))
             {
-                return manifest.IsNep11Compliant();
+                manifest.IsNep11Compliant();
             }
 
             if (manifest.SupportedStandards.Contains(NEPStandard.NEP17.ToStandard()))
             {
-                return manifest.IsNep17Compliant();
+                manifest.IsNep17Compliant();
             }
 
             return manifest;

--- a/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
+++ b/src/Neo.Compiler.CSharp/ContractManifestExtension.cs
@@ -1,0 +1,183 @@
+
+
+// Copyright (C) 2015-2023 The Neo Project.
+//
+// ContractManifestExtensions.cs file belongs to neo-express project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+extern alias scfx;
+using System;
+using System.Linq;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using scfx::Neo.SmartContract.Framework.Attributes;
+
+namespace Neo.Compiler
+{
+    internal static class ContractManifestExtensions
+    {
+        private static ContractManifest IsNep11Compliant(this ContractManifest manifest)
+        {
+            try
+            {
+                var symbolMethod = manifest.Abi.GetMethod("symbol", 0);
+                var decimalsMethod = manifest.Abi.GetMethod("decimals", 0);
+                var totalSupplyMethod = manifest.Abi.GetMethod("totalSupply", 0);
+                var balanceOfMethod1 = manifest.Abi.GetMethod("balanceOf", 1);
+                var balanceOfMethod2 = manifest.Abi.GetMethod("balanceOf", 2);
+                var tokensOfMethod = manifest.Abi.GetMethod("tokensOf", 1);
+                var ownerOfMethod = manifest.Abi.GetMethod("ownerOf", 1);
+                var transferMethod1 = manifest.Abi.GetMethod("transfer", 3);
+                var transferMethod2 = manifest.Abi.GetMethod("transfer", 5);
+
+                var symbolValid = symbolMethod != null && symbolMethod.Safe == true &&
+                                  symbolMethod.ReturnType == ContractParameterType.String;
+                var decimalsValid = decimalsMethod != null && decimalsMethod.Safe == true &&
+                                    decimalsMethod.ReturnType == ContractParameterType.Integer;
+                var totalSupplyValid = totalSupplyMethod != null && totalSupplyMethod.Safe == true &&
+                                       totalSupplyMethod.ReturnType == ContractParameterType.Integer;
+                var balanceOfValid1 = balanceOfMethod1 != null && balanceOfMethod1.Safe == true &&
+                                      balanceOfMethod1.ReturnType == ContractParameterType.Integer &&
+                                      balanceOfMethod1.Parameters[0].Type == ContractParameterType.Hash160;
+                var balanceOfValid2 = balanceOfMethod2?.Safe == true &&
+                                      balanceOfMethod2?.ReturnType == ContractParameterType.Integer &&
+                                      balanceOfMethod2?.Parameters[0].Type == ContractParameterType.Hash160 &&
+                                      balanceOfMethod2?.Parameters[0].Type == ContractParameterType.ByteArray;
+                var tokensOfValid = tokensOfMethod != null && tokensOfMethod.Safe == true &&
+                                    tokensOfMethod.ReturnType == ContractParameterType.InteropInterface &&
+                                    tokensOfMethod.Parameters[0].Type == ContractParameterType.Hash160;
+                var ownerOfValid1 = ownerOfMethod != null && ownerOfMethod.Safe == true &&
+                                    ownerOfMethod.ReturnType == ContractParameterType.Hash160 &&
+                                    ownerOfMethod.Parameters[0].Type == ContractParameterType.ByteArray;
+                var ownerOfValid2 = ownerOfMethod != null && ownerOfMethod.Safe == true &&
+                                    ownerOfMethod.ReturnType == ContractParameterType.InteropInterface &&
+                                    ownerOfMethod.Parameters[0].Type == ContractParameterType.ByteArray;
+                var transferValid1 = transferMethod1 != null && transferMethod1.Safe == false &&
+                                     transferMethod1.ReturnType == ContractParameterType.Boolean &&
+                                     transferMethod1.Parameters[0].Type == ContractParameterType.Hash160 &&
+                                     transferMethod1.Parameters[1].Type == ContractParameterType.ByteArray &&
+                                     transferMethod1.Parameters[2].Type == ContractParameterType.Any;
+                var transferValid2 = transferMethod2?.Safe == false &&
+                                     transferMethod2?.ReturnType == ContractParameterType.Boolean &&
+                                     transferMethod2?.Parameters[0].Type == ContractParameterType.Hash160 &&
+                                     transferMethod2?.Parameters[1].Type == ContractParameterType.Hash160 &&
+                                     transferMethod2?.Parameters[2].Type == ContractParameterType.Integer &&
+                                     transferMethod2?.Parameters[3].Type == ContractParameterType.ByteArray &&
+                                     transferMethod2?.Parameters[4].Type == ContractParameterType.Any;
+                var transferEvent = manifest.Abi.Events.Any(a =>
+                    a.Name == "Transfer" &&
+                    a.Parameters.Length == 4 &&
+                    a.Parameters[0].Type == ContractParameterType.Hash160 &&
+                    a.Parameters[1].Type == ContractParameterType.Hash160 &&
+                    a.Parameters[2].Type == ContractParameterType.Integer &&
+                    a.Parameters[3].Type == ContractParameterType.ByteArray);
+
+                if (!symbolValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: symbol");
+                if (!decimalsValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: decimals");
+
+                if (!totalSupplyValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: totalSupply");
+
+                if (!balanceOfValid1 && !balanceOfValid2) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: balanceOf");
+
+                if (!tokensOfValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: tokensOf");
+
+                if (!ownerOfValid1 && !ownerOfValid2) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: ownerOf");
+
+                if (!transferValid1 && !transferValid2) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation:transfer");
+
+                if (!transferEvent) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: {nameof(transferEvent)}");
+            }
+            catch (Exception ex) when (ex is not CompilationException)
+            {
+                throw;
+            }
+            catch
+            {
+                throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP11.ToStandard()} implementation: Unidentified issue.");
+            }
+
+            return manifest;
+        }
+
+        private static ContractManifest IsNep17Compliant(this ContractManifest manifest)
+        {
+            try
+            {
+                var symbolMethod = manifest.Abi.GetMethod("symbol", 0);
+                var decimalsMethod = manifest.Abi.GetMethod("decimals", 0);
+                var totalSupplyMethod = manifest.Abi.GetMethod("totalSupply", 0);
+                var balanceOfMethod = manifest.Abi.GetMethod("balanceOf", 1);
+                var transferMethod = manifest.Abi.GetMethod("transfer", 4);
+
+                var symbolValid = symbolMethod != null && symbolMethod.Safe &&
+                                  symbolMethod.ReturnType == ContractParameterType.String;
+                var decimalsValid = decimalsMethod != null && decimalsMethod.Safe &&
+                                    decimalsMethod.ReturnType == ContractParameterType.Integer;
+                var totalSupplyValid = totalSupplyMethod != null && totalSupplyMethod.Safe &&
+                                       totalSupplyMethod.ReturnType == ContractParameterType.Integer;
+                var balanceOfValid = balanceOfMethod != null && balanceOfMethod.Safe &&
+                                     balanceOfMethod.ReturnType == ContractParameterType.Integer &&
+                                     balanceOfMethod.Parameters[0].Type == ContractParameterType.Hash160;
+                var transferValid = transferMethod != null && transferMethod.Safe == false &&
+                                    transferMethod.ReturnType == ContractParameterType.Boolean &&
+                                    transferMethod.Parameters[0].Type == ContractParameterType.Hash160 &&
+                                    transferMethod.Parameters[1].Type == ContractParameterType.Hash160 &&
+                                    transferMethod.Parameters[2].Type == ContractParameterType.Integer &&
+                                    transferMethod.Parameters[3].Type == ContractParameterType.Any;
+                var transferEvent = manifest.Abi.Events.Any(s =>
+                    s.Name == "Transfer" &&
+                    s.Parameters.Length == 3 &&
+                    s.Parameters[0].Type == ContractParameterType.Hash160 &&
+                    s.Parameters[1].Type == ContractParameterType.Hash160 &&
+                    s.Parameters[2].Type == ContractParameterType.Integer);
+
+                if (!symbolValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: symbol");
+                if (!decimalsValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: decimals");
+                if (!totalSupplyValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: totalSupply");
+                if (!balanceOfValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: balanceOf");
+                if (!transferValid) throw new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                    $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: transfer");
+            }
+            catch (Exception ex) when (ex is not CompilationException)
+            {
+                throw new CompilationException(DiagnosticId.IncorrectNEPStandard, $"Incomplete NEP standard {NEPStandard.NEP17.ToStandard()} implementation: Unidentified issue.");
+            }
+
+            return manifest;
+        }
+
+        internal static ContractManifest VerifyStandards(this ContractManifest manifest)
+        {
+            if (manifest.SupportedStandards.Contains(NEPStandard.NEP11.ToStandard()))
+            {
+                return manifest.IsNep11Compliant();
+            }
+
+            if (manifest.SupportedStandards.Contains(NEPStandard.NEP17.ToStandard()))
+            {
+                return manifest.IsNep17Compliant();
+            }
+
+            return manifest;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/DiagnosticId.cs
+++ b/src/Neo.Compiler.CSharp/DiagnosticId.cs
@@ -1,10 +1,10 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.Compiler.CSharp is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
@@ -34,5 +34,6 @@ namespace Neo.Compiler
         public const string MethodNameConflict = "NC3003";
         public const string EventNameConflict = "NC3004";
         public const string InvalidInitialValue = "NC3005";
+        public const string IncorrectNEPStandard = "NC3006";
     }
 }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
@@ -10,7 +10,6 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return true;
         }
 
-
         public override string Symbol { [Safe] get; }
     }
 }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
@@ -2,12 +2,15 @@ using Neo.SmartContract.Framework.Attributes;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
-    [SupportedStandards(NEPStandard.NEP11, NEPStandard.NEP17)]
-    public class ContractSupportedStandardsEnum : SmartContract
+    [SupportedStandards(NEPStandard.NEP11)]
+    public class Contract_SupportedStandard11Enum : Nep11Token<Nep11TokenState>
     {
         public static bool TestStandard()
         {
             return true;
         }
+
+
+        public override string Symbol { [Safe] get; }
     }
 }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard17Enum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard17Enum.cs
@@ -1,0 +1,19 @@
+using Neo.SmartContract.Framework.Attributes;
+using System.ComponentModel;
+
+namespace Neo.SmartContract.Framework.UnitTests.TestClasses
+{
+    [DisplayName(nameof(Contract_SupportedStandard17Enum))]
+    [ManifestExtra("Author", "<Your Name Or Company Here>")]
+    [ManifestExtra("Description", "<Description Here>")]
+    [ManifestExtra("Email", "<Your Public Email Here>")]
+    [ManifestExtra("Version", "<Version String Here>")]
+    [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master/src/Neo.SmartContract.Template")]
+    [ContractPermission("*", "*")]
+    [SupportedStandards(NEPStandard.NEP17)]
+    public class Contract_SupportedStandard17Enum : Nep17Token
+    {
+        public override string Symbol { [Safe] get; }
+        public override byte Decimals { [Safe] get; }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
@@ -14,11 +14,19 @@ namespace Neo.SmartContract.Framework.UnitTests
         }
 
         [TestMethod]
-        public void TestStandardAttributeEnum()
+        public void TestStandardNEP11AttributeEnum()
         {
             var testengine = new TestEngine.TestEngine();
-            testengine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_SupportedStandardsEnum.cs");
-            CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP-11", "NEP-17" });
+            testengine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_SupportedStandard11Enum.cs");
+            CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP-11" });
+        }
+
+        [TestMethod]
+        public void TestStandardNEP17AttributeEnum()
+        {
+            var testengine = new TestEngine.TestEngine();
+            testengine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_SupportedStandard17Enum.cs");
+            CollectionAssert.AreEqual(testengine.Manifest.SupportedStandards, new string[] { "NEP-17" });
         }
     }
 }


### PR DESCRIPTION
This pr adds verification logic to standard 11 and standard 17.

checking logic is borrowed from the neo-express written by @cschuchardt88  at https://github.com/neo-project/neo-express/blob/9cdfc5bb5a938da2c88257782f634b453cff6776/src/neoxp/Extensions/ContractManifestExtensions.cs, so i just keep the copyright as it is.