### PR TITLE
Fixed `PackageReference` for `neo`

### DIFF
--- a/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
+++ b/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Neo" Version="3.6.2" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 


### PR DESCRIPTION
![image](https://github.com/neo-project/neo-devpack-dotnet/assets/8141309/49d5ddbf-d5a9-4133-b4ec-860088326751)

There was a `PackageReference` problem that is now fix. @shargon may or may **not fix** your problem. I don't know how anyone didn't catch this.