### PR TITLE
Sync native RoleManagement node roles with the Neo core

### DIFF
--- a/src/Neo.SmartContract.Framework/Native/Role.cs
+++ b/src/Neo.SmartContract.Framework/Native/Role.cs
@@ -13,6 +13,7 @@ namespace Neo.SmartContract.Framework.Native
     public enum Role : byte
     {
         StateValidator = 4,
-        Oracle = 8
+        Oracle = 8,
+        NeoFSAlphabetNode = 16
     }
 }

--- a/src/Neo.SmartContract.Framework/Native/Role.cs
+++ b/src/Neo.SmartContract.Framework/Native/Role.cs
@@ -10,10 +10,24 @@
 
 namespace Neo.SmartContract.Framework.Native
 {
+    /// <summary>
+    /// Represents the roles in the NEO system.
+    /// </summary>
     public enum Role : byte
     {
+        /// <summary>
+        /// The validators of state. Used to generate and sign the state root.
+        /// </summary>
         StateValidator = 4,
+
+        /// <summary>
+        /// The nodes used to process Oracle requests.
+        /// </summary>
         Oracle = 8,
+
+        /// <summary>
+        /// NeoFS Alphabet nodes.
+        /// </summary>
         NeoFSAlphabetNode = 16
     }
 }


### PR DESCRIPTION
In this PR:
* Add missing NeoFSAlphabetNode role (ref. https://github.com/neo-project/neo/blob/d3c91750cc64f16bacecec0eaebd52cf1a35f882/src/Neo/SmartContract/Native/Role.cs#L32).
* Add documentation to node roles.