### PR TITLE
TestEngine: Allow to change the caller

### DIFF
--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -83,6 +83,9 @@ And for read and write, we have:
 
 - **Gas**: Sets the gas execution limit for contract calls. Sets the `NetworkFee` of the `Transaction` object.
 - **EnableCoverageCapture**: Enables or disables the coverage capture. 
+- **Trigger**: The trigger of the execution.
+- **OnGetEntryScriptHash**: This feature makes it easy to change the EntryScriptHash.
+- **OnGetCallingScriptHash**: This feature makes it easy to change the CallingScriptHash.
 
 #### Methods
 

--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -473,3 +473,4 @@ The currently known limitations are:
 
 - Receive events during the deploy, because the object is returned after performing the deploy, it is not possible to intercept notifications for the deploy unless the contract is previously created with `FromHash` knowing the hash of the contract to be created.
 - It is possible that if the contract is updated, the coverage calculation may be incorrect. The update method of a contract can be tested, but if the same script and abi as the original are not used, it can result in a coverage calculation error. 
+- Some native contracts use the values of `CallingScriptHash` and `EntryScriptHash` for certain actions, such as `CheckWitness`, so overriding the syscalls with `OnGetEntryScriptHash` and `OnGetCallingScriptHash` could fail.

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -146,11 +146,13 @@ namespace Neo.SmartContract.Testing
 
         /// <summary>
         /// On GetEntryScriptHash
+        ///     The argument is the ExecutingScriptHash, and it must return the new EntryScriptHash, or null if we don't want to make any change
         /// </summary>
         public Func<UInt160, UInt160?>? OnGetEntryScriptHash { get; set; } = null;
 
         /// <summary>
         /// On GetCallingScriptHash
+        ///     The argument is the ExecutingScriptHash, and it must return the new CallingScriptHash, or null if we don't want to make any change
         /// </summary>
         public Func<UInt160, UInt160?>? OnGetCallingScriptHash { get; set; } = null;
 

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -140,6 +140,21 @@ namespace Neo.SmartContract.Testing
         public Transaction Transaction { get; }
 
         /// <summary>
+        /// The trigger of the execution.
+        /// </summary>
+        public TriggerType Trigger { get; set; } = TriggerType.Application;
+
+        /// <summary>
+        /// On GetEntryScriptHash
+        /// </summary>
+        public Func<UInt160, UInt160?>? OnGetEntryScriptHash { get; set; } = null;
+
+        /// <summary>
+        /// On GetCallingScriptHash
+        /// </summary>
+        public Func<UInt160, UInt160?>? OnGetCallingScriptHash { get; set; } = null;
+
+        /// <summary>
         /// Gas
         /// </summary>
         public long Gas
@@ -512,7 +527,7 @@ namespace Neo.SmartContract.Testing
 
             var snapshot = Storage.Snapshot.CreateSnapshot();
 
-            using var engine = new TestingApplicationEngine(this, TriggerType.Application, Transaction, snapshot, CurrentBlock);
+            using var engine = new TestingApplicationEngine(this, Trigger, Transaction, snapshot, CurrentBlock);
 
             engine.LoadScript(script);
 

