### PR TITLE
[Compiler Fix] checkstandards

### DIFF
--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -178,7 +178,7 @@ namespace Neo.Compiler
                 {
                     (nef, manifest, debugInfo) = context.CreateResults(folder);
                 }
-                catch (Exception ex) when(ex is CompilationException)
+                catch (Exception ex) when (ex is CompilationException)
                 {
                     Console.Error.WriteLine((ex as CompilationException).Diagnostic);
                     return 1;

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -171,9 +171,9 @@ namespace Neo.Compiler
                 string path = outputFolder;
                 string baseName = options.BaseName ?? context.ContractName!;
 
-                NefFile nef = new();
-                ContractManifest manifest = new();
-                JToken debugInfo = JToken.Null;
+                NefFile nef;
+                ContractManifest manifest;
+                JToken debugInfo;
                 try
                 {
                     (nef, manifest, debugInfo) = context.CreateResults(folder);

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -171,7 +171,18 @@ namespace Neo.Compiler
                 string path = outputFolder;
                 string baseName = options.BaseName ?? context.ContractName!;
 
-                (NefFile nef, ContractManifest manifest, JToken debugInfo) = context.CreateResults(folder);
+                NefFile nef = new();
+                ContractManifest manifest = new();
+                JToken debugInfo = JToken.Null;
+                try
+                {
+                    (nef, manifest, debugInfo) = context.CreateResults(folder);
+                }
+                catch (Exception ex) when(ex is CompilationException)
+                {
+                    Console.Error.WriteLine((ex as CompilationException).Diagnostic);
+                    return 1;
+                }
 
                 try
                 {

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -178,9 +178,9 @@ namespace Neo.Compiler
                 {
                     (nef, manifest, debugInfo) = context.CreateResults(folder);
                 }
-                catch (Exception ex) when (ex is CompilationException)
+                catch (CompilationException ex)
                 {
-                    Console.Error.WriteLine((ex as CompilationException).Diagnostic);
+                    Console.Error.WriteLine(ex.Diagnostic);
                     return -1;
                 }
 

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -181,7 +181,7 @@ namespace Neo.Compiler
                 catch (Exception ex) when (ex is CompilationException)
                 {
                     Console.Error.WriteLine((ex as CompilationException).Diagnostic);
-                    return 1;
+                    return -1;
                 }
 
                 try


### PR DESCRIPTION
Bug fix: when a contract declares NEP-11/NEP-17 but does not implement the corresponding method, nccs will crash directly at compile time instead of outputting an error message.

Before, the output is as follows:
```
Neo.Compiler.CompilationException: Exception of type 'Neo.Compiler.CompilationException' was thrown.
   at Neo.Compiler.ContractManifestExtensions.CheckNep17Compliant(ContractManifest manifest) in D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\ContractManifestExtension.cs:line 149
   at Neo.Compiler.ContractManifestExtensions.CheckStandards(ContractManifest manifest) in D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\ContractManifestExtension.cs:line 175
   at Neo.Compiler.CompilationContext.CreateManifest() in D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\CompilationContext.cs:line 249
   at Neo.Compiler.CompilationContext.CreateResults(String folder) in D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\CompilationContext.cs:line 148
   at Neo.Compiler.Program.ProcessOutput(Options options, String folder, CompilationContext context) in D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\Program.cs:line 174
   at Neo.Compiler.Program.ProcessOutputs(Options options, String folder, List`1 contexts) in D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\Program.cs:line 146

D:\1Code\chen\neo-devpack-dotnet\src\Neo.Compiler.CSharp\bin\Debug\net8.0\nccs.exe (Process 46000) has exited with a code of 1.
```

After fixed, the output is as follows:

```
error NC3006: Incomplete NEP standard NEP-17 implementation: symbol
```