### PR TITLE
[Neo Compiler] rename and comment various call methods

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/CallHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/CallHelpers.cs
@@ -24,7 +24,12 @@ namespace Neo.Compiler;
 
 partial class MethodConvert
 {
-    private Instruction Call(InteropDescriptor descriptor)
+    /// <summary>
+    /// Creates an instruction to call an interop method using the given descriptor.
+    /// </summary>
+    /// <param name="descriptor">The interop descriptor representing the method to call.</param>
+    /// <returns>The instruction to perform the interop call.</returns>
+    private Instruction CallInteropMethod(InteropDescriptor descriptor)
     {
         return AddInstruction(new Instruction
         {
@@ -33,7 +38,16 @@ partial class MethodConvert
         });
     }
 
-    private Instruction Call(UInt160 hash, string method, ushort parametersCount, bool hasReturnValue, CallFlags callFlags = CallFlags.All)
+    /// <summary>
+    /// Creates an instruction to call a method in another smart contract identified by its hash.
+    /// </summary>
+    /// <param name="hash">The hash of the contract containing the method.</param>
+    /// <param name="method">The name of the method to call.</param>
+    /// <param name="parametersCount">The number of parameters the method takes.</param>
+    /// <param name="hasReturnValue">Whether the method returns a value.</param>
+    /// <param name="callFlags">The call flags to use for the method call.</param>
+    /// <returns>The instruction to perform the contract method call.</returns>
+    private Instruction CallContractMethod(UInt160 hash, string method, ushort parametersCount, bool hasReturnValue, CallFlags callFlags = CallFlags.All)
     {
         ushort token = _context.AddMethodToken(hash, method, parametersCount, hasReturnValue, callFlags);
         return AddInstruction(new Instruction
@@ -43,7 +57,14 @@ partial class MethodConvert
         });
     }
 
-    private void Call(SemanticModel model, IMethodSymbol symbol, bool instanceOnStack, IReadOnlyList<ArgumentSyntax> arguments)
+    /// <summary>
+    /// Creates instructions to call an instance method, handling the instance on the stack and preparing the arguments.
+    /// </summary>
+    /// <param name="model">The semantic model of the code.</param>
+    /// <param name="symbol">The method symbol representing the method to call.</param>
+    /// <param name="instanceOnStack">Whether the instance is on the stack.</param>
+    /// <param name="arguments">The list of arguments for the method call.</param>
+    private void CallInstanceMethod(SemanticModel model, IMethodSymbol symbol, bool instanceOnStack, IReadOnlyList<ArgumentSyntax> arguments)
     {
         if (TryProcessSystemMethods(model, symbol, null, arguments))
             return;
@@ -87,7 +108,14 @@ partial class MethodConvert
             EmitCall(convert);
     }
 
-    private void Call(SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, params SyntaxNode[] arguments)
+    /// <summary>
+    /// Creates instructions to call a method with an optional instance expression, handling both instance and static methods.
+    /// </summary>
+    /// <param name="model">The semantic model of the code.</param>
+    /// <param name="symbol">The method symbol representing the method to call.</param>
+    /// <param name="instanceExpression">The optional instance expression for the method call.</param>
+    /// <param name="arguments">The list of arguments for the method call.</param>
+    private void CallMethodWithInstanceExpression(SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, params SyntaxNode[] arguments)
     {
         if (TryProcessSystemMethods(model, symbol, instanceExpression, arguments))
             return;
@@ -128,7 +156,13 @@ partial class MethodConvert
             EmitCall(convert);
     }
 
