### PR TITLE
TestEngine: Some fixes

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine.cs
@@ -249,7 +249,7 @@ namespace Neo.Compiler
             if (!remove.Contains("*.cs"))
             {
                 var obj = Path.Combine(folder, "obj");
-                var binSc = Path.Combine(Path.Combine(folder, "bin"), "sc");
+                var binSc = Path.Combine(folder, "bin");
                 foreach (var entry in Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories)
                       .Where(p => !p.StartsWith(obj) && !p.StartsWith(binSc))
                       .Select(u => u))

--- a/src/Neo.Compiler.CSharp/CompilationOptions.cs
+++ b/src/Neo.Compiler.CSharp/CompilationOptions.cs
@@ -32,7 +32,7 @@ namespace Neo.Compiler
         public OptimizationType Optimize { get; set; } = OptimizationType.Basic;
         public bool Checked { get; set; }
         public bool NoInline { get; set; }
-        public byte AddressVersion { get; set; }
+        public byte AddressVersion { get; set; } = 0x35;
         public string? BaseName { get; set; }
 
         private CSharpParseOptions? parseOptions = null;

--- a/src/Neo.SmartContract.Testing/Coverage/CoveredCollection.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/CoveredCollection.cs
@@ -61,12 +61,12 @@ namespace Neo.SmartContract.Testing.Coverage
         /// <returns>Coverage dump</returns>
         public override string Dump(DumpFormat format = DumpFormat.Console)
         {
-            switch (format)
+            return format switch
             {
-                case DumpFormat.Console: return new ConsoleFormat(GetEntries()).Dump();
-                case DumpFormat.Html: return new IntructionHtmlFormat(GetEntries()).Dump();
-                default: throw new NotImplementedException();
-            }
+                DumpFormat.Console => new ConsoleFormat(GetEntries()).Dump(),
+                DumpFormat.Html => new IntructionHtmlFormat(GetEntries()).Dump(),
+                _ => throw new NotImplementedException(),
+            };
         }
 
         /// <summary>

--- a/src/Neo.SmartContract.Testing/Coverage/CoveredContract.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/CoveredContract.cs
@@ -292,12 +292,12 @@ namespace Neo.SmartContract.Testing.Coverage
         /// <returns>Coverage dump</returns>
         public override string Dump(DumpFormat format = DumpFormat.Console)
         {
-            switch (format)
+            return format switch
             {
-                case DumpFormat.Console: return new ConsoleFormat(this).Dump();
-                case DumpFormat.Html: return new IntructionHtmlFormat(this).Dump();
-                default: throw new NotImplementedException();
-            }
+                DumpFormat.Console => new ConsoleFormat(this).Dump(),
+                DumpFormat.Html => new IntructionHtmlFormat(this).Dump(),
+                _ => throw new NotImplementedException(),
+            };
         }
 
         /// <summary>

--- a/src/Neo.SmartContract.Testing/Coverage/CoveredMethod.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/CoveredMethod.cs
@@ -61,12 +61,12 @@ namespace Neo.SmartContract.Testing.Coverage
         /// <returns>Coverage dump</returns>
         public override string Dump(DumpFormat format = DumpFormat.Console)
         {
-            switch (format)
+            return format switch
             {
-                case DumpFormat.Console: return new ConsoleFormat(Contract, m => ReferenceEquals(m, this)).Dump();
-                case DumpFormat.Html: return new IntructionHtmlFormat(Contract, m => ReferenceEquals(m, this)).Dump();
-                default: throw new NotImplementedException();
-            }
+                DumpFormat.Console => new ConsoleFormat(Contract, m => ReferenceEquals(m, this)).Dump(),
+                DumpFormat.Html => new IntructionHtmlFormat(Contract, m => ReferenceEquals(m, this)).Dump(),
+                _ => throw new NotImplementedException(),
+            };
         }
 
         public override string ToString() => Method.ToString();

--- a/src/Neo.SmartContract.Testing/Coverage/Formats/ConsoleFormat.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/Formats/ConsoleFormat.cs
@@ -19,7 +19,7 @@ namespace Neo.SmartContract.Testing.Coverage.Formats
         /// <param name="filter">Method Filter</param>
         public ConsoleFormat(CoveredContract contract, Func<CoveredMethod, bool>? filter = null)
         {
-            Entries = new (CoveredContract, Func<CoveredMethod, bool>?)[] { (contract, filter) };
+            Entries = new[] { (contract, filter) };
         }
 
         /// <summary>
