### PR TITLE
Contract in basic blocks

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
@@ -67,8 +67,10 @@ namespace Neo.Optimizer
                     basicBlocksByStartingInstruction[block.First()].jumpTargetBlock1 = basicBlocksByStartingInstruction[target];
                 if (coverage.tryInstructionSourceToTargets.TryGetValue(lastInstruction, out (Instruction, Instruction) targets))
                 {
-                    basicBlocksByStartingInstruction[block.First()].jumpTargetBlock1 = basicBlocksByStartingInstruction[targets.Item1];
-                    basicBlocksByStartingInstruction[block.First()].jumpTargetBlock2 = basicBlocksByStartingInstruction[targets.Item2];
+                    if (lastInstruction != targets.Item1)
+                        basicBlocksByStartingInstruction[block.First()].jumpTargetBlock1 = basicBlocksByStartingInstruction[targets.Item1];
+                    if (lastInstruction != targets.Item2)
+                        basicBlocksByStartingInstruction[block.First()].jumpTargetBlock2 = basicBlocksByStartingInstruction[targets.Item2];
                 }
             }
             this.basicBlocks = basicBlocksByStartingInstruction.Values.ToList();

--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
@@ -6,9 +6,33 @@ using System.Collections.Generic;
 
 namespace Neo.Optimizer
 {
-    static class BasicBlock
+    class BasicBlock
     {
         public static Dictionary<int, Dictionary<int, Instruction>> FindBasicBlocks(NefFile nef, ContractManifest manifest, JToken debugInfo)
             => new InstructionCoverage(nef, manifest, debugInfo).basicBlocks;
+
+        public List<Instruction> instructions { get; set; }
+        public BasicBlock? nextBlock = null;
+        public BasicBlock? jumpTargetBlock1 = null;
+        public BasicBlock? jumpTargetBlock2 = null;
+
+        public BasicBlock(List<Instruction> instructions)
+        {
+            this.instructions = instructions;
+        }
+
+        public void SetNextBasicBlock(BasicBlock block) => this.nextBlock = block;
+        public void SetJumpTargetBlock1(BasicBlock block) => this.jumpTargetBlock1 = block;
+        public void SetJumpTargetBlock2(BasicBlock block) => this.jumpTargetBlock2 = block;
+    }
+
+    class BasicBlocksInContract
+    {
+        List<BasicBlock> basicBlocks;
+        public BasicBlocksInContract(NefFile nef, ContractManifest manifest, JToken debugInfo)
+        {
+            InstructionCoverage coverage = new InstructionCoverage(nef, manifest, debugInfo);
+            Dictionary<int, Dictionary<int, Instruction>> basicBlocks = coverage.basicBlocks;
+        }
     }
 }

--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
@@ -3,14 +3,12 @@ using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.VM;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Neo.Optimizer
 {
-    class BasicBlock
+    public class BasicBlock
     {
-        public static Dictionary<int, Dictionary<int, Instruction>> FindBasicBlocks(NefFile nef, ContractManifest manifest, JToken debugInfo)
-            => new InstructionCoverage(nef, manifest, debugInfo).basicBlocks;
-
         public List<Instruction> instructions { get; set; }
         public BasicBlock? nextBlock = null;
         public BasicBlock? jumpTargetBlock1 = null;
@@ -21,18 +19,66 @@ namespace Neo.Optimizer
             this.instructions = instructions;
         }
 
-        public void SetNextBasicBlock(BasicBlock block) => this.nextBlock = block;
-        public void SetJumpTargetBlock1(BasicBlock block) => this.jumpTargetBlock1 = block;
-        public void SetJumpTargetBlock2(BasicBlock block) => this.jumpTargetBlock2 = block;
+        public BasicBlock(Dictionary<int, Instruction> instructions)
+        {
+            this.instructions = (from kv in instructions orderby kv.Key ascending select kv.Value).ToList();
+        }
+
+        //public void SetNextBasicBlock(BasicBlock block) => this.nextBlock = block;
+        //public void SetJumpTargetBlock1(BasicBlock block) => this.jumpTargetBlock1 = block;
+        //public void SetJumpTargetBlock2(BasicBlock block) => this.jumpTargetBlock2 = block;
     }
 