-    private void Call(SemanticModel model, IMethodSymbol symbol, CallingConvention callingConvention = CallingConvention.Cdecl)
+    /// <summary>
+    /// Creates instructions to call a method with a specified calling convention.
+    /// </summary>
+    /// <param name="model">The semantic model of the code.</param>
+    /// <param name="symbol">The method symbol representing the method to call.</param>
+    /// <param name="callingConvention">The calling convention to use for the method call.</param>
+    private void CallMethodWithConvention(SemanticModel model, IMethodSymbol symbol, CallingConvention callingConvention = CallingConvention.Cdecl)
     {
         if (TryProcessSystemMethods(model, symbol, null, null))
             return;

--- a/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
@@ -49,13 +49,13 @@ partial class MethodConvert
             IMethodSymbol baseConstructor = baseType.InstanceConstructors.First(p => p.Parameters.Length == 0);
             if (baseType.DeclaringSyntaxReferences.IsEmpty && baseConstructor.GetAttributes().All(p => p.AttributeClass!.ContainingAssembly.Name != "Neo.SmartContract.Framework"))
                 return;
-            Call(model, baseConstructor, null);
+            CallMethodWithInstanceExpression(model, baseConstructor, null);
         }
         else
         {
             IMethodSymbol baseConstructor = (IMethodSymbol)model.GetSymbolInfo(initializer).Symbol!;
             using (InsertSequencePoint(initializer))
-                Call(model, baseConstructor, null, initializer.ArgumentList.Arguments.ToArray());
+                CallMethodWithInstanceExpression(model, baseConstructor, null, initializer.ArgumentList.Arguments.ToArray());
         }
     }
 

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.CoalesceAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.CoalesceAssignment.cs
@@ -77,7 +77,7 @@ partial class MethodConvert
             ConvertExpression(model, left.ArgumentList.Arguments[0].Expression);
             AddInstruction(OpCode.OVER);
             AddInstruction(OpCode.OVER);
-            Call(model, property.GetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.GetMethod!, CallingConvention.StdCall);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.ISNULL);
             Jump(OpCode.JMPIF_L, assignmentTarget);
@@ -88,7 +88,7 @@ partial class MethodConvert
             ConvertExpression(model, right);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.REVERSE4);
-            Call(model, property.SetMethod!, CallingConvention.Cdecl);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.Cdecl);
         }
         else
         {
@@ -225,19 +225,19 @@ partial class MethodConvert
         JumpTarget endTarget = new();
         if (left.IsStatic)
         {
-            Call(model, left.GetMethod!);
+            CallMethodWithConvention(model, left.GetMethod!);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.ISNULL);
             Jump(OpCode.JMPIFNOT_L, endTarget);
             AddInstruction(OpCode.DROP);
             ConvertExpression(model, right);
             AddInstruction(OpCode.DUP);
-            Call(model, left.SetMethod!);
+            CallMethodWithConvention(model, left.SetMethod!);
         }
         else
         {
             AddInstruction(OpCode.LDARG0);
-            Call(model, left.GetMethod!);
+            CallMethodWithConvention(model, left.GetMethod!);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.ISNULL);
             Jump(OpCode.JMPIFNOT_L, endTarget);
@@ -245,7 +245,7 @@ partial class MethodConvert
             AddInstruction(OpCode.LDARG0);
             ConvertExpression(model, right);
             AddInstruction(OpCode.TUCK);
-            Call(model, left.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, left.SetMethod!, CallingConvention.StdCall);
         }
         endTarget.Instruction = AddInstruction(OpCode.NOP);
     }
@@ -294,21 +294,21 @@ partial class MethodConvert
         JumpTarget endTarget = new();
         if (property.IsStatic)
         {
-            Call(model, property.GetMethod!);
+            CallMethodWithConvention(model, property.GetMethod!);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.ISNULL);
             Jump(OpCode.JMPIFNOT_L, endTarget);
             AddInstruction(OpCode.DROP);
             ConvertExpression(model, right);
             AddInstruction(OpCode.DUP);
-            Call(model, property.SetMethod!);
+            CallMethodWithConvention(model, property.SetMethod!);
         }
         else
         {
             JumpTarget assignmentTarget = new();
             ConvertExpression(model, left.Expression);
             AddInstruction(OpCode.DUP);
-            Call(model, property.GetMethod!);
+            CallMethodWithConvention(model, property.GetMethod!);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.ISNULL);
             Jump(OpCode.JMPIF_L, assignmentTarget);