@@ -69,13 +69,13 @@ namespace Neo.SmartContract.Testing.Coverage.Formats
                     max[2] = Math.Max(coverLines.Length, max[2]);
                 }
 
-                writer.WriteLine($"┌-{"─".PadLeft(max[0], '─')}-┬-{"─".PadLeft(max[1], '─')}-┬-{"─".PadLeft(max[1], '─')}-┐");
-                writer.WriteLine($"│ {string.Format($"{{0,-{max[0]}}}", "Method", max[0])} │ {string.Format($"{{0,{max[1]}}}", "Line  ", max[1])} │ {string.Format($"{{0,{max[2]}}}", "Branch", max[1])} │");
-                writer.WriteLine($"├-{"─".PadLeft(max[0], '─')}-┼-{"─".PadLeft(max[1], '─')}-┼-{"─".PadLeft(max[1], '─')}-┤");
+                writer.WriteLine($"┌-{"─".PadLeft(max[0], '─')}-┬-{"─".PadLeft(max[1], '─')}-┬-{"─".PadLeft(max[2], '─')}-┐");
+                writer.WriteLine($"│ {string.Format($"{{0,-{max[0]}}}", "Method", max[0])} │ {string.Format($"{{0,{max[1]}}}", "Line  ", max[1])} │ {string.Format($"{{0,{max[2]}}}", "Branch", max[2])} │");
+                writer.WriteLine($"├-{"─".PadLeft(max[0], '─')}-┼-{"─".PadLeft(max[1], '─')}-┼-{"─".PadLeft(max[2], '─')}-┤");
 
                 foreach (var print in rows)
                 {
-                    writer.WriteLine($"│ {string.Format($"{{0,-{max[0]}}}", print[0], max[0])} │ {string.Format($"{{0,{max[1]}}}", print[1], max[1])} │ {string.Format($"{{0,{max[1]}}}", print[2], max[2])} │");
+                    writer.WriteLine($"│ {string.Format($"{{0,-{max[0]}}}", print[0], max[0])} │ {string.Format($"{{0,{max[1]}}}", print[1], max[1])} │ {string.Format($"{{0,{max[2]}}}", print[2], max[2])} │");
                 }
 
                 writer.WriteLine($"└-{"─".PadLeft(max[0], '─')}-┴-{"─".PadLeft(max[1], '─')}-┴-{"─".PadLeft(max[2], '─')}-┘");

--- a/src/Neo.SmartContract.Testing/Extensions/TestExtensions.cs
+++ b/src/Neo.SmartContract.Testing/Extensions/TestExtensions.cs
@@ -1,4 +1,3 @@
-using Akka.Util;
 using Neo.Cryptography.ECC;
 using Neo.SmartContract.Testing.Attributes;
 using Neo.VM.Types;
@@ -50,6 +49,7 @@ namespace Neo.SmartContract.Testing.Extensions
 
             return type switch
             {
+                _ when type == stackItem.GetType() => stackItem,
                 _ when type == typeof(object) => stackItem,
                 _ when type == typeof(string) => Utility.StrictUTF8.GetString(stackItem.GetSpan()),
                 _ when type == typeof(byte[]) => stackItem.GetSpan().ToArray(),

--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -84,6 +84,7 @@ And for read and write, we have:
 - **Gas**: Sets the gas execution limit for contract calls. Sets the `NetworkFee` of the `Transaction` object.
 - **EnableCoverageCapture**: Enables or disables the coverage capture. 
 - **Trigger**: The trigger of the execution.
+- **CallFlags**: Define the `CallFlags` for the mocked function, `All` by default.
 - **OnGetEntryScriptHash**: This feature makes it easy to change the EntryScriptHash.
 - **OnGetCallingScriptHash**: This feature makes it easy to change the CallingScriptHash.
 

--- a/src/Neo.SmartContract.Testing/SmartContract.cs
+++ b/src/Neo.SmartContract.Testing/SmartContract.cs
@@ -55,6 +55,20 @@ namespace Neo.SmartContract.Testing
 
             using ScriptBuilder script = new();
 
+            ConvertArgs(script, args);
+
+            script.EmitPush(Engine.CallFlags);
+            script.EmitPush(methodName);
+            script.EmitPush(Hash);
+            script.EmitSysCall(ApplicationEngine.System_Contract_Call);
+
+            // Execute
+
+            return Engine.Execute(script.ToArray());
+        }
+
+        private void ConvertArgs(ScriptBuilder script, object[] args)
+        {
             if (args is null || args.Length == 0)
                 script.Emit(OpCode.NEWARRAY0);
             else
@@ -62,6 +76,11 @@ namespace Neo.SmartContract.Testing
                 for (int i = args.Length - 1; i >= 0; i--)
                 {
                     var arg = args[i];
+                    if (arg is object[] arg2)
+                    {
+                        ConvertArgs(script, arg2);
+                        break;
+                    }
 
                     if (ReferenceEquals(arg, InvalidTypes.InvalidUInt160.InvalidLength) ||
                         ReferenceEquals(arg, InvalidTypes.InvalidUInt256.InvalidLength))
@@ -79,15 +98,6 @@ namespace Neo.SmartContract.Testing
                 script.EmitPush(args.Length);
                 script.Emit(OpCode.PACK);
             }
-
-            script.EmitPush(CallFlags.All);
-            script.EmitPush(methodName);
-            script.EmitPush(Hash);
-            script.EmitSysCall(ApplicationEngine.System_Contract_Call);
-
-            // Execute
-
-            return Engine.Execute(script.ToArray());
         }
 
         /// <summary>

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -173,6 +173,11 @@ namespace Neo.SmartContract.Testing
         public UInt160 Sender => Transaction.Sender;
 
         /// <summary>
