### PR TITLE
[Framework Add] predefine manifest

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationContext.cs
@@ -428,9 +428,7 @@ namespace Neo.Compiler
             {
                 if (scTypeFound) throw new CompilationException(DiagnosticId.MultiplyContracts, "Only one smart contract is allowed.");
                 scTypeFound = true;
-                var a = symbol.GetAttributes();
-                var b = symbol.GetAttributesWithInherited();
-                foreach (var attribute in b)
+                foreach (var attribute in symbol.GetAttributesWithInherited())
                 {
                     if (attribute.AttributeClass!.IsSubclassOf(nameof(ManifestExtraAttribute)))
                     {

--- a/src/Neo.SmartContract.Framework/Attributes/AuthorAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/AuthorAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Neo.SmartContract.Framework.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AuthorAttribute : ManifestExtraAttribute
+    {
+        public AuthorAttribute(string value) : base(AttributeType[nameof(AuthorAttribute)], value)
+        {
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/Attributes/DescriptionAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/DescriptionAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Neo.SmartContract.Framework.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DescriptionAttribute : ManifestExtraAttribute
+    {
+        public DescriptionAttribute(string value) : base(AttributeType[nameof(DescriptionAttribute)], value)
+        {
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/Attributes/EmailAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/EmailAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Neo.SmartContract.Framework.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class EmailAttribute : ManifestExtraAttribute
+    {
+        public EmailAttribute(string value) : base(AttributeType[nameof(EmailAttribute)], value)
+        {
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+
 namespace Neo.SmartContract.Framework.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]

--- a/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
@@ -30,36 +30,4 @@ namespace Neo.SmartContract.Framework.Attributes
             { nameof(VersionAttribute), "Version" },
         };
     }
-
-    [AttributeUsage(AttributeTargets.Class)]
-    public class AuthorAttribute : ManifestExtraAttribute
-    {
-        public AuthorAttribute(string value) : base(AttributeType[nameof(AuthorAttribute)], value)
-        {
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Class)]
-    public class EmailAttribute : ManifestExtraAttribute
-    {
-        public EmailAttribute(string value) : base(AttributeType[nameof(EmailAttribute)], value)
-        {
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Class)]
-    public class DescriptionAttribute : ManifestExtraAttribute
-    {
-        public DescriptionAttribute(string value) : base(AttributeType[nameof(DescriptionAttribute)], value)
-        {
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Class)]
-    public class VersionAttribute : ManifestExtraAttribute
-    {
-        public VersionAttribute(string value) : base(AttributeType[nameof(VersionAttribute)], value)
-        {
-        }
-    }
 }

--- a/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
@@ -1,21 +1,64 @@
 // Copyright (C) 2015-2023 The Neo Project.
-// 
-// The Neo.SmartContract.Framework is free software distributed under the MIT 
-// software license, see the accompanying file LICENSE in the main directory 
-// of the project or http://www.opensource.org/licenses/mit-license.php 
+//
+// The Neo.SmartContract.Framework is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
 // for more details.
-// 
+//
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Neo.SmartContract.Framework.Attributes
 {
+
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ManifestExtraAttribute : Attribute
     {
         public ManifestExtraAttribute(string key, string value)
+        {
+        }
+
+        internal static readonly Dictionary<string, string> AttributeType = new Dictionary<string, string>
+        {
+            { nameof(AuthorAttribute), "Author" },
+            { nameof(EmailAttribute), "E-mail" },
+            { nameof(DescriptionAttribute), "Description" },
+            { nameof(VersionAttribute), "Version" },
+        };
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AuthorAttribute : ManifestExtraAttribute
+    {
+        public AuthorAttribute(string value) : base(AttributeType[nameof(AuthorAttribute)], value)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class EmailAttribute : ManifestExtraAttribute
+    {
+        public EmailAttribute(string value) : base(AttributeType[nameof(EmailAttribute)], value)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DescriptionAttribute : ManifestExtraAttribute
+    {
+        public DescriptionAttribute(string value) : base(AttributeType[nameof(DescriptionAttribute)], value)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class VersionAttribute : ManifestExtraAttribute
+    {
+        public VersionAttribute(string value) : base(AttributeType[nameof(VersionAttribute)], value)
         {
         }
     }

--- a/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 
 namespace Neo.SmartContract.Framework.Attributes
 {
-
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ManifestExtraAttribute : Attribute
     {

--- a/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/ManifestExtraAttribute.cs
@@ -10,8 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-
-
 namespace Neo.SmartContract.Framework.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]

--- a/src/Neo.SmartContract.Framework/Attributes/VersionAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/VersionAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Neo.SmartContract.Framework.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class VersionAttribute : ManifestExtraAttribute
+    {
+        public VersionAttribute(string value) : base(AttributeType[nameof(VersionAttribute)], value)
+        {
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_ManifestAttribute.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_ManifestAttribute.cs
@@ -1,0 +1,22 @@
+using Neo.SmartContract.Framework.Attributes;
+
+namespace Neo.SmartContract.Framework.UnitTests.TestClasses
+{
+    [Author("core-dev")]
+    [Email("core@neo.org")]
+    [Version("v3.6.3")]
+    [Description("This is a test contract.")]
+    [ManifestExtra("ExtraKey", "ExtraValue")]
+    public class Contract_ManifestAttribute : SmartContract
+    {
+        [NoReentrant]
+        public void reentrantTest(int value)
+        {
+            if (value == 0) return;
+            if (value == 123)
+            {
+                reentrantTest(0);
+            }
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/ManifestAttributeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ManifestAttributeTest.cs
@@ -5,7 +5,6 @@ namespace Neo.SmartContract.Framework.UnitTests;
 [TestClass]
 public class ManifestAttributeTest
 {
-
     [TestMethod]
     public void TestManifestAttribute()
     {

--- a/tests/Neo.SmartContract.Framework.UnitTests/ManifestAttributeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ManifestAttributeTest.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+[TestClass]
+public class ManifestAttributeTest
+{
+
+    [TestMethod]
+    public void TestManifestAttribute()
+    {
+        var testEngine = new TestEngine.TestEngine();
+        testEngine.AddEntryScript(Utils.Extensions.TestContractRoot + "Contract_ManifestAttribute.cs");
+
+        var extra = testEngine.Manifest!.Extra;
+
+        Assert.AreEqual(5, extra.Count);
+        // [Author("core-dev")]
+        // [Email("core@neo.org")]
+        // [Version("v3.6.3")]
+        // [Description("This is a test contract.")]
+        // [ManifestExtra("ExtraKey", "ExtraValue")]
+        Assert.AreEqual("core-dev", extra["Author"]!.GetString());
+        Assert.AreEqual("core@neo.org", extra["E-mail"]!.GetString());
+        Assert.AreEqual("v3.6.3", extra["Version"]!.GetString());
+        Assert.AreEqual("This is a test contract.", extra["Description"]!.GetString());
+        Assert.AreEqual("ExtraValue", extra["ExtraKey"]!.GetString());
+    }
+}


### PR DESCRIPTION
This pr adds a few prefefined manifest extra field. Making it easier to setup the contract manifest.

```C#
    [Author("core-dev")]
    [Email("core@neo.org")]
    [Version("v3.6.3")]
    [Description("This is a test contract.")]
    [ManifestExtra("ExtraKey", "ExtraValue")]
```