@@ -317,7 +317,7 @@ partial class MethodConvert
             assignmentTarget.Instruction = AddInstruction(OpCode.DROP);
             ConvertExpression(model, right);
             AddInstruction(OpCode.TUCK);
-            Call(model, property.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.StdCall);
         }
         endTarget.Instruction = AddInstruction(OpCode.NOP);
     }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
@@ -78,12 +78,12 @@ partial class MethodConvert
             ConvertExpression(model, left.ArgumentList.Arguments[0].Expression);
             AddInstruction(OpCode.OVER);
             AddInstruction(OpCode.OVER);
-            Call(model, property.GetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.GetMethod!, CallingConvention.StdCall);
             ConvertExpression(model, right);
             EmitComplexAssignmentOperator(type, operatorToken);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.REVERSE4);
-            Call(model, property.SetMethod!, CallingConvention.Cdecl);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.Cdecl);
         }
         else
         {
@@ -188,21 +188,21 @@ partial class MethodConvert
     {
         if (left.IsStatic)
         {
-            Call(model, left.GetMethod!);
+            CallMethodWithConvention(model, left.GetMethod!);
             ConvertExpression(model, right);
             EmitComplexAssignmentOperator(type, operatorToken);
             AddInstruction(OpCode.DUP);
-            Call(model, left.SetMethod!);
+            CallMethodWithConvention(model, left.SetMethod!);
         }
         else
         {
             AddInstruction(OpCode.LDARG0);
             AddInstruction(OpCode.DUP);
-            Call(model, left.GetMethod!);
+            CallMethodWithConvention(model, left.GetMethod!);
             ConvertExpression(model, right);
             EmitComplexAssignmentOperator(type, operatorToken);
             AddInstruction(OpCode.TUCK);
-            Call(model, left.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, left.SetMethod!, CallingConvention.StdCall);
         }
     }
 
@@ -237,21 +237,21 @@ partial class MethodConvert
     {
         if (property.IsStatic)
         {
-            Call(model, property.GetMethod!);
+            CallMethodWithConvention(model, property.GetMethod!);
             ConvertExpression(model, right);
             EmitComplexAssignmentOperator(type, operatorToken);
             AddInstruction(OpCode.DUP);
-            Call(model, property.SetMethod!);
+            CallMethodWithConvention(model, property.SetMethod!);
         }
         else
         {
             ConvertExpression(model, left.Expression);
             AddInstruction(OpCode.DUP);
-            Call(model, property.GetMethod!);
+            CallMethodWithConvention(model, property.GetMethod!);
             ConvertExpression(model, right);
             EmitComplexAssignmentOperator(type, operatorToken);
             AddInstruction(OpCode.TUCK);
-            Call(model, property.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.StdCall);
         }
     }
 

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.SimpleAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.SimpleAssignment.cs
@@ -99,7 +99,7 @@ partial class MethodConvert
         {
             ConvertExpression(model, left.ArgumentList.Arguments[0].Expression);
             ConvertExpression(model, left.Expression);
-            Call(model, property.SetMethod!, CallingConvention.Cdecl);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.Cdecl);
         }
         else
         {
@@ -162,7 +162,7 @@ partial class MethodConvert
                 else if (property.SetMethod != null)
                 {
                     if (!property.IsStatic) AddInstruction(OpCode.LDARG0);
-                    Call(model, property.SetMethod, CallingConvention.Cdecl);
+                    CallMethodWithConvention(model, property.SetMethod, CallingConvention.Cdecl);
                 }
                 else
                 {
@@ -196,7 +196,7 @@ partial class MethodConvert
                 break;
             case IPropertySymbol property:
                 if (!property.IsStatic) ConvertExpression(model, left.Expression);
-                Call(model, property.SetMethod!, CallingConvention.Cdecl);
+                CallMethodWithConvention(model, property.SetMethod!, CallingConvention.Cdecl);
                 break;
             default:
                 throw new CompilationException(left, DiagnosticId.SyntaxNotSupported, $"Unsupported symbol: {symbol}");

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/CastExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/CastExpression.cs
@@ -48,7 +48,7 @@ partial class MethodConvert
         IMethodSymbol method = (IMethodSymbol)model.GetSymbolInfo(expression).Symbol!;
         if (method is not null)
         {
-            Call(model, method, null, expression.Expression);
+            CallMethodWithInstanceExpression(model, method, null, expression.Expression);
             return;
         }
         ConvertExpression(model, expression.Expression);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/ElementExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/ElementExpression.cs
@@ -50,7 +50,7 @@ partial class MethodConvert
             throw new CompilationException(expression.ArgumentList, DiagnosticId.MultidimensionalArray, $"Unsupported array rank: {expression.ArgumentList.Arguments}");
         if (model.GetSymbolInfo(expression).Symbol is IPropertySymbol property)
         {
-            Call(model, property.GetMethod!, expression.Expression, expression.ArgumentList.Arguments.ToArray());
+            CallMethodWithInstanceExpression(model, property.GetMethod!, expression.Expression, expression.ArgumentList.Arguments.ToArray());
         }
         else
         {

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
@@ -375,7 +375,7 @@ partial class MethodConvert
             case "ulong":
             case "System.Numerics.BigInteger":
                 ConvertExpression(model, expression);
-                Call(NativeContract.StdLib.Hash, "itoa", 1, true);
+                CallContractMethod(NativeContract.StdLib.Hash, "itoa", 1, true);
                 break;
             case "string":
             case "Neo.SmartContract.Framework.ECPoint":

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/IdentifierNameExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/IdentifierNameExpression.cs
@@ -84,12 +84,12 @@ partial class MethodConvert
             case IPropertySymbol property:
                 if (property.IsStatic)
                 {
-                    Call(model, property.GetMethod!);
+                    CallMethodWithConvention(model, property.GetMethod!);
                 }
                 else
                 {
                     AddInstruction(OpCode.LDARG0);
-                    Call(model, property.GetMethod!);
+                    CallMethodWithConvention(model, property.GetMethod!);
                 }
                 break;
             case ITypeSymbol type:

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/InvocationExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/InvocationExpression.cs
@@ -62,7 +62,7 @@ partial class MethodConvert
             AddInstruction(OpCode.APPEND);
         }
         Push(symbol.GetDisplayName());
-        Call(ApplicationEngine.System_Runtime_Notify);
+        CallInteropMethod(ApplicationEngine.System_Runtime_Notify);
     }
 
     /// <summary>
@@ -80,16 +80,16 @@ partial class MethodConvert
         switch (expression)
         {
             case IdentifierNameSyntax:
-                Call(model, symbol, null, arguments);
+                CallMethodWithInstanceExpression(model, symbol, null, arguments);
                 break;
             case MemberAccessExpressionSyntax syntax:
                 if (symbol.IsStatic)
-                    Call(model, symbol, null, arguments);
+                    CallMethodWithInstanceExpression(model, symbol, null, arguments);
                 else
-                    Call(model, symbol, syntax.Expression, arguments);
+                    CallMethodWithInstanceExpression(model, symbol, syntax.Expression, arguments);
                 break;
             case MemberBindingExpressionSyntax:
-                Call(model, symbol, true, arguments);
+                CallInstanceMethod(model, symbol, true, arguments);
                 break;
             default:
                 throw new CompilationException(expression, DiagnosticId.SyntaxNotSupported, $"Unsupported expression: {expression}");

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/MemberExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/MemberExpression.cs
@@ -75,7 +75,7 @@ partial class MethodConvert
                 break;
             case IPropertySymbol property:
                 ExpressionSyntax? instanceExpression = property.IsStatic ? null : expression.Expression;
-                Call(model, property.GetMethod!, instanceExpression);
+                CallMethodWithInstanceExpression(model, property.GetMethod!, instanceExpression);
                 break;
             default:
                 throw new CompilationException(expression, DiagnosticId.SyntaxNotSupported, $"Unsupported symbol: {symbol}");
@@ -115,7 +115,7 @@ partial class MethodConvert
                 AddInstruction(OpCode.PICKITEM);
                 break;
             case IPropertySymbol property:
-                Call(model, property.GetMethod!);
+                CallMethodWithConvention(model, property.GetMethod!);
                 break;
             default:
                 throw new CompilationException(expression, DiagnosticId.SyntaxNotSupported, $"Unsupported symbol: {symbol}");

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/ObjectCreationExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/ObjectCreationExpression.cs
@@ -39,7 +39,7 @@ partial class MethodConvert
         {
             CreateObject(model, type, null);
         }
-        Call(model, constructor, needCreateObject, arguments);
+        CallInstanceMethod(model, constructor, needCreateObject, arguments);
         if (expression.Initializer is not null)
         {
             ConvertObjectCreationExpressionInitializer(model, expression.Initializer);
@@ -65,7 +65,7 @@ partial class MethodConvert
                 case IPropertySymbol property:
                     ConvertExpression(model, ae.Right);
                     AddInstruction(OpCode.OVER);
-                    Call(model, property.SetMethod!, CallingConvention.Cdecl);
+                    CallMethodWithConvention(model, property.SetMethod!, CallingConvention.Cdecl);
                     break;
                 default:
                     throw new CompilationException(ae.Left, DiagnosticId.SyntaxNotSupported, $"Unsupported symbol: {symbol}");

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PostfixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PostfixUnary.cs
@@ -82,12 +82,12 @@ partial class MethodConvert
             ConvertExpression(model, operand.ArgumentList.Arguments[0].Expression);
             AddInstruction(OpCode.OVER);
             AddInstruction(OpCode.OVER);
-            Call(model, property.GetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.GetMethod!, CallingConvention.StdCall);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.REVERSE4);
             AddInstruction(OpCode.REVERSE3);
             EmitIncrementOrDecrement(operatorToken, property.Type);
-            Call(model, property.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.StdCall);
         }
         else
         {
@@ -171,19 +171,19 @@ partial class MethodConvert
     {
         if (symbol.IsStatic)
         {
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             AddInstruction(OpCode.DUP);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
-            Call(model, symbol.SetMethod!);
+            CallMethodWithConvention(model, symbol.SetMethod!);
         }
         else
         {
             AddInstruction(OpCode.LDARG0);
             AddInstruction(OpCode.DUP);
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             AddInstruction(OpCode.TUCK);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
-            Call(model, symbol.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, symbol.SetMethod!, CallingConvention.StdCall);
         }
     }
 
@@ -232,19 +232,19 @@ partial class MethodConvert
     {
         if (symbol.IsStatic)
         {
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             AddInstruction(OpCode.DUP);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
-            Call(model, symbol.SetMethod!);
+            CallMethodWithConvention(model, symbol.SetMethod!);
         }
         else
         {
             ConvertExpression(model, operand.Expression);
             AddInstruction(OpCode.DUP);
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             AddInstruction(OpCode.TUCK);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
-            Call(model, symbol.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, symbol.SetMethod!, CallingConvention.StdCall);
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
@@ -99,11 +99,11 @@ partial class MethodConvert
             ConvertExpression(model, operand.ArgumentList.Arguments[0].Expression);
             AddInstruction(OpCode.OVER);
             AddInstruction(OpCode.OVER);
-            Call(model, property.GetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, property.GetMethod!, CallingConvention.StdCall);
             EmitIncrementOrDecrement(operatorToken, property.Type);
             AddInstruction(OpCode.DUP);
             AddInstruction(OpCode.REVERSE4);
-            Call(model, property.SetMethod!, CallingConvention.Cdecl);
+            CallMethodWithConvention(model, property.SetMethod!, CallingConvention.Cdecl);
         }
         else
         {
@@ -187,19 +187,19 @@ partial class MethodConvert
     {
         if (symbol.IsStatic)
         {
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
             AddInstruction(OpCode.DUP);
-            Call(model, symbol.SetMethod!);
+            CallMethodWithConvention(model, symbol.SetMethod!);
         }
         else
         {
             AddInstruction(OpCode.LDARG0);
             AddInstruction(OpCode.DUP);
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
             AddInstruction(OpCode.TUCK);
-            Call(model, symbol.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, symbol.SetMethod!, CallingConvention.StdCall);
         }
     }
 
@@ -248,19 +248,19 @@ partial class MethodConvert
     {
         if (symbol.IsStatic)
         {
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
             AddInstruction(OpCode.DUP);
-            Call(model, symbol.SetMethod!);
+            CallMethodWithConvention(model, symbol.SetMethod!);
         }
         else
         {
             ConvertExpression(model, operand.Expression);
             AddInstruction(OpCode.DUP);
-            Call(model, symbol.GetMethod!);
+            CallMethodWithConvention(model, symbol.GetMethod!);
             EmitIncrementOrDecrement(operatorToken, symbol.Type);
             AddInstruction(OpCode.TUCK);
-            Call(model, symbol.SetMethod!, CallingConvention.StdCall);
+            CallMethodWithConvention(model, symbol.SetMethod!, CallingConvention.StdCall);
         }
     }
 

--- a/src/Neo.Compiler.CSharp/MethodConvert/ExternConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ExternConvert.cs
@@ -95,7 +95,7 @@ partial class MethodConvert
             string method = Symbol.GetDisplayName(true);
             ushort parametersCount = (ushort)Symbol.Parameters.Length;
             bool hasReturnValue = !Symbol.ReturnsVoid || Symbol.MethodKind == MethodKind.Constructor;
-            Call(hash, method, parametersCount, hasReturnValue);
+            CallContractMethod(hash, method, parametersCount, hasReturnValue);
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
@@ -254,7 +254,7 @@ namespace Neo.Compiler
             CreateObject(model, type, null);
             IMethodSymbol? constructor = type.InstanceConstructors.FirstOrDefault(p => p.Parameters.Length == 0)
                 ?? throw new CompilationException(type, DiagnosticId.NoParameterlessConstructor, "The contract class requires a parameterless constructor.");
-            Call(model, constructor, true, Array.Empty<ArgumentSyntax>());
+            CallInstanceMethod(model, constructor, true, Array.Empty<ArgumentSyntax>());
             _returnTarget.Instruction = Jump(OpCode.JMP_L, target._startTarget);
             _startTarget.Instruction = _instructions[0];
         }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RecursivePattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RecursivePattern.cs
@@ -35,7 +35,7 @@ partial class MethodConvert
 
                     if (propertySymbol is IPropertySymbol property)
                     {
-                        Call(model, property.GetMethod!);
+                        CallMethodWithConvention(model, property.GetMethod!);
                     }
                     else
                     {

--- a/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
@@ -136,8 +136,8 @@ partial class MethodConvert
                 Jump(OpCode.JMPIF_L, endTarget);
             }
             Push(key);
-            Call(ApplicationEngine.System_Storage_GetReadOnlyContext);
-            Call(ApplicationEngine.System_Storage_Get);
+            CallInteropMethod(ApplicationEngine.System_Storage_GetReadOnlyContext);
+            CallInteropMethod(ApplicationEngine.System_Storage_Get);
             switch (property.Type.Name)
             {
                 case "byte":
@@ -178,7 +178,7 @@ partial class MethodConvert
                 case "ECPoint":
                     break;
                 default:
-                    Call(NativeContract.StdLib.Hash, "deserialize", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "deserialize", 1, true);
                     break;
             }
             AddInstruction(OpCode.DUP);
@@ -234,12 +234,12 @@ partial class MethodConvert
                 case "ECPoint":
                     break;
                 default:
-                    Call(NativeContract.StdLib.Hash, "serialize", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "serialize", 1, true);
                     break;
             }
             Push(key);
-            Call(ApplicationEngine.System_Storage_GetContext);
-            Call(ApplicationEngine.System_Storage_Put);
+            CallInteropMethod(ApplicationEngine.System_Storage_GetContext);
+            CallInteropMethod(ApplicationEngine.System_Storage_Put);
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/CommonForEachStatement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/CommonForEachStatement.cs
@@ -82,14 +82,14 @@ namespace Neo.Compiler
             using (InsertSequencePoint(syntax.Identifier))
             {
                 startTarget.Instruction = AccessSlot(OpCode.LDLOC, iteratorIndex);
-                Call(ApplicationEngine.System_Iterator_Value);
+                CallInteropMethod(ApplicationEngine.System_Iterator_Value);
                 AccessSlot(OpCode.STLOC, elementIndex);
             }
             ConvertStatement(model, syntax.Statement);
             using (InsertSequencePoint(syntax.Expression))
             {
                 continueTarget.Instruction = AccessSlot(OpCode.LDLOC, iteratorIndex);
-                Call(ApplicationEngine.System_Iterator_Next);
+                CallInteropMethod(ApplicationEngine.System_Iterator_Next);
                 Jump(OpCode.JMPIF_L, startTarget);
             }
             breakTarget.Instruction = AddInstruction(OpCode.NOP);
@@ -160,7 +160,7 @@ namespace Neo.Compiler
             using (InsertSequencePoint(syntax.Variable))
             {
                 startTarget.Instruction = AccessSlot(OpCode.LDLOC, iteratorIndex);
-                Call(ApplicationEngine.System_Iterator_Value);
+                CallInteropMethod(ApplicationEngine.System_Iterator_Value);
                 AddInstruction(OpCode.UNPACK);
                 AddInstruction(OpCode.DROP);
                 for (int i = 0; i < symbols.Length; i++)
@@ -180,7 +180,7 @@ namespace Neo.Compiler
             using (InsertSequencePoint(syntax.Expression))
             {
                 continueTarget.Instruction = AccessSlot(OpCode.LDLOC, iteratorIndex);
-                Call(ApplicationEngine.System_Iterator_Next);
+                CallInteropMethod(ApplicationEngine.System_Iterator_Next);
                 Jump(OpCode.JMPIF_L, startTarget);
             }
             breakTarget.Instruction = AddInstruction(OpCode.NOP);

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.cs
@@ -334,7 +334,7 @@ partial class MethodConvert
             case "System.Numerics.BigInteger.Parse(string)":
                 if (arguments is not null)
                     PrepareArgumentsForMethod(model, symbol, arguments);
-                Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                 return true;
             case "System.Math.Abs(sbyte)":
             case "System.Math.Abs(short)":
@@ -395,7 +395,7 @@ partial class MethodConvert
             case "System.Numerics.BigInteger.ToString()":
                 if (instanceExpression is not null)
                     ConvertExpression(model, instanceExpression);
-                Call(NativeContract.StdLib.Hash, "itoa", 1, true);
+                CallContractMethod(NativeContract.StdLib.Hash, "itoa", 1, true);
                 return true;
             case "System.Numerics.BigInteger.Equals(long)":
             case "System.Numerics.BigInteger.Equals(ulong)":
@@ -424,7 +424,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(sbyte.MinValue);
                     Push(sbyte.MaxValue + 1);
@@ -440,7 +440,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(byte.MinValue);
                     Push(byte.MaxValue + 1);
@@ -456,7 +456,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(short.MinValue);
                     Push(short.MaxValue + 1);
@@ -472,7 +472,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(ushort.MinValue);
                     Push(ushort.MaxValue + 1);
@@ -488,7 +488,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(int.MinValue);
                     Push(new BigInteger(int.MaxValue) + 1);
@@ -504,7 +504,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(uint.MinValue);
                     Push(new BigInteger(uint.MaxValue) + 1);
@@ -520,7 +520,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(long.MinValue);
                     Push(new BigInteger(long.MaxValue) + 1);
@@ -536,7 +536,7 @@ partial class MethodConvert
                     JumpTarget endTarget = new();
                     if (arguments is not null)
                         PrepareArgumentsForMethod(model, symbol, arguments);
-                    Call(NativeContract.StdLib.Hash, "atoi", 1, true);
+                    CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
                     AddInstruction(OpCode.DUP);
                     Push(ulong.MinValue);
                     Push(new BigInteger(ulong.MaxValue) + 1);


### PR DESCRIPTION
It was not clear why we have so many calls and how/when to use them, thus having this pr.