### PR TITLE
TestEngine: Some fixes in TestEngine

### DIFF
--- a/src/Neo.SmartContract.Testing/Attributes/FieldOrderAttribute.cs
+++ b/src/Neo.SmartContract.Testing/Attributes/FieldOrderAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Neo.SmartContract.Testing.Attributes;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class FieldOrderAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the deserialization order of the property.
+    /// </summary>
+    public int Order { get; }
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="order">Order</param>
+    public FieldOrderAttribute(int order)
+    {
+        Order = order;
+    }
+}

--- a/src/Neo.SmartContract.Testing/Extensions/TestExtensions.cs
+++ b/src/Neo.SmartContract.Testing/Extensions/TestExtensions.cs
@@ -1,5 +1,4 @@
 using Neo.Cryptography.ECC;
-using Neo.SmartContract.Iterators;
 using Neo.VM.Types;
 using System;
 using System.Collections.Generic;

--- a/src/Neo.SmartContract.Testing/Extensions/TestExtensions.cs
+++ b/src/Neo.SmartContract.Testing/Extensions/TestExtensions.cs
@@ -1,3 +1,4 @@
+using Akka.Util;
 using Neo.Cryptography.ECC;
 using Neo.SmartContract.Testing.Attributes;
 using Neo.VM.Types;
@@ -11,7 +12,8 @@ namespace Neo.SmartContract.Testing.Extensions
 {
     public static class TestExtensions
     {
-        private static readonly Dictionary<Type, Dictionary<int, PropertyInfo>> _deserializationCache = new();
+        private static readonly Dictionary<Type, Dictionary<int, PropertyInfo>> _propertyCache = new();
+        private static readonly Dictionary<Type, FieldInfo[]> _fieldCache = new();
 
         /// <summary>
         /// Convert Array stack item to dotnet array
@@ -77,14 +79,24 @@ namespace Neo.SmartContract.Testing.Extensions
                 _ when type == typeof(UInt160) => new UInt160(stackItem.GetSpan().ToArray()),
                 _ when type == typeof(UInt256) => new UInt256(stackItem.GetSpan().ToArray()),
                 _ when type == typeof(ECPoint) => ECPoint.FromBytes(stackItem.GetSpan().ToArray(), ECCurve.Secp256r1),
-                _ when type == typeof(IDictionary<object, object>) && stackItem is Map mp => ToDictionary(mp), // SubItems in StackItem type
-                _ when type == typeof(Dictionary<object, object>) && stackItem is Map mp => ToDictionary(mp), // SubItems in StackItem type
-                _ when type == typeof(IList<object>) && stackItem is CompoundType cp => new List<object>(cp.SubItems), // SubItems in StackItem type
-                _ when type == typeof(List<object>) && stackItem is CompoundType cp => new List<object>(cp.SubItems), // SubItems in StackItem type
                 _ when typeof(IInteroperable).IsAssignableFrom(type) => CreateInteroperable(stackItem, type),
-                _ when type.IsArray && stackItem is CompoundType cp => CreateTypeArray(cp.SubItems, type.GetElementType()!),
                 _ when stackItem is InteropInterface it && it.GetInterface().GetType() == type => it.GetInterface(),
-                _ when type.IsClass && stackItem is CompoundType cp => CreateObject(cp.SubItems, type),
+
+                _ when stackItem is VM.Types.Array ar => type switch
+                {
+                    _ when type == typeof(IList<object>) => new List<object>(ar.SubItems), // SubItems in StackItem type
+                    _ when type == typeof(List<object>) => new List<object>(ar.SubItems), // SubItems in StackItem type
+                    _ when type.IsArray => CreateTypeArray(ar.SubItems, type.GetElementType()!),
+                    _ when type.IsClass => CreateObject(ar.SubItems, type),
+                    _ when type.IsValueType => CreateValueType(ar.SubItems, type),
+                    _ => throw new FormatException($"Impossible to convert {stackItem} to {type}"),
+                },
+                _ when stackItem is Map mp => type switch
+                {
+                    _ when type == typeof(IDictionary<object, object>) => ToDictionary(mp), // SubItems in StackItem type
+                    _ when type == typeof(Dictionary<object, object>) => ToDictionary(mp), // SubItems in StackItem type
+                    _ => throw new FormatException($"Impossible to convert {stackItem} to {type}"),
+                },
 
                 _ => throw new FormatException($"Impossible to convert {stackItem} to {type}"),
             };
@@ -97,7 +109,7 @@ namespace Neo.SmartContract.Testing.Extensions
 
             // Cache the object properties by offset
 
-            if (!_deserializationCache.TryGetValue(type, out var cache))
+            if (!_propertyCache.TryGetValue(type, out var cache))
             {
                 cache = new Dictionary<int, PropertyInfo>();
 
@@ -123,7 +135,7 @@ namespace Neo.SmartContract.Testing.Extensions
                     index = 0;
                 }
 
-                _deserializationCache[type] = cache;
+                _propertyCache[type] = cache;
             }
 
             // Fill the object