--- a/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
@@ -165,11 +165,32 @@ namespace Neo.SmartContract.Testing
 
         protected override void OnSysCall(InteropDescriptor descriptor)
         {
-            // Check if the syscall is a contract call and we need to mock it because it was defined by the user
-
-            if (descriptor.Hash == 1381727586 && descriptor.Name == "System.Contract.Call" && descriptor.Parameters.Count == 4)
+            if (descriptor == System_Runtime_GetEntryScriptHash)
             {
-                // Extract args
+                var currentHash = InstructionContext.GetScriptHash();
+                var hash = Engine.OnGetEntryScriptHash?.Invoke(currentHash);
+
+                if (hash is not null)
+                {
+                    Push(Convert(hash));
+                    return;
+                }
+            }
+            else if (descriptor == System_Runtime_GetCallingScriptHash)
+            {
+                var currentHash = InstructionContext.GetScriptHash();
+                var hash = Engine.OnGetCallingScriptHash?.Invoke(currentHash);
+
+                if (hash is not null)
+                {
+                    Push(Convert(hash));
+                    return;
+                }
+            }
+            //  descriptor.Hash == 1381727586 && descriptor.Name == "System.Contract.Call" && descriptor.Parameters.Count == 4)
+            else if (descriptor == System_Contract_Call)
+            {
+                // Check if the syscall is a contract call and we need to mock it because it was defined by the user
 
                 if (Convert(Peek(0), descriptor.Parameters[0]) is UInt160 contractHash &&
                     Convert(Peek(1), descriptor.Parameters[1]) is string method &&

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using Neo.SmartContract.Testing.Extensions;
 using Neo.SmartContract.Testing.Native;
 using Neo.VM;
+using Neo.VM.Types;
 using System.Collections.Generic;
 using System.IO;
 
@@ -28,6 +29,36 @@ namespace Neo.SmartContract.Testing.UnitTests
 
                 File.WriteAllText(fullPath, source);
             }
+        }
+
+        [TestMethod]
+        public void TestOnGetEntryScriptHash()
+        {
+            TestEngine engine = new(true);
+
+            var builder = new ScriptBuilder();
+            builder.EmitSysCall(ApplicationEngine.System_Runtime_GetEntryScriptHash);
+            var script = builder.ToArray();
+
+            Assert.AreEqual("0xfa99b1aeedab84a47856358515e7f982341aa767", engine.Execute(script).ConvertTo(typeof(UInt160)).ToString());
+
+            engine.OnGetEntryScriptHash = caller => UInt160.Parse("0x0000000000000000000000000000000000000001");
+            Assert.AreEqual("0x0000000000000000000000000000000000000001", engine.Execute(script).ConvertTo(typeof(UInt160)).ToString());
+        }
+
+        [TestMethod]
+        public void TestOnGetCallingScriptHash()
+        {
+            TestEngine engine = new(true);
+
+            var builder = new ScriptBuilder();
+            builder.EmitSysCall(ApplicationEngine.System_Runtime_GetCallingScriptHash);
+            var script = builder.ToArray();
+
+            Assert.AreEqual(StackItem.Null, engine.Execute(script));
+
+            engine.OnGetCallingScriptHash = caller => UInt160.Parse("0x0000000000000000000000000000000000000001");
+            Assert.AreEqual("0x0000000000000000000000000000000000000001", engine.Execute(script).ConvertTo(typeof(UInt160)).ToString());
         }
 
         [TestMethod]

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -42,7 +42,7 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             Assert.AreEqual("0xfa99b1aeedab84a47856358515e7f982341aa767", engine.Execute(script).ConvertTo(typeof(UInt160)).ToString());
 
-            engine.OnGetEntryScriptHash = caller => UInt160.Parse("0x0000000000000000000000000000000000000001");
+            engine.OnGetEntryScriptHash = current => UInt160.Parse("0x0000000000000000000000000000000000000001");
             Assert.AreEqual("0x0000000000000000000000000000000000000001", engine.Execute(script).ConvertTo(typeof(UInt160)).ToString());
         }
 
@@ -57,7 +57,7 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             Assert.AreEqual(StackItem.Null, engine.Execute(script));
 
-            engine.OnGetCallingScriptHash = caller => UInt160.Parse("0x0000000000000000000000000000000000000001");
+            engine.OnGetCallingScriptHash = current => UInt160.Parse("0x0000000000000000000000000000000000000001");
             Assert.AreEqual("0x0000000000000000000000000000000000000001", engine.Execute(script).ConvertTo(typeof(UInt160)).ToString());
         }
 


### PR DESCRIPTION
Before this change it's not possible to fake (easy) this method for testing

```csharp
public static bool ItsMe()
{
    Assert(Runtime.CallingScriptHash == Runtime.ExecutingScriptHash, "only me");
    return true;
}
```