### PR TITLE
Improve error info on invalid command line arguments

### DIFF
--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -94,6 +94,9 @@ namespace Neo.Compiler
                 {
                     Console.Error.WriteLine("The files must have a .cs extension.");
                     context.ExitCode = 1;
+                    Console.Error.WriteLine("Maybe invalid command line args. Got the following paths to compile:");
+                    foreach (string p in paths)
+                        Console.Error.WriteLine($"  {p}");
                     return;
                 }
                 if (!File.Exists(path))


### PR DESCRIPTION
```bash
nccs /path/to/contract.csproj --some-invalid-args --debug --assembly
```
The command above only results in `The files must have a .cs extension.`, and nothing gets compiled. Users may not come up with checking and fixing the invalid arguments input in the command line.