### PR TITLE
More fixes on optimizer

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/Reachability.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/Reachability.cs
@@ -106,7 +106,7 @@ namespace Neo.Optimizer
             nef.Compiler = AppDomain.CurrentDomain.FriendlyName;
             nef.CheckSum = NefFile.ComputeChecksum(nef);
 
-            Dictionary<int, (int docId, int startLine, int startCol, int endLine, int endCol)> newAddrToSequencePoint = new();
+            //Dictionary<int, (int docId, int startLine, int startCol, int endLine, int endCol)> newAddrToSequencePoint = new();
             Dictionary<int, string> newMethodStart = new();
             Dictionary<int, string> newMethodEnd = new();
             HashSet<JToken> methodsToRemove = new();
@@ -140,14 +140,6 @@ namespace Neo.Optimizer
                     }
                     else
                         newSequencePoints.Add(new JString($"{previousSequencePoint}{sequencePointGroups[2]}"));
-                    GroupCollection documentGroups = DocumentRegex.Match(sequencePointGroups[2].ToString()).Groups;
-                    newAddrToSequencePoint.Add(previousSequencePoint, (
-                        int.Parse(documentGroups[1].ToString()),
-                        int.Parse(documentGroups[2].ToString()),
-                        int.Parse(documentGroups[3].ToString()),
-                        int.Parse(documentGroups[4].ToString()),
-                        int.Parse(documentGroups[5].ToString())
-                        ));
                 }
                 method["sequence-points"] = newSequencePoints;
             }
@@ -280,7 +272,7 @@ namespace Neo.Optimizer
                         if (stackType != TryStack.TRY && stackType != TryStack.CATCH)
                             throw new BadScriptException("No try stack on ENDTRY");
 
-                        if (stackType == TryStack.TRY)
+                        if (stackType == TryStack.TRY && catchAddr != -1)
                         {
                             // Visit catchAddr because there may still be exceptions at runtime
                             Stack<((int returnAddr, int finallyAddr), TryStack stackType)> newStack = new(stack.Reverse());

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -157,7 +157,7 @@ namespace Neo.Compiler
                 {
                     try
                     {
-                        (nef, manifest, debugInfo) = Reachability.RemoveUncoveredInstructions(nef, manifest, debugInfo);
+                        (nef, manifest, debugInfo) = Reachability.RemoveUncoveredInstructions(nef, manifest, debugInfo.Clone());
                     }
                     catch (Exception ex)
                     {

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -272,9 +272,16 @@ namespace Neo.Compiler
                     path = Path.Combine(outputFolder, $"{baseName}.asm");
                     File.WriteAllText(path, context.CreateAssembly());
                     Console.WriteLine($"Created {path}");
-                    path = Path.Combine(outputFolder, $"{baseName}.nef.txt");
-                    File.WriteAllText(path, DumpNef.GenerateDumpNef(nef, debugInfo));
-                    Console.WriteLine($"Created {path}");
+                    try
+                    {
+                        path = Path.Combine(outputFolder, $"{baseName}.nef.txt");
+                        File.WriteAllText(path, DumpNef.GenerateDumpNef(nef, debugInfo));
+                        Console.WriteLine($"Created {path}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Failed to dumpnef: {ex}");
+                    }
                 }
                 Console.WriteLine("Compilation completed successfully.");
                 return 0;


### PR DESCRIPTION
It should pass most tests, except that...
1. Unable to support PUSHA without executing the instruction at the pushed address (Typically seen in `Contract_Polymorphism.cs` )

2. There may be error in the DebugInfo of `Contract_TryCatch.cs`:

```
{
    "id": "Neo.Compiler.CSharp.UnitTests.TestClasses.Contract_TryCatch.throwcall()",
    "name": "Neo.Compiler.CSharp.UnitTests.TestClasses.Contract_TryCatch,throwcall",
    "range": "519-531",
    "params": [],
    "return": "Any",
    "variables": [],
    "sequence-points": ["519[3]387:13-387:42", "531[3]388:9-388:10"]
},
{
    "id": "Neo.Compiler.CSharp.UnitTests.TestClasses.Contract_TryCatch.tryNest()",
    "name": "Neo.Compiler.CSharp.UnitTests.TestClasses.Contract_TryCatch,tryNest",
    "range": "532-676",
    "params": [],
    "return": "Any",
    "variables": ["v,Integer,0"],
    "sequence-points": ["535[3]76:17-76:22", "543[3]81:21-81:27", "547[3]82:21-82:33", "552[3]84:17-84:22", "553[3]86:21-86:27", "557[3]87:21-87:33", "562[3]91:21-91:33", "565[3]92:21-92:25", "619[3]95:13-95:18", "620[3]97:17-97:21", "673[3]99:13-99:22", "676[3]100:9-100:10"]
}
```

​	The `range` of instruction addresses above does not match with the assembly codes.

3. Maybe we need to test THROW and ABORT in `catch` blocks. By definition in the VM, THROW in `catch` blocks leads to `finally`, and ABORT terminates the whole execution.
4. The nef and manifest are modified in the process of optimization, and it is hard to revert the modifications. The final output may be polluted if there is exception in the optimizer.