### PR TITLE
[TestEngine] Unify coverage check

### DIFF
--- a/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
@@ -1,0 +1,86 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing.Coverage;
+using Neo.SmartContract.Testing.Coverage.Formats;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace Neo.SmartContract.Testing.TestingStandards
+{
+    public abstract class TestCleanupBase
+    {
+        /// <summary>
+        /// Required coverage to be success
+        /// </summary>
+        public static decimal RequiredCoverage { get; set; } = 0.9M;
+
+        public static readonly Dictionary<Type, NeoDebugInfo> DebugInfos = new();
+
+        protected static void EnsureCoverageInternal(Assembly assembly)
+        {
+            // Join here all of your coverage sources
+
+            CoverageBase? coverage = null;
+            var allTypes = assembly.GetTypes();
+            var list = new List<(CoveredContract Contract, NeoDebugInfo DebugInfo)>();
+
+            foreach (var infos in DebugInfos)
+            {
+                Type type = typeof(TestBase<>).MakeGenericType(infos.Key);
+                CoveredContract? cov = null;
+
+                foreach (var aType in allTypes)
+                {
+                    if (type.IsAssignableFrom(aType))
+                    {
+                        cov = type.GetProperty("Coverage")!.GetValue(null) as CoveredContract;
+                        Assert.IsNotNull(cov, $"{infos.Key} coverage can't be null");
+
+                        // It doesn't require join, because we have only one UnitTest class per contract
+
+                        coverage += cov;
+                        list.Add((cov, infos.Value));
+                        break;
+                    }
+                }
+
+                if (cov is null)
+                {
+                    Console.Error.WriteLine($"Coverage not found for {infos.Key}");
+                }
+            }
+
+            // Ensure we have coverage
+
+            Assert.IsNotNull(coverage, $"Coverage can't be null");
+
+            // Dump current coverage
+
+            Console.WriteLine(coverage.Dump(DumpFormat.Console));
+            File.WriteAllText("coverage.instruction.html", coverage.Dump(DumpFormat.Html));
+
+            // Write the cobertura format
+
+            File.WriteAllText("coverage.cobertura.xml", new CoberturaFormat(list.ToArray()).Dump());
+
+            // Write the report to the specific path
+
+            CoverageReporting.CreateReport("coverage.cobertura.xml", "./coverageReport/");
+
+            // Merge coverlet json
+
+            if (Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN") is string mergeWith &&
+                !string.IsNullOrEmpty(mergeWith))
+            {
+                new CoverletJsonFormat(list.ToArray()).Write(Environment.ExpandEnvironmentVariables(mergeWith), true);
+
+                Console.WriteLine($"Coverage merged with: {mergeWith}");
+            }
+
+            // Ensure that the coverage is more than X% at the end of the tests
+
+            Assert.IsTrue(coverage.CoveredLinesPercentage >= RequiredCoverage, $"Coverage is {coverage.CoveredLinesPercentage:P2}, less than {RequiredCoverage:P2}");
+        }
+    }
+}