+        /// Call flags
+        /// </summary>
+        public CallFlags CallFlags { get; set; } = CallFlags.All;
+
+        /// <summary>
         /// Native artifacts
         /// </summary>
         public NativeArtifacts Native

--- a/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
@@ -3,12 +3,15 @@ using Neo.IO;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Testing.Coverage;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Neo.SmartContract.Testing.TestingStandards;
 
 public class TestBase<T> where T : SmartContract
 {
+    private readonly List<string> _contractLogs = new();
+
     public static CoveredContract? Coverage { get; private set; }
     public static Signer Alice { get; } = TestEngine.GetNewSigner();
     public static Signer Bob { get; } = TestEngine.GetNewSigner();
@@ -53,13 +56,44 @@ public class TestBase<T> where T : SmartContract
             Coverage = Contract.GetCoverage()!;
             Assert.IsNotNull(Coverage);
         }
+
+        Contract.OnRuntimeLog += Contract_OnRuntimeLog;
     }
+
+    private void Contract_OnRuntimeLog(string message)
+    {
+        _contractLogs.Add(message);
+    }
+
+    #region Asserts
+
+    /// <summary>
+    /// Assert that Log event was raised
+    /// </summary>
+    /// <param name="logs">Logs</param>
+    public void AssertLogs(params string[] logs)
+    {
+        Assert.AreEqual(logs.Length, _contractLogs.Count);
+        CollectionAssert.AreEqual(_contractLogs, logs);
+        _contractLogs.Clear();
+    }
+
+    /// <summary>
+    /// Assert that Transfer event was NOT raised
+    /// </summary>
+    public void AssertNoLogs()
+    {
+        Assert.AreEqual(0, _contractLogs.Count);
+    }
+
+    #endregion
 
     [TestCleanup]
     public virtual void OnCleanup()
     {
         // Join the current coverage into the static one
 
+        Contract.OnRuntimeLog -= Contract_OnRuntimeLog;
         Coverage?.Join(Contract.GetCoverage());
     }
 }

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep17/TestingArtifacts/Nep17ContractTemplate.artifacts.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep17/TestingArtifacts/Nep17ContractTemplate.artifacts.cs
@@ -1,4 +1,5 @@
 using Neo.Cryptography.ECC;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractoracle/TestingArtifacts/OracleRequestTemplate.artifacts.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractoracle/TestingArtifacts/OracleRequestTemplate.artifacts.cs
@@ -1,4 +1,5 @@
 using Neo.Cryptography.ECC;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractowner/TestingArtifacts/OwnableTemplate.artifacts.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractowner/TestingArtifacts/OwnableTemplate.artifacts.cs
@@ -1,4 +1,5 @@
 using Neo.Cryptography.ECC;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;

--- a/tests/Neo.SmartContract.Testing.UnitTests/Extensions/ArtifactExtensionsTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Extensions/ArtifactExtensionsTests.cs
@@ -20,6 +20,7 @@ namespace Neo.SmartContract.Testing.UnitTests.Extensions
 
             Assert.AreEqual(source, @"
 using Neo.Cryptography.ECC;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;


### PR DESCRIPTION
In order to reduce the changes from https://github.com/neo-project/neo-devpack-dotnet/pull/968 I will separate the fixes found during the process

- Fixed console coverage output.
- Added `CallFlags` in TestEngine.