### PR TITLE
Remove debuginfo param in optimizer

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/OpCodeTypes.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/OpCodeTypes.cs
@@ -11,8 +11,8 @@
 
 using Neo.VM;
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using static Neo.VM.OpCode;
 
 namespace Neo.Optimizer

--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/Reachability.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/Reachability.cs
@@ -33,7 +33,7 @@ namespace Neo.Optimizer
         [Strategy(Priority = int.MaxValue)]
         public static (NefFile, ContractManifest, JObject) RemoveUncoveredInstructions(NefFile nef, ContractManifest manifest, JObject debugInfo)
         {
-            InstructionCoverage oldContractCoverage = new InstructionCoverage(nef, manifest, debugInfo);
+            InstructionCoverage oldContractCoverage = new InstructionCoverage(nef, manifest);
             Dictionary<int, BranchType> coveredMap = oldContractCoverage.coveredMap;
             Script oldScript = nef.Script;
             List<(int, Instruction)> oldAddressAndInstructionsList = oldContractCoverage.addressAndInstructions;
@@ -129,13 +129,13 @@ namespace Neo.Optimizer
                 foreach (JToken? sequencePoint in (JArray)method!["sequence-points"]!)
                 {
                     GroupCollection sequencePointGroups = SequencePointRegex.Match(sequencePoint!.AsString()).Groups;
-                    int startingInstructionAddress = int.Parse(sequencePointGroups[1].ToString());
-                    Instruction oldInstruction = oldAddressToInstruction[startingInstructionAddress];
+                    int startInstructionAddress = int.Parse(sequencePointGroups[1].ToString());
+                    Instruction oldInstruction = oldAddressToInstruction[startInstructionAddress];
                     if (simplifiedInstructionsToAddress.Contains(oldInstruction))
                     {
-                        startingInstructionAddress = (int)simplifiedInstructionsToAddress[oldInstruction]!;
-                        newSequencePoints.Add(new JString($"{startingInstructionAddress}{sequencePointGroups[2]}"));
-                        previousSequencePoint = startingInstructionAddress;
+                        startInstructionAddress = (int)simplifiedInstructionsToAddress[oldInstruction]!;
+                        newSequencePoints.Add(new JString($"{startInstructionAddress}{sequencePointGroups[2]}"));
+                        previousSequencePoint = startInstructionAddress;
                     }
                     else
                         newSequencePoints.Add(new JString($"{previousSequencePoint}{sequencePointGroups[2]}"));
@@ -156,7 +156,7 @@ namespace Neo.Optimizer
         }
 
         public static Dictionary<int, BranchType>
-            FindCoveredInstructions(NefFile nef, ContractManifest manifest, JToken debugInfo)
-            => new InstructionCoverage(nef, manifest, debugInfo).coveredMap;
+            FindCoveredInstructions(NefFile nef, ContractManifest manifest)
+            => new InstructionCoverage(nef, manifest).coveredMap;
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/BasicBlockTests.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/BasicBlockTests.cs
@@ -73,7 +73,7 @@ namespace Neo.Compiler.CSharp.UnitTests.Optimizer
 
             // Each jump target starts a new basic block
             foreach (VM.Instruction target in jumpTargets.Keys)
-                Assert.IsTrue(basicBlocks.basicBlocksByStartingInstruction.ContainsKey(target));
+                Assert.IsTrue(basicBlocks.basicBlocksByStartInstruction.ContainsKey(target));
 
             // Each instruction is included in only 1 basic block
             HashSet<VM.Instruction> includedInstructions = new();

--- a/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/HasCallATests.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/HasCallATests.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Optimizer;
+using Neo.SmartContract.Testing;
+
+namespace Neo.Compiler.CSharp.UnitTests.Optimizer
+{
+    [TestClass]
+    public class HasCallATests
+    {
+        [TestMethod]
+        public void Test_HasCallA()
+        {
+            Assert.IsTrue(EntryPoint.HasCallA(Contract_IndexOrRange.Nef));
+            Assert.IsFalse(EntryPoint.HasCallA(Contract_Polymorphism.Nef));
+            Assert.IsFalse(EntryPoint.HasCallA(Contract_TryCatch.Nef));
+        }
+    }
+}


### PR DESCRIPTION
Remove unnecessary debuginfo param in optimizer
Add startAddr for BasicBlock
Rename all `starting` in optimizer to `start`
Add tests for HasCallA

Without relying on debuginfo we may analyze all deployed contracts on mainnet in the future.