--- a/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
@@ -10,14 +10,9 @@ namespace Neo.SmartContract.Testing.TestingStandards
 {
     public abstract class TestCleanupBase
     {
-        /// <summary>
-        /// Required coverage to be success
-        /// </summary>
-        public static decimal RequiredCoverage { get; set; } = 0.9M;
-
         public static readonly Dictionary<Type, NeoDebugInfo> DebugInfos = new();
 
-        protected static void EnsureCoverageInternal(Assembly assembly)
+        protected static void EnsureCoverageInternal(Assembly assembly, decimal requiredCoverage = 0.9M)
         {
             // Join here all of your coverage sources
 
@@ -80,7 +75,7 @@ namespace Neo.SmartContract.Testing.TestingStandards
 
             // Ensure that the coverage is more than X% at the end of the tests
 
-            Assert.IsTrue(coverage.CoveredLinesPercentage >= RequiredCoverage, $"Coverage is {coverage.CoveredLinesPercentage:P2}, less than {RequiredCoverage:P2}");
+            Assert.IsTrue(coverage.CoveredLinesPercentage >= requiredCoverage, $"Coverage is {coverage.CoveredLinesPercentage:P2}, less than {requiredCoverage:P2}");
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestCleanup.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestCleanup.cs
@@ -16,14 +16,8 @@ namespace Neo.Compiler.CSharp.UnitTests
         private static readonly Regex WhiteSpaceRegex = new("\\s");
         private static CompilationContext[]? compilationContexts;
 
-        static TestCleanup()
-        {
-            // TODO: Improve this coverage
-            RequiredCoverage = 0.75M;
-        }
-
         [AssemblyCleanup]
-        public static void EnsureCoverage() => EnsureCoverageInternal(Assembly.GetExecutingAssembly());
+        public static void EnsureCoverage() => EnsureCoverageInternal(Assembly.GetExecutingAssembly(), 0.75M);
 
         [TestMethod]
         public void EnsureArtifactsUpToDate() => EnsureArtifactsUpToDateInternal();

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestCleanup.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestCleanup.cs
@@ -1,9 +1,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing.Coverage;
-using Neo.SmartContract.Testing.Coverage.Formats;
 using Neo.SmartContract.Testing.Extensions;
+using Neo.SmartContract.Testing.TestingStandards;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -12,16 +11,19 @@ using System.Text.RegularExpressions;
 namespace Neo.Compiler.CSharp.UnitTests
 {
     [TestClass]
-    public class TestCleanup
+    public class TestCleanup : TestCleanupBase
     {
         private static readonly Regex WhiteSpaceRegex = new("\\s");
         private static CompilationContext[]? compilationContexts;
-        internal static readonly Dictionary<Type, NeoDebugInfo> DebugInfos = new();
 
-        /// <summary>
-        /// Required coverage to be success
-        /// </summary>
-        public static decimal RequiredCoverage { get; set; } = 0.0M;
+        static TestCleanup()
+        {
+            // TODO: Improve this coverage
+            RequiredCoverage = 0.75M;
+        }
+
+        [AssemblyCleanup]
+        public static void EnsureCoverage() => EnsureCoverageInternal(Assembly.GetExecutingAssembly());
 
         [TestMethod]
         public void EnsureArtifactsUpToDate() => EnsureArtifactsUpToDateInternal();
@@ -108,73 +110,6 @@ namespace Neo.Compiler.CSharp.UnitTests
             }
 
             return debug;
-        }
-
-        [AssemblyCleanup]
-        public static void EnsureCoverage()
-        {
-            // Join here all of your coverage sources
-
-            CoverageBase? coverage = null;
-            var allTypes = Assembly.GetExecutingAssembly().GetTypes();
-            var list = new List<(CoveredContract Contract, NeoDebugInfo DebugInfo)>();
-
-            foreach (var infos in DebugInfos)
-            {
-                Type type = typeof(SmartContract.Testing.TestingStandards.TestBase<>).MakeGenericType(infos.Key);
-                CoveredContract? cov = null;
-
-                foreach (var aType in allTypes)
-                {
-                    if (type.IsAssignableFrom(aType))
-                    {
-                        cov = type.GetProperty("Coverage")!.GetValue(null) as CoveredContract;
-                        Assert.IsNotNull(cov, $"{infos.Key} coverage can't be null");
-
-                        // It doesn't require join, because we have only one UnitTest class per contract
-
-                        coverage += cov;
-                        list.Add((cov, infos.Value));
-                        break;
-                    }
-                }
-
-                if (cov is null)
-                {
-                    Console.Error.WriteLine($"Coverage not found for {infos.Key}");
-                }
-            }
-
-            // Ensure we have coverage
-
-            Assert.IsNotNull(coverage, $"Coverage can't be null");
-
-            // Dump current coverage
-
-            Console.WriteLine(coverage.Dump(DumpFormat.Console));
-            File.WriteAllText("coverage.instruction.html", coverage.Dump(DumpFormat.Html));
-
-            // Write the cobertura format
-
-            File.WriteAllText("coverage.cobertura.xml", new CoberturaFormat(list.ToArray()).Dump());
-
-            // Write the report to the specific path
-
-            CoverageReporting.CreateReport("coverage.cobertura.xml", "./coverageReport/");
-
-            // Merge coverlet json
-
-            if (Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN") is string mergeWith &&
-                !string.IsNullOrEmpty(mergeWith))
-            {
-                new CoverletJsonFormat(list.ToArray()).Write(Environment.ExpandEnvironmentVariables(mergeWith), true);
-
-                Console.WriteLine($"Coverage merged with: {mergeWith}");
-            }
-
-            // Ensure that the coverage is more than X% at the end of the tests
-
-            Assert.IsTrue(coverage.CoveredLinesPercentage >= RequiredCoverage, $"Coverage is less than {RequiredCoverage:P2}");
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ABI_Attributes.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ABI_Attributes.cs
@@ -1,12 +1,13 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Json;
 using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.TestingStandards;
 using System.Linq;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
     [TestClass]
-    public class UnitTest_ABI_Attributes
+    public class UnitTest_ABI_Attributes() : TestBase<Contract_ABIAttributes>(Contract_ABIAttributes.Nef, Contract_ABIAttributes.Manifest)
     {
         [TestMethod]
         public void TestAbiAttributes()
@@ -15,6 +16,12 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(@"[{""contract"":""0x01ff00ff00ff00ff00ff00ff00ff00ff00ff00a4"",""methods"":[""a"",""b""]},{""contract"":""*"",""methods"":[""c""]}]", permissions);
             var trust = Contract_ABIAttributes.Manifest.Trusts.ToJson(p => p.ToJson());
             Assert.AreEqual(@"[""0x0a0b00ff00ff00ff00ff00ff00ff00ff00ff00a4""]", trust.ToString(false));
+        }
+
+        [TestMethod]
+        public void MethodTest()
+        {
+            Assert.AreEqual(0, Contract.Test());
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ABI_Safe.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ABI_Safe.cs
@@ -1,10 +1,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.TestingStandards;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
     [TestClass]
-    public class UnitTest_ABI_Safe
+    public class UnitTest_ABI_Safe() : TestBase<Contract_ABISafe>(Contract_ABISafe.Nef, Contract_ABISafe.Manifest)
     {
         [TestMethod]
         public void UnitTest_TestSafe()
@@ -12,6 +13,18 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsFalse(Contract_ABISafe.Manifest.Abi.Methods[0].Safe);
             Assert.IsTrue(Contract_ABISafe.Manifest.Abi.Methods[1].Safe);
             Assert.IsFalse(Contract_ABISafe.Manifest.Abi.Methods[2].Safe);
+        }
+
+        [TestMethod]
+        public void Method1Test()
+        {
+            Assert.AreEqual(1, Contract.UnitTest_001());
+        }
+
+        [TestMethod]
+        public void Method3Test()
+        {
+            Assert.AreEqual(3, Contract.UnitTest_003());
         }
     }
 }

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/TestCleanup.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/TestCleanup.cs
@@ -1,33 +1,27 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler;
-using Neo.SmartContract.Template.UnitTests.templates.neocontractnep17;
-using Neo.SmartContract.Template.UnitTests.templates.neocontractoracle;
-using Neo.SmartContract.Template.UnitTests.templates.neocontractowner;
 using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.Coverage;
-using Neo.SmartContract.Testing.Coverage.Formats;
 using Neo.SmartContract.Testing.Extensions;
+using Neo.SmartContract.Testing.TestingStandards;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Neo.SmartContract.Template.UnitTests.templates
 {
     [TestClass]
-    public class TestCleanup
+    public class TestCleanup : TestCleanupBase
     {
         private static readonly Regex WhiteSpaceRegex = new("\\s");
 
-        private static NeoDebugInfo? DebugInfo_NEP17;
-        private static NeoDebugInfo? DebugInfo_Oracle;
-        private static NeoDebugInfo? DebugInfo_Ownable;
-
-        /// <summary>
-        /// Required coverage to be success
-        /// </summary>
-        public static decimal RequiredCoverage { get; set; } = 0.85M;
+        [AssemblyCleanup]
+        public static void EnsureCoverage() => EnsureCoverageInternal(Assembly.GetExecutingAssembly());
 
         [TestMethod]
         public void EnsureArtifactsUpToDate()
         {
+            if (DebugInfos.Count > 0) return; // Maybe a UT call it
+
             // Define paths
 
             string frameworkPath = Path.GetFullPath("../../../../../src/Neo.SmartContract.Framework/Neo.SmartContract.Framework.csproj");
@@ -43,30 +37,36 @@ namespace Neo.SmartContract.Template.UnitTests.templates
                 Optimize = CompilationOptions.OptimizationType.All,
                 Nullable = Microsoft.CodeAnalysis.NullableContextOptions.Enable
             })
-            .CompileSources(new CompilationSourceReferences() { Projects = new[] { frameworkPath } },
-            new[] {
+            .CompileSources(new CompilationSourceReferences() { Projects = [frameworkPath] },
+                [
                     Path.Combine(templatePath, "neocontractnep17/Nep17Contract.cs"),
                     Path.Combine(templatePath, "neocontractoracle/OracleRequest.cs"),
                     Path.Combine(templatePath, "neocontractowner/Ownable.cs")
-                });
+                ]);
 
             Assert.IsTrue(result.Count() == 3 && result.All(u => u.Success), "Error compiling templates");
 
             // Ensure Nep17
 
             var root = Path.GetPathRoot(templatePath) ?? "";
-            (var artifact, DebugInfo_NEP17) = CreateArtifact<Nep17ContractTemplate>(result.FirstOrDefault(p => p.ContractName == "Nep17Contract") ?? throw new InvalidOperationException(), root,
+            (var artifact, var dbg) = CreateArtifact<Nep17ContractTemplate>(result.FirstOrDefault(p => p.ContractName == "Nep17Contract") ?? throw new InvalidOperationException(), root,
                 Path.Combine(artifactsPath, "neocontractnep17/TestingArtifacts/Nep17ContractTemplate.artifacts.cs"));
+
+            DebugInfos[typeof(Nep17ContractTemplate)] = dbg;
 
             // Ensure Oracle
 
-            (artifact, DebugInfo_Oracle) = CreateArtifact<OracleRequestTemplate>(result.FirstOrDefault(p => p.ContractName == "OracleRequest") ?? throw new InvalidOperationException(), root,
+            (artifact, dbg) = CreateArtifact<OracleRequestTemplate>(result.FirstOrDefault(p => p.ContractName == "OracleRequest") ?? throw new InvalidOperationException(), root,
                 Path.Combine(artifactsPath, "neocontractoracle/TestingArtifacts/OracleRequestTemplate.artifacts.cs"));
+
+            DebugInfos[typeof(OracleRequestTemplate)] = dbg;
 
             // Ensure Ownable
 
-            (artifact, DebugInfo_Ownable) = CreateArtifact<OwnableTemplate>(result.FirstOrDefault(p => p.ContractName == "Ownable") ?? throw new InvalidOperationException(), root,
+            (artifact, dbg) = CreateArtifact<OwnableTemplate>(result.FirstOrDefault(p => p.ContractName == "Ownable") ?? throw new InvalidOperationException(), root,
                 Path.Combine(artifactsPath, "neocontractowner/TestingArtifacts/OwnableTemplate.artifacts.cs"));
+
+            DebugInfos[typeof(OwnableTemplate)] = dbg;
         }
 
         private static (string artifact, NeoDebugInfo debugInfo) CreateArtifact<T>(CompilationContext context, string rootDebug, string artifactsPath)
@@ -84,68 +84,6 @@ namespace Neo.SmartContract.Template.UnitTests.templates
             }
 
             return (artifact, debug);
-        }
-
-        [AssemblyCleanup]
-        public static void EnsureCoverage()
-        {
-            // Join here all of your coverage sources
-
-            var coverageNep17 = Nep17ContractTests.Coverage;
-            coverageNep17?.Join(OwnerContractTests.Coverage);
-            var coverageOwnable = OwnableContractTests.Coverage;
-            var coverageOracle = OracleRequestTests.Coverage;
-
-            // Dump coverage to console
-
-            Assert.IsNotNull(coverageNep17, "NEP17 coverage can't be null");
-            Assert.IsNotNull(coverageOwnable, "Ownable coverage can't be null");
-            Assert.IsNotNull(coverageOracle, "Oracle coverage can't be null");
-
-            var coverage = coverageNep17 + coverageOwnable + coverageOracle;
-
-            Assert.IsNotNull(coverage, "Coverage can't be null");
-
-            // Dump current coverage
-
-            Console.WriteLine(coverage.Dump(DumpFormat.Console));
-            File.WriteAllText("coverage.instruction.html", coverage.Dump(DumpFormat.Html));
-
-            if (DebugInfo_NEP17 is not null &&
-                DebugInfo_Ownable is not null &&
-                DebugInfo_Oracle is not null)
-            {
-                // Write the cobertura format
-
-                File.WriteAllText("coverage.cobertura.xml", new CoberturaFormat(
-                    (coverageNep17, DebugInfo_NEP17),
-                    (coverageOwnable, DebugInfo_Ownable),
-                    (coverageOracle, DebugInfo_Oracle)
-                    ).Dump());
-
-                // Write the report to the specific path
-
-                CoverageReporting.CreateReport("coverage.cobertura.xml", "./coverageReport/");
-
-                // Merge coverlet json
-
-                if (Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN") is string mergeWith &&
-                    !string.IsNullOrEmpty(mergeWith))
-                {
-                    new CoverletJsonFormat(
-                       (coverageNep17, DebugInfo_NEP17),
-                       (coverageOwnable, DebugInfo_Ownable),
-                       (coverageOracle, DebugInfo_Oracle)
-                       ).
-                       Write(Environment.ExpandEnvironmentVariables(mergeWith), true);
-
-                    Console.WriteLine($"Coverage merged with: {mergeWith}");
-                }
-            }
-
-            // Ensure that the coverage is more than X% at the end of the tests
-
-            Assert.IsTrue(coverage.CoveredLinesPercentage >= RequiredCoverage, $"Coverage is less than {RequiredCoverage:P2}");
         }
     }
 }


### PR DESCRIPTION
There are some test contracts that are not checked (or covered) like:

```
Coverage not found for Neo.SmartContract.Testing.Contract_ABIAttributes2
Coverage not found for Neo.SmartContract.Testing.Contract_ABIAttributes3
Coverage not found for Neo.SmartContract.Testing.Contract_Event
Coverage not found for Neo.SmartContract.Testing.Contract_IndexOrRange
Coverage not found for Neo.SmartContract.Testing.Contract_Logical
Coverage not found for Neo.SmartContract.Testing.Contract_MemberAccess
Coverage not found for Neo.SmartContract.Testing.Contract_MultipleA
Coverage not found for Neo.SmartContract.Testing.Contract_MultipleB
Coverage not found for Neo.SmartContract.Testing.Contract_NEP11
Coverage not found for Neo.SmartContract.Testing.Contract_NEP17
Coverage not found for Neo.SmartContract.Testing.Contract_OnDeployment1
Coverage not found for Neo.SmartContract.Testing.Contract_OnDeployment2
Coverage not found for Neo.SmartContract.Testing.Contract_PostfixUnary
Coverage not found for Neo.SmartContract.Testing.Contract_String
Coverage not found for Neo.SmartContract.Testing.Contract_Throw
```