@@ -155,6 +167,32 @@ namespace Neo.SmartContract.Testing.Extensions
             }
 
             return dictionary;
+        }
+
+        private static object CreateValueType(IEnumerable<StackItem> objects, Type valueType)
+        {
+            var arr = objects.ToArray();
+            var value = Activator.CreateInstance(valueType);
+
+            // Cache the object properties by offset
+
+            if (!_fieldCache.TryGetValue(valueType, out var cache))
+            {
+                cache = valueType.GetFields().ToArray();
+                _fieldCache[valueType] = cache;
+            }
+
+            if (cache.Length != arr.Length)
+            {
+                throw new FormatException($"Error converting {valueType}, field count doesn't match.");
+            }
+
+            for (int x = 0; x < arr.Length; x++)
+            {
+                cache[x].SetValue(value, ConvertTo(arr[x], cache[x].FieldType));
+            }
+
+            return value;
         }
 
         private static object CreateTypeArray(IEnumerable<StackItem> objects, Type elementType)

--- a/src/Neo.SmartContract.Testing/Native/ContractManagement.cs
+++ b/src/Neo.SmartContract.Testing/Native/ContractManagement.cs
@@ -2,7 +2,7 @@ using Neo.SmartContract.Iterators;
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class ContractManagement : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/CryptoLib.cs
+++ b/src/Neo.SmartContract.Testing/Native/CryptoLib.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class CryptoLib : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/GasToken.cs
+++ b/src/Neo.SmartContract.Testing/Native/GasToken.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class GasToken : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/LedgerContract.cs
+++ b/src/Neo.SmartContract.Testing/Native/LedgerContract.cs
@@ -4,7 +4,7 @@ using Neo.VM;
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class LedgerContract : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/NeoToken.cs
+++ b/src/Neo.SmartContract.Testing/Native/NeoToken.cs
@@ -1,45 +1,26 @@
 using Neo.Cryptography.ECC;
-using Neo.IO;
 using Neo.SmartContract.Iterators;
-using Neo.VM;
-using Neo.VM.Types;
-using System;
+using Neo.SmartContract.Testing.Attributes;
 using System.ComponentModel;
 using System.Numerics;