-    class BasicBlocksInContract
+    public class ContractInBasicBlocks
     {
-        List<BasicBlock> basicBlocks;
-        public BasicBlocksInContract(NefFile nef, ContractManifest manifest, JToken debugInfo)
+        public static Dictionary<int, Dictionary<int, Instruction>> BasicBlocksInDict(NefFile nef, ContractManifest manifest, JToken debugInfo)
+            => new InstructionCoverage(nef, manifest, debugInfo).basicBlocksInDict;
+
+        public List<BasicBlock> basicBlocks;
+        public Dictionary<Instruction, BasicBlock> basicBlocksByStartingInstruction;
+        public ContractManifest manifest;
+        public JToken debugInfo;
+        public ContractInBasicBlocks(NefFile nef, ContractManifest manifest, JToken debugInfo)
         {
-            InstructionCoverage coverage = new InstructionCoverage(nef, manifest, debugInfo);
-            Dictionary<int, Dictionary<int, Instruction>> basicBlocks = coverage.basicBlocks;
+            this.manifest = manifest;
+            this.debugInfo = debugInfo;
+            InstructionCoverage coverage = new(nef, manifest, debugInfo);
+            IEnumerable<(int startingAddr, List<Instruction> block)> sortedBasicBlocks =
+                from kv in coverage.basicBlocksInDict
+                orderby kv.Key ascending
+                select (kv.Key,
+                    // kv.Value sorted by address
+                    (from singleBlockKv in kv.Value orderby singleBlockKv.Key ascending select singleBlockKv.Value).ToList()
+                );
+            basicBlocksByStartingInstruction = new();
+            BasicBlock? prevBlock = null;
+            foreach ((int startingAddr, List<Instruction> block) in sortedBasicBlocks)
+            {
+                BasicBlock thisBlock = new(block);
+                basicBlocksByStartingInstruction.Add(block.First(), thisBlock);
+                if (prevBlock != null)
+                    prevBlock.nextBlock = thisBlock;
+                prevBlock = thisBlock;
+            }
+            foreach ((int startingAddr, List<Instruction> block) in sortedBasicBlocks)
+            {
+                Instruction lastInstruction = block.Last();
+                if (coverage.jumpInstructionSourceToTargets.TryGetValue(lastInstruction, out Instruction? target))
+                    basicBlocksByStartingInstruction[block.First()].jumpTargetBlock1 = basicBlocksByStartingInstruction[target];
+                if (coverage.tryInstructionSourceToTargets.TryGetValue(lastInstruction, out (Instruction, Instruction) targets))
+                {
+                    basicBlocksByStartingInstruction[block.First()].jumpTargetBlock1 = basicBlocksByStartingInstruction[targets.Item1];
+                    basicBlocksByStartingInstruction[block.First()].jumpTargetBlock2 = basicBlocksByStartingInstruction[targets.Item2];
+                }
+            }
+            this.basicBlocks = basicBlocksByStartingInstruction.Values.ToList();
+        }
+
+        public IEnumerable<Instruction> EnumerateInstructions()
+        {
+            foreach (BasicBlock basicBlock in basicBlocks)
+                foreach (Instruction instruction in basicBlock.instructions)
+                    yield return instruction;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/InstructionCoverage.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/InstructionCoverage.cs
@@ -33,6 +33,8 @@ namespace Neo.Optimizer
         public Dictionary<int, BranchType> coveredMap { get; protected set; }
         public Dictionary<int, Dictionary<int, Instruction>> basicBlocks { get; protected set; }
         public List<(int a, Instruction i)> addressAndInstructions { get; init; }
+        public Dictionary<Instruction, Instruction> jumpInstructionSourceToTargets { get; init; }
+        public Dictionary<Instruction, (Instruction, Instruction)> tryInstructionSourceToTargets { get; init; }
         public Dictionary<int, HashSet<int>> jumpTargetToSources { get; init; }
         public InstructionCoverage(NefFile nef, ContractManifest manifest, JToken debugInfo)
         {
@@ -40,7 +42,8 @@ namespace Neo.Optimizer
             coveredMap = new();
             basicBlocks = new();
             addressAndInstructions = script.EnumerateInstructions().ToList();
-            (_, _, jumpTargetToSources) = FindAllJumpAndTrySourceToTargets(addressAndInstructions);
+            (jumpInstructionSourceToTargets, tryInstructionSourceToTargets, jumpTargetToSources) =
+                FindAllJumpAndTrySourceToTargets(addressAndInstructions);
             foreach ((int addr, Instruction _) in addressAndInstructions)
                 coveredMap.Add(addr, BranchType.UNCOVERED);
 

--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/JumpTarget.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/JumpTarget.cs
@@ -56,7 +56,7 @@ namespace Neo.Optimizer
 
         public static (Dictionary<Instruction, Instruction>,
             Dictionary<Instruction, (Instruction, Instruction)>,
-            Dictionary<int, HashSet<int>>)
+            Dictionary<Instruction, HashSet<Instruction>>)
             FindAllJumpAndTrySourceToTargets(NefFile nef)
         {
             Script script = nef.Script;
@@ -64,12 +64,28 @@ namespace Neo.Optimizer
         }
         public static (Dictionary<Instruction, Instruction>,
             Dictionary<Instruction, (Instruction, Instruction)>,
-            Dictionary<int, HashSet<int>>)
+            Dictionary<Instruction, HashSet<Instruction>>)
             FindAllJumpAndTrySourceToTargets(Script script) => FindAllJumpAndTrySourceToTargets(script.EnumerateInstructions().ToList());
         public static (
             Dictionary<Instruction, Instruction>,  // jump source to target
             Dictionary<Instruction, (Instruction, Instruction)>,  // try source to targets
-            Dictionary<int, HashSet<int>>  // target to source
+            Dictionary<Instruction, HashSet<Instruction>>  // target to source
+            )
+            FindAllJumpAndTrySourceToTargets(List<Instruction> instructionsList)
+        {
+            int addr = 0;
+            List<(int, Instruction)> addressAndInstructionsList = new();
+            foreach (Instruction i in instructionsList)
+            {
+                addressAndInstructionsList.Add((addr, i));
+                addr += i.Size;
+            }
+            return FindAllJumpAndTrySourceToTargets(addressAndInstructionsList);
+        }
+        public static (
+            Dictionary<Instruction, Instruction>,  // jump source to target
+            Dictionary<Instruction, (Instruction, Instruction)>,  // try source to targets
+            Dictionary<Instruction, HashSet<Instruction>>  // target to source
             )
             FindAllJumpAndTrySourceToTargets(List<(int, Instruction)> addressAndInstructionsList)
         {
@@ -78,7 +94,7 @@ namespace Neo.Optimizer
                 addressToInstruction.Add(a, i);
             Dictionary<Instruction, Instruction> jumpSourceToTargets = new();
             Dictionary<Instruction, (Instruction, Instruction)> trySourceToTargets = new();
-            Dictionary<int, HashSet<int>> targetToSources = new();
+            Dictionary<Instruction, HashSet<Instruction>> targetToSources = new();
             foreach ((int a, Instruction i) in addressAndInstructionsList)
             {
                 if (SingleJumpInOperand(i))
@@ -86,12 +102,12 @@ namespace Neo.Optimizer
                     int targetAddr = ComputeJumpTarget(a, i);
                     Instruction target = addressToInstruction[targetAddr];
                     jumpSourceToTargets.TryAdd(i, target);
-                    if (!targetToSources.TryGetValue(targetAddr, out HashSet<int>? sources))
+                    if (!targetToSources.TryGetValue(target, out HashSet<Instruction>? sources))
                     {
                         sources = new();
-                        targetToSources.Add(targetAddr, sources);
+                        targetToSources.Add(target, sources);
                     }
-                    sources.Add(a);
+                    sources.Add(i);
                 }
                 if (i.OpCode == TRY || i.OpCode == TRY_L)
                 {
@@ -100,18 +116,18 @@ namespace Neo.Optimizer
                         (a + i.TokenI32, a + i.TokenI32_1);
                     (Instruction t1, Instruction t2) = (addressToInstruction[a1], addressToInstruction[a2]);
                     trySourceToTargets.TryAdd(i, (t1, t2));
-                    if (!targetToSources.TryGetValue(a1, out HashSet<int>? sources1))
+                    if (!targetToSources.TryGetValue(t1, out HashSet<Instruction>? sources1))
                     {
                         sources1 = new();
-                        targetToSources.Add(a1, sources1);
+                        targetToSources.Add(t1, sources1);
                     }
-                    sources1.Add(a);
-                    if (!targetToSources.TryGetValue(a1, out HashSet<int>? sources2))
+                    sources1.Add(i);
+                    if (!targetToSources.TryGetValue(t1, out HashSet<Instruction>? sources2))
                     {
                         sources2 = new();
-                        targetToSources.Add(a2, sources2);
+                        targetToSources.Add(t2, sources2);
                     }
-                    sources2.Add(a);
+                    sources2.Add(i);
                 }
             }
             return (jumpSourceToTargets, trySourceToTargets, targetToSources);

--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/OpCodeTypes.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/OpCodeTypes.cs
@@ -1,4 +1,6 @@
 using Neo.VM;
+using System;
+using System.Linq;
 using System.Collections.Generic;
 using static Neo.VM.OpCode;
 
@@ -7,6 +9,7 @@ namespace Neo.Optimizer
     static class OpCodeTypes
     {
         public static readonly HashSet<OpCode> push = new();
+        public static readonly HashSet<OpCode> allowedBasicBlockEnds;
 
         static OpCodeTypes()
         {
@@ -18,12 +21,16 @@ namespace Neo.Optimizer
             push.Add(PUSHNULL);
             foreach (OpCode op in pushData)
                 push.Add(op);
-            foreach (OpCode op in pushConst)
+            foreach (OpCode op in pushConstInt)
                 push.Add(op);
             foreach (OpCode op in pushStackOps)
                 push.Add(op);
             foreach (OpCode op in pushNewCompoundType)
                 push.Add(op);
+            allowedBasicBlockEnds = ((OpCode[])Enum.GetValues(typeof(OpCode)))
+                    .Where(i => JumpTarget.SingleJumpInOperand(i) && i != PUSHA || JumpTarget.DoubleJumpInOperand(i)).ToHashSet()
+                    .Union(new HashSet<OpCode>() { RET, ABORT, ABORTMSG, THROW, ENDFINALLY
+            }).ToHashSet();
         }
 
         public static readonly HashSet<OpCode> pushInt = new()
@@ -48,7 +55,7 @@ namespace Neo.Optimizer
             PUSHDATA4,
         };
 
-        public static readonly HashSet<OpCode> pushConst = new()
+        public static readonly HashSet<OpCode> pushConstInt = new()
         {
             PUSHM1,
             PUSH0,
@@ -130,6 +137,67 @@ namespace Neo.Optimizer
             JMPGE_L,
             JMPLT_L,
             JMPLE_L,
+        };
+
+        public static readonly HashSet<OpCode> loadStaticFieldsConst = new()
+        {
+            LDSFLD0,
+            LDSFLD1,
+            LDSFLD2,
+            LDSFLD3,
+            LDSFLD4,
+            LDSFLD5,
+            LDSFLD6,
+        };
+        public static readonly HashSet<OpCode> storeStaticFieldsConst = new()
+        {
+            STSFLD0,
+            STSFLD1,
+            STSFLD2,
+            STSFLD3,
+            STSFLD4,
+            STSFLD5,
+            STSFLD6,
+        };
+        public static readonly HashSet<OpCode> loadLocalVariablesConst = new()
+        {
+            LDLOC0,
+            LDLOC1,
+            LDLOC2,
+            LDLOC3,
+            LDLOC4,
+            LDLOC5,
+            LDLOC6,
+        };
+        public static readonly HashSet<OpCode> storeLocalVariablesConst = new()
+        {
+            STLOC0,
+            STLOC1,
+            STLOC2,
+            STLOC3,
+            STLOC4,
+            STLOC5,
+            STLOC6,
+        };
+        public static readonly HashSet<OpCode> loadArgumentsConst = new()
+        {
+            LDARG0,
+            LDARG1,
+            LDARG2,
+            LDARG3,
+            LDARG4,
+            LDARG5,
+            LDARG6,
+        };
+        public static readonly HashSet<OpCode> storeArgumentsConst = new()
+        {
+            STARG0,
+            STARG1,
+            STARG2,
+            STARG3,
+            STARG4,
+            STARG5,
+            STARG6,
         };
     }
 }

