### PR TITLE
Fixes for compiling multi contracts in single csproj

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine.cs
@@ -172,8 +172,9 @@ namespace Neo.Compiler
         {
             string folder = Path.GetDirectoryName(csproj)!;
             string obj = Path.Combine(folder, "obj");
+            string binSc = Path.Combine(Path.Combine(folder, "bin"), "sc");
             HashSet<string> sourceFiles = Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories)
-                .Where(p => !p.StartsWith(obj))
+                .Where(p => !p.StartsWith(obj) && !p.StartsWith(binSc))
                 .GroupBy(Path.GetFileName)
                 .Select(g => g.First())
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -138,7 +138,22 @@ namespace Neo.Compiler
 
         private static int ProcessOutputs(Options options, string folder, List<CompilationContext> contexts)
         {
-            return contexts.Select(p => ProcessOutput(options, folder, p)).Any(p => p != 1) ? 0 : 1;
+            int result = 0;
+            List<Exception> exceptions = new();
+            foreach (CompilationContext context in contexts)
+                try
+                {
+                    if (ProcessOutput(options, folder, context) != 0)
+                        result = 1;
+                }
+                catch (Exception e)
+                {
+                    result = 1;
+                    exceptions.Add(e);
+                }
+            foreach (Exception e in exceptions)
+                Console.Error.WriteLine(e.ToString());
+            return result;
         }
 
         private static int ProcessOutput(Options options, string folder, CompilationContext context)


### PR DESCRIPTION
1. I believe there are problems at https://github.com/neo-project/neo-devpack-dotnet/blob/7add5a9139a57bc0743d367aa048f4408c66ff8b/src/Neo.Compiler.CSharp/Program.cs#L139-L142  A return value of 0 means correct compilation, while the current codes immediately returns 0 on any p != 1. This does not consider the compilation of the subsequent multiple contracts, and does not handle exceptions.
2. Current codes may build `.artifacts.cs` files in the output directory. If a user just want everything to be placed in `bin/sc`, the `artifacts.cs` may be considered as contract source codes, when the compiler is run for the second time. I asked the compiler to ignore `bin/sc`, but this **DOES NOT** fix the cases where users place outputs in another directory contained by the directory of the `.csproj`.