-using Neo.SmartContract.Testing.Extensions;
-using System.Linq;
 
 namespace Neo.SmartContract.Testing;
 
 public abstract class NeoToken : SmartContract
 {
-    public class Candidate : IInteroperable
+    public class Candidate
     {
         /// <summary>
         /// Public key
         /// </summary>
-        public ECPoint? PublicKey { get; private set; }
+        [FieldOrder(0)]
+        public ECPoint? PublicKey { get; set; }
 
         /// <summary>
         /// Votes
         /// </summary>
-        public BigInteger Votes { get; private set; } = BigInteger.Zero;
-
-        public void FromStackItem(StackItem stackItem)
-        {
-            if (stackItem is not CompoundType cp) throw new FormatException();
-            if (cp.Count < 2) throw new FormatException();
-
-            var items = cp.SubItems.ToArray();
-
-            PublicKey = (ECPoint)items[0].ConvertTo(typeof(ECPoint))!;
-            Votes = (BigInteger)items[1].ConvertTo(typeof(BigInteger))!;
-        }
-
-        public StackItem ToStackItem(ReferenceCounter referenceCounter)
-        {
-            return new VM.Types.Array(new StackItem[] { PublicKey.ToArray(), Votes });
-        }
+        [FieldOrder(1)]
+        public BigInteger Votes { get; set; }
     }
 
     #region Events

--- a/src/Neo.SmartContract.Testing/Native/NeoToken.cs
+++ b/src/Neo.SmartContract.Testing/Native/NeoToken.cs
@@ -4,7 +4,7 @@ using Neo.SmartContract.Testing.Attributes;
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class NeoToken : SmartContract
 {
@@ -100,7 +100,7 @@ public abstract class NeoToken : SmartContract
     /// Safe method
     /// </summary>
     [DisplayName("getAccountState")]
-    public abstract Native.NeoToken.NeoAccountState GetAccountState(UInt160? account);
+    public abstract Neo.SmartContract.Native.NeoToken.NeoAccountState GetAccountState(UInt160? account);
 
     /// <summary>
     /// Safe method

--- a/src/Neo.SmartContract.Testing/Native/OracleContract.cs
+++ b/src/Neo.SmartContract.Testing/Native/OracleContract.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class OracleContract : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/PolicyContract.cs
+++ b/src/Neo.SmartContract.Testing/Native/PolicyContract.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class PolicyContract : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/RoleManagement.cs
+++ b/src/Neo.SmartContract.Testing/Native/RoleManagement.cs
@@ -3,7 +3,7 @@ using Neo.SmartContract.Native;
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class RoleManagement : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/Native/StdLib.cs
+++ b/src/Neo.SmartContract.Testing/Native/StdLib.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Numerics;
 
-namespace Neo.SmartContract.Testing;
+namespace Neo.SmartContract.Testing.Native;
 
 public abstract class StdLib : SmartContract
 {

--- a/src/Neo.SmartContract.Testing/NativeArtifacts.cs
+++ b/src/Neo.SmartContract.Testing/NativeArtifacts.cs
@@ -1,4 +1,5 @@
 using Neo.Persistence;
+using Neo.SmartContract.Testing.Native;
 using System;
 using System.Reflection;
 
@@ -64,15 +65,15 @@ namespace Neo.SmartContract.Testing
         {
             _engine = engine;
 
-            ContractManagement = _engine.FromHash<ContractManagement>(Native.NativeContract.ContractManagement.Hash, Native.NativeContract.ContractManagement.Id);
-            CryptoLib = _engine.FromHash<CryptoLib>(Native.NativeContract.CryptoLib.Hash, Native.NativeContract.CryptoLib.Id);
-            GAS = _engine.FromHash<GasToken>(Native.NativeContract.GAS.Hash, Native.NativeContract.GAS.Id);
-            NEO = _engine.FromHash<NeoToken>(Native.NativeContract.NEO.Hash, Native.NativeContract.NEO.Id);
-            Ledger = _engine.FromHash<LedgerContract>(Native.NativeContract.Ledger.Hash, Native.NativeContract.Ledger.Id);
-            Oracle = _engine.FromHash<OracleContract>(Native.NativeContract.Oracle.Hash, Native.NativeContract.Oracle.Id);
-            Policy = _engine.FromHash<PolicyContract>(Native.NativeContract.Policy.Hash, Native.NativeContract.Policy.Id);
-            RoleManagement = _engine.FromHash<RoleManagement>(Native.NativeContract.RoleManagement.Hash, Native.NativeContract.RoleManagement.Id);
-            StdLib = _engine.FromHash<StdLib>(Native.NativeContract.StdLib.Hash, Native.NativeContract.StdLib.Id);
+            ContractManagement = _engine.FromHash<ContractManagement>(Neo.SmartContract.Native.NativeContract.ContractManagement.Hash, Neo.SmartContract.Native.NativeContract.ContractManagement.Id);
+            CryptoLib = _engine.FromHash<CryptoLib>(Neo.SmartContract.Native.NativeContract.CryptoLib.Hash, Neo.SmartContract.Native.NativeContract.CryptoLib.Id);
+            GAS = _engine.FromHash<GasToken>(Neo.SmartContract.Native.NativeContract.GAS.Hash, Neo.SmartContract.Native.NativeContract.GAS.Id);
+            NEO = _engine.FromHash<NeoToken>(Neo.SmartContract.Native.NativeContract.NEO.Hash, Neo.SmartContract.Native.NativeContract.NEO.Id);
+            Ledger = _engine.FromHash<LedgerContract>(Neo.SmartContract.Native.NativeContract.Ledger.Hash, Neo.SmartContract.Native.NativeContract.Ledger.Id);
+            Oracle = _engine.FromHash<OracleContract>(Neo.SmartContract.Native.NativeContract.Oracle.Hash, Neo.SmartContract.Native.NativeContract.Oracle.Id);
+            Policy = _engine.FromHash<PolicyContract>(Neo.SmartContract.Native.NativeContract.Policy.Hash, Neo.SmartContract.Native.NativeContract.Policy.Id);
+            RoleManagement = _engine.FromHash<RoleManagement>(Neo.SmartContract.Native.NativeContract.RoleManagement.Hash, Neo.SmartContract.Native.NativeContract.RoleManagement.Id);
+            StdLib = _engine.FromHash<StdLib>(Neo.SmartContract.Native.NativeContract.StdLib.Hash, Neo.SmartContract.Native.NativeContract.StdLib.Id);
         }
 
         /// <summary>
@@ -92,12 +93,12 @@ namespace Neo.SmartContract.Testing
 
             // Process native contracts
 
-            foreach (var native in new Native.NativeContract[]
+            foreach (var native in new Neo.SmartContract.Native.NativeContract[]
                 {
-                    Native.NativeContract.ContractManagement,
-                    Native.NativeContract.Ledger,
-                    Native.NativeContract.NEO,
-                    Native.NativeContract.GAS
+                    Neo.SmartContract.Native.NativeContract.ContractManagement,
+                    Neo.SmartContract.Native.NativeContract.Ledger,
+                    Neo.SmartContract.Native.NativeContract.NEO,
+                    Neo.SmartContract.Native.NativeContract.GAS
                 }
             )
             {

--- a/src/Neo.SmartContract.Testing/Storage/EngineStorage.cs
+++ b/src/Neo.SmartContract.Testing/Storage/EngineStorage.cs
@@ -12,7 +12,7 @@ namespace Neo.SmartContract.Testing.Storage
     public class EngineStorage
     {
         // Key to check if native contracts are initialized, by default: Neo.votersCountPrefix
-        private static readonly StorageKey _initKey = new() { Id = Native.NativeContract.NEO.Id, Key = new byte[] { 1 } };
+        private static readonly StorageKey _initKey = new() { Id = Neo.SmartContract.Native.NativeContract.NEO.Id, Key = new byte[] { 1 } };
 
         /// <summary>
         /// Store

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -11,6 +11,7 @@ using Neo.VM;
 using Neo.VM.Types;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -394,7 +395,9 @@ namespace Neo.SmartContract.Testing
 
                 if (mock.IsMocked(method))
                 {
-                    var mockName = method.Name + ";" + method.GetParameters().Length;
+                    var display = method.GetCustomAttribute<DisplayNameAttribute>();
+                    var name = display is not null ? display.DisplayName : method.Name;
+                    var mockName = name + ";" + method.GetParameters().Length;
                     var cm = new CustomMock(mock.Object, method);
 
                     if (_customMocks.TryGetValue(hash, out var mocks))

--- a/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
@@ -1,5 +1,6 @@
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
+using Neo.SmartContract.Native;
 using Neo.SmartContract.Testing.Extensions;
 using Neo.VM;
 using Neo.VM.Types;
@@ -76,7 +77,7 @@ namespace Neo.SmartContract.Testing
             {
                 // We need the contract state without pay gas
 
-                var state = Native.NativeContract.ContractManagement.GetContract(Engine.Storage.Snapshot, contractHash);
+                var state = NativeContract.ContractManagement.GetContract(Engine.Storage.Snapshot, contractHash);
 
                 coveredContract = new(Engine.MethodDetection, contractHash, state);
                 Engine.Coverage[contractHash] = coveredContract;

--- a/tests/Neo.SmartContract.Testing.UnitTests/Extensions/TestExtensionsTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Extensions/TestExtensionsTests.cs
@@ -1,7 +1,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Cryptography.ECC;
+using Neo.IO;
+using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.Extensions;
 using Neo.VM;
 using Neo.VM.Types;
+using System.Numerics;
 
 namespace Neo.SmartContract.TestEngine.UnitTests.Extensions
 {
@@ -14,6 +18,18 @@ namespace Neo.SmartContract.TestEngine.UnitTests.Extensions
             StackItem stackItem = new Integer((int)VMState.FAULT);
 
             Assert.AreEqual(VMState.FAULT, (VMState)stackItem.ConvertTo(typeof(VMState)));
+        }
+
+        [TestMethod]
+        public void TestClass()
+        {
+            var point = ECCurve.Secp256r1.G;
+            StackItem stackItem = new Array(new StackItem[] { point.ToArray(), BigInteger.One });
+
+            var ret = (NeoToken.Candidate)stackItem.ConvertTo(typeof(NeoToken.Candidate));
+
+            Assert.AreEqual(point, ret.PublicKey);
+            Assert.AreEqual(1, ret.Votes);
         }
     }
 }

--- a/tests/Neo.SmartContract.Testing.UnitTests/Extensions/TestExtensionsTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Extensions/TestExtensionsTests.cs
@@ -1,8 +1,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Cryptography.ECC;
 using Neo.IO;
-using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.Extensions;
+using Neo.SmartContract.Testing.Native;
 using Neo.VM;
 using Neo.VM.Types;
 using System.Numerics;
@@ -30,6 +30,15 @@ namespace Neo.SmartContract.TestEngine.UnitTests.Extensions
 
             Assert.AreEqual(point, ret.PublicKey);
             Assert.AreEqual(1, ret.Votes);
+        }
+
+        [TestMethod]
+        public void TestValueType()
+        {
+            StackItem stackItem = new Array(new StackItem[] { 1, 2 });
+            var ret = stackItem.ConvertTo(typeof((int, int)));
+
+            Assert.IsTrue(ret.GetType().IsValueType);
         }
     }
 }

--- a/tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
@@ -5,6 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\neo\src\Neo\Neo.csproj" />
 	  <ProjectReference Include="..\..\src\Neo.SmartContract.Testing\Neo.SmartContract.Testing.csproj" />
 	</ItemGroup>
 

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Neo.SmartContract.Testing.Extensions;
+using Neo.SmartContract.Testing.Native;
 using Neo.VM;
 using System.Collections.Generic;
 using System.IO;
@@ -19,7 +20,7 @@ namespace Neo.SmartContract.Testing.UnitTests
         //[TestMethod]
         public void GenerateNativeArtifacts()
         {
-            foreach (var n in Native.NativeContract.Contracts)
+            foreach (var n in Neo.SmartContract.Native.NativeContract.Contracts)
             {
                 var manifest = n.Manifest;
                 var source = manifest.GetArtifactsSource(manifest.Name, generateProperties: true);
@@ -86,14 +87,14 @@ namespace Neo.SmartContract.Testing.UnitTests
         {
             TestEngine engine = new(false);
 
-            Assert.AreEqual(engine.Native.ContractManagement.Hash, Native.NativeContract.ContractManagement.Hash);
-            Assert.AreEqual(engine.Native.StdLib.Hash, Native.NativeContract.StdLib.Hash);
-            Assert.AreEqual(engine.Native.CryptoLib.Hash, Native.NativeContract.CryptoLib.Hash);
-            Assert.AreEqual(engine.Native.GAS.Hash, Native.NativeContract.GAS.Hash);
-            Assert.AreEqual(engine.Native.NEO.Hash, Native.NativeContract.NEO.Hash);
-            Assert.AreEqual(engine.Native.Oracle.Hash, Native.NativeContract.Oracle.Hash);
-            Assert.AreEqual(engine.Native.Policy.Hash, Native.NativeContract.Policy.Hash);
-            Assert.AreEqual(engine.Native.RoleManagement.Hash, Native.NativeContract.RoleManagement.Hash);
+            Assert.AreEqual(engine.Native.ContractManagement.Hash, Neo.SmartContract.Native.NativeContract.ContractManagement.Hash);
+            Assert.AreEqual(engine.Native.StdLib.Hash, Neo.SmartContract.Native.NativeContract.StdLib.Hash);
+            Assert.AreEqual(engine.Native.CryptoLib.Hash, Neo.SmartContract.Native.NativeContract.CryptoLib.Hash);
+            Assert.AreEqual(engine.Native.GAS.Hash, Neo.SmartContract.Native.NativeContract.GAS.Hash);
+            Assert.AreEqual(engine.Native.NEO.Hash, Neo.SmartContract.Native.NativeContract.NEO.Hash);
+            Assert.AreEqual(engine.Native.Oracle.Hash, Neo.SmartContract.Native.NativeContract.Oracle.Hash);
+            Assert.AreEqual(engine.Native.Policy.Hash, Neo.SmartContract.Native.NativeContract.Policy.Hash);
+            Assert.AreEqual(engine.Native.RoleManagement.Hash, Neo.SmartContract.Native.NativeContract.RoleManagement.Hash);
         }
 
         [TestMethod]

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -62,7 +62,7 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             using (ScriptBuilder script = new())
             {
-                script.EmitDynamicCall(neo.Hash, nameof(neo.BalanceOf), engine.ValidatorsAddress);
+                script.EmitDynamicCall(neo.Hash, "balanceOf", engine.ValidatorsAddress);
 
                 Assert.AreEqual(123, engine.Execute(script.ToArray()).GetInteger());
             }


### PR DESCRIPTION
- ```m.Setup(m => m.MyProperty).Returns(123);``` doesn't work before this because the method is `get_MyProperty`
- Simplify class conversion