--- a/src/Neo.Compiler.CSharp/Optimizer/DumpNef.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/DumpNef.cs
@@ -55,6 +55,13 @@ namespace Neo.Optimizer
             return result;
         }
 
+        /// <summary>
+        /// DO NOT use this very often. It builds new instruction objects,
+        /// while the optimizer compares instruction objects using ReferenceEquals
+        /// </summary>
+        /// <param name="script"></param>
+        /// <param name="print">Console.WriteLine all instructions for debugging</param>
+        /// <returns></returns>
         public static IEnumerable<(int address, Instruction instruction)> EnumerateInstructions(this Script script, bool print = false)
         {
             int address = 0;

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Optimizer/UnitTest_BasicBlock.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Optimizer/UnitTest_BasicBlock.cs
@@ -6,7 +6,6 @@ using Neo.SmartContract;
 using Neo.Json;
 using Neo.SmartContract.Manifest;
 using System.Linq;
-using Neo.VM;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -36,7 +35,6 @@ namespace Neo.Compiler.CSharp.UnitTests.Optimizer
             catch (Exception e) { return; }
             // TODO: support CALLA and do not return
 
-            Script script = nef.Script;
             List<VM.Instruction> instructions = basicBlocks.EnumerateInstructions().ToList();
             (_, _, Dictionary<VM.Instruction, HashSet<VM.Instruction>> jumpTargets) = Neo.Optimizer.JumpTarget.FindAllJumpAndTrySourceToTargets(instructions);
 
@@ -53,6 +51,9 @@ namespace Neo.Compiler.CSharp.UnitTests.Optimizer
             {
                 // Basic block ends with allowed OpCodes only, or the next instruction is a jump target
                 Assert.IsTrue(OpCodeTypes.allowedBasicBlockEnds.Contains(basicBlock.instructions.Last().OpCode) || jumpTargets.ContainsKey(nextAddrTable[basicBlock.instructions.Last()]));
+                // Instructions except the first are not jump targets
+                foreach (VM.Instruction i in basicBlock.instructions.Skip(1))
+                    Assert.IsFalse(jumpTargets.ContainsKey(i));
                 // Other instructions in the basic block are not those in allowedBasicBlockEnds
                 foreach (VM.Instruction i in basicBlock.instructions.Take(basicBlock.instructions.Count - 1))
                     Assert.IsFalse(OpCodeTypes.allowedBasicBlockEnds.Contains(i.OpCode));

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Optimizer/UnitTest_BasicBlock.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Optimizer/UnitTest_BasicBlock.cs
@@ -18,10 +18,6 @@ namespace Neo.Compiler.CSharp.UnitTests.Optimizer
     {
         private TestEngine testengine;
 
-        HashSet<OpCode> allowedEnds = ((OpCode[])Enum.GetValues(typeof(OpCode)))
-            .Where(i => Neo.Optimizer.JumpTarget.SingleJumpInOperand(i) && i != OpCode.PUSHA || Neo.Optimizer.JumpTarget.DoubleJumpInOperand(i)).ToHashSet()
-            .Union(new HashSet<OpCode>() { OpCode.RET, OpCode.ABORT, OpCode.ABORTMSG, OpCode.THROW, OpCode.ENDFINALLY }).ToHashSet();
-
         public void Test_SingleContractBasicBlockStartEnd(string fileName)
         {
             testengine = new TestEngine();
@@ -57,10 +53,10 @@ namespace Neo.Compiler.CSharp.UnitTests.Optimizer
             {
                 (int a, VM.Instruction i)[] sortedInstructions = (from kv in basicBlock orderby kv.Key ascending select (kv.Key, kv.Value)).ToArray();
                 // Basic block ends with allowed OpCodes only, or the next instruction is a jump target
-                Assert.IsTrue(allowedEnds.Contains(sortedInstructions.Last().i.OpCode) || jumpTargets.ContainsKey(nextAddrTable[sortedInstructions.Last().a]));
-                // Other instructions in the basic block are not those in allowedEnds
+                Assert.IsTrue(OpCodeTypes.allowedBasicBlockEnds.Contains(sortedInstructions.Last().i.OpCode) || jumpTargets.ContainsKey(nextAddrTable[sortedInstructions.Last().a]));
+                // Other instructions in the basic block are not those in allowedBasicBlockEnds
                 foreach ((int a, VM.Instruction i) in sortedInstructions.Take(sortedInstructions.Length - 1))
-                    Assert.IsFalse(allowedEnds.Contains(i.OpCode));
+                    Assert.IsFalse(OpCodeTypes.allowedBasicBlockEnds.Contains(i.OpCode));
             }
             // Each jump target starts a new basic block
             foreach (int target in jumpTargets.Keys)


### PR DESCRIPTION
Refactoring the optimizer to analyze jumps between basic blocks. There should be no difference in the writing behavior of optimizer.
I am failing tests in my local environment in `Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs` and `Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs`. Still finding the fix.