### PR TITLE
update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.dockerfile
+++ b/.devcontainer/devcontainer.dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:8.0-jammy

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
 	"name": "C# (.NET)",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-jammy",
+	"build": {
+		// Path is relative to the devcontainer.json file.
+		"dockerfile": "devcontainer.dockerfile"
+	},
 	"onCreateCommand": "./scripts/load_submodule.sh",
 	"postCreateCommand": "dotnet restore && dotnet build",
 	"customizations": {


### PR DESCRIPTION
Devcontainer is now the same as in neo-core repo, using a dockerfile.
The current version is not working anymore in a stable manner.