### PR TITLE
ensure finally executed on exceptions from catch

### DIFF
--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_TryCatch.cs
@@ -99,6 +99,25 @@ namespace Neo.Compiler.CSharp.UnitTests.TestClasses
             return v;
         }
 
+        public static object throwInCatch()
+        {
+            int v = 0;
+            try
+            {
+                v = 1;
+                throw new System.Exception();
+            }
+            catch
+            {
+                v = 2;
+                throw new System.Exception();
+            }
+            finally
+            {
+                v = 3;
+            }
+        }
+
         public static object tryFinally()
         {
             int v = 0;

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
@@ -77,6 +77,17 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         [TestMethod]
+        public void Test_ThrowInCatch()
+        {
+            testengine.Reset();
+            var result = testengine.ExecuteTestCaseStandard("throwInCatch");
+            Console.WriteLine("state=" + testengine.State + "  result on stack= " + result.Count);
+            Assert.AreEqual(VM.VMState.FAULT, testengine.State);
+            var v = testengine.CurrentContext.LocalVariables[0];
+            Assert.AreEqual(v.GetInteger(), 3);
+        }
+
+        [TestMethod]
         public void Test_TryFinally()
         {
             testengine.Reset();


### PR DESCRIPTION
I am directly checking `testengine.CurrentContext.LocalVariables[0]`, without making sure it is actually the variable `v`.