### PR TITLE
add switch to gas consume test

### DIFF
--- a/tests/Neo.Compiler.CSharp.UnitTests/DebugAndTestBase.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/DebugAndTestBase.cs
@@ -14,6 +14,8 @@ namespace Neo.Compiler.CSharp.UnitTests;
 public class DebugAndTestBase<T> : TestBase<T>
     where T : SmartContract.Testing.SmartContract, IContractInfo
 {
+    internal bool TestGasConsume { set; get; } = true;
+
     static DebugAndTestBase()
     {
         var context = TestCleanup.TestInitialize(typeof(T));
@@ -83,5 +85,11 @@ public class DebugAndTestBase<T> : TestBase<T>
                 Assert.IsFalse(includedInstructions.Contains(instruction));
                 includedInstructions.Add(instruction);
             }
+    }
+
+    protected void AssertGasConsumed(long gasConsumed)
+    {
+        if (TestGasConsume)
+            Assert.AreEqual(gasConsumed, Engine.FeeConsumed.Value);
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Abort.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Abort.cs
@@ -26,7 +26,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             // All the ABORT instruction addresses in "testAbort" method
             List<int> AbortAddresses = DumpNef.OpCodeAddressesInMethod(Contract_Abort.Nef, _debugInfo, "testAbort", OpCode.ABORT);
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAbort());
-            Assert.AreEqual(1021260, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1021260);
             Assert.AreEqual(exception.CurrentContext?.InstructionPointer, AbortAddresses[0]);  // stop at the 1st ABORT
             Assert.AreEqual(exception.CurrentContext?.LocalVariables?[0].GetInteger(), 0);  // v==0
             Assert.AreEqual(exception.State, VMState.FAULT);
@@ -38,7 +38,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             // All the ABORTMSG instruction addresses in "testAbortMsg" method
             List<int> AbortAddresses = DumpNef.OpCodeAddressesInMethod(Contract_Abort.Nef, _debugInfo, "testAbortMsg", OpCode.ABORTMSG);
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAbortMsg());
-            Assert.AreEqual(1021500, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1021500);
             Assert.AreEqual(exception.CurrentContext?.InstructionPointer, AbortAddresses[0]);  // stop at the 1st ABORTMSG
             Assert.AreEqual(exception.CurrentContext?.LocalVariables?[0].GetInteger(), 0);  // v==0
             Assert.AreEqual(exception.State, VMState.FAULT);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Array.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Array.cs
@@ -26,7 +26,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_GetTreeByteLengthPrefix2()
         {
             var result = Contract.GetTreeByteLengthPrefix2();
-            Assert.AreEqual(1784760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1784760);
 
             CollectionAssert.AreEqual(new byte[] { 0x01, 0x03 }, result);
         }
@@ -35,7 +35,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_JaggedArray()
         {
             var arr = Contract.TestJaggedArray();
-            Assert.AreEqual(2094930, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2094930);
 
             Assert.AreEqual(4, arr?.Count);
             var element0 = (Array?)arr?[0];
@@ -46,7 +46,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_JaggedByteArray()
         {
             var arr = Contract.TestJaggedByteArray();
-            Assert.AreEqual(2832570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2832570);
 
             Assert.AreEqual(4, arr?.Count);
             var element0 = (byte[]?)arr?[0];
@@ -57,7 +57,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_EmptyArray()
         {
             var arr = Contract.TestEmptyArray();
-            Assert.AreEqual(1787220, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1787220);
 
             Assert.AreEqual(0, arr?.Count);
         }
@@ -66,7 +66,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_IntArray()
         {
             var arr = Contract.TestIntArray();
-            Assert.AreEqual(2540310, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2540310);
 
             //test 0,1,2
             CollectionAssert.AreEqual(new BigInteger[] { 0, 1, 2 }, arr?.ToArray());
@@ -77,18 +77,18 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             //test 1,4,5
             var arr = Contract.TestIntArrayInit();
-            Assert.AreEqual(2340420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2340420);
             CollectionAssert.AreEqual(new BigInteger[] { 1, 4, 5 }, arr?.ToArray());
 
 
             //test 1,4,5
             arr = Contract.TestIntArrayInit2();
-            Assert.AreEqual(2340420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2340420);
             CollectionAssert.AreEqual(new BigInteger[] { 1, 4, 5 }, arr?.ToArray());
 
             //test 1,4,5
             arr = Contract.TestIntArrayInit3();
-            Assert.AreEqual(2340420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2340420);
             CollectionAssert.AreEqual(new BigInteger[] { 1, 4, 5 }, arr?.ToArray());
         }
 
@@ -96,7 +96,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_StructArray()
         {
             var result = Contract.TestStructArray();
-            Assert.AreEqual(3543240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3543240);
 
             //test (1+5)*7 == 42
             var bequal = result as Struct != null;
@@ -114,14 +114,14 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsInstanceOfType(state[1], typeof(VM.Types.Null));
             Assert.IsInstanceOfType(state[2], typeof(VM.Types.Integer));
             Assert.AreEqual(0, state[2]);
-            Assert.AreEqual(3279750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3279750);
         }
 
         [TestMethod]
         public void Test_StructArrayInit()
         {
             var result = Contract.TestStructArrayInit();
-            Assert.AreEqual(3343410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3343410);
 
             //test (1+5)*7 == 42
             var bequal = result as Struct != null;
@@ -132,7 +132,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ByteArrayOwner()
         {
             var bts = Contract.TestByteArrayOwner();
-            Assert.AreEqual(1784760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1784760);
 
             CollectionAssert.AreEqual(new byte[] { 0xf6, 0x64, 0x43, 0x49, 0x8d, 0x38, 0x78, 0xd3, 0x2b, 0x99, 0x4e, 0x4e, 0x12, 0x83, 0xc6, 0x93, 0x44, 0x21, 0xda, 0xfe }, bts);
         }
@@ -141,7 +141,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_DynamicArrayInit()
         {
             var arr = Contract.TestDynamicArrayInit(3);
-            Assert.AreEqual(2605350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2605350);
 
             Assert.AreEqual(3, arr?.Count);
             Assert.AreEqual(new BigInteger(0), arr?[0]);
@@ -149,7 +149,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(new BigInteger(2), arr?[2]);
 
             arr = Contract.TestDynamicArrayInit(0);
-            Assert.AreEqual(1863750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1863750);
             Assert.AreEqual(0, arr?.Count);
             Assert.ThrowsException<TestException>(() => Contract.TestDynamicArrayInit(-1));
             Assert.ThrowsException<TestException>(() => Contract.TestDynamicArrayInit(int.MaxValue));
@@ -159,7 +159,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_DefaultArray()
         {
             var arr = Contract.TestDefaultArray();
-            Assert.AreEqual(1805220, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1805220);
             Assert.IsTrue(arr!.Value);
         }
 
@@ -167,7 +167,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_DynamicArrayStringInit()
         {
             var arr = Contract.TestDynamicArrayStringInit("hello");
-            Assert.AreEqual(1855710, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1855710);
 
             Assert.AreEqual(5, arr?.Length);
             Assert.IsTrue(arr?.All(a => a == 0));
@@ -177,7 +177,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ByteArrayOwnerCall()
         {
             var bts = Contract.TestByteArrayOwnerCall();
-            Assert.AreEqual(2048100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048100);
 
             CollectionAssert.AreEqual(new byte[] { 0xf6, 0x64, 0x43, 0x49, 0x8d, 0x38, 0x78, 0xd3, 0x2b, 0x99, 0x4e, 0x4e, 0x12, 0x83, 0xc6, 0x93, 0x44, 0x21, 0xda, 0xfe }, bts);
         }
@@ -186,7 +186,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_StringArray()
         {
             var items = Contract.TestSupportedStandards();
-            Assert.AreEqual(1784760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1784760);
 
             Assert.AreEqual((ByteString)"NEP-5", items?[0]);
             Assert.AreEqual((ByteString)"NEP-10", items?[1]);
@@ -196,7 +196,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Collectionexpressions()
         {
             var arr = Contract.TestCollectionexpressions();
-            Assert.AreEqual(3387420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3387420);
 
             Assert.AreEqual(4, arr?.Count);
 
@@ -225,7 +225,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ElementBinding()
         {
             Contract.TestElementBinding();
-            Assert.AreEqual(5907840, Engine.FeeConsumed.Value);
+            AssertGasConsumed(5907840);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Assert.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Assert.cs
@@ -33,7 +33,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_AssertFalse()
         {
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAssertFalse());
-            Assert.AreEqual(1021590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1021590);
             AssertsInFalse(exception);
         }
 
@@ -41,7 +41,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_AssertInFunction()
         {
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAssertInFunction());
-            Assert.AreEqual(1039020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1039020);
             AssertsInFalse(exception);
             Assert.AreEqual(exception.InvocationStack?.ToArray()?[1]?.LocalVariables?[0].GetInteger(), 0);  // v==0
         }
@@ -50,7 +50,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_AssertInTry()
         {
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAssertInTry());
-            Assert.AreEqual(1039140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1039140);
             AssertsInFalse(exception);
             Assert.AreEqual(exception.InvocationStack?.ToArray()?[1]?.LocalVariables?[0].GetInteger(), 0);  // v==0
         }
@@ -59,7 +59,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_AssertInCatch()
         {
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAssertInCatch());
-            Assert.AreEqual(1055010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1055010);
             AssertsInFalse(exception);
             Assert.AreEqual(exception.InvocationStack?.ToArray()?[1]?.LocalVariables?[0].GetInteger(), 1);  // v==1
         }
@@ -68,7 +68,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_AssertInFinally()
         {
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestAssertInFinally());
-            Assert.AreEqual(1039470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1039470);
             AssertsInFalse(exception);
             Assert.AreEqual(exception.InvocationStack?.ToArray()?[1]?.LocalVariables?[0].GetInteger(), 1);  // v==1
         }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Attribute.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Attribute.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             Assert.AreEqual(Contract_AttributeChanged.Manifest.Name, "Contract_AttributeChanged");
             Assert.IsTrue(Contract.Test());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigInteger.cs
@@ -13,118 +13,118 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Pow()
         {
             Assert.AreEqual(8, Contract.TestPow(2, 3));
-            Assert.AreEqual(1049040, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049040);
         }
 
         [TestMethod]
         public void Test_Sqrt()
         {
             Assert.AreEqual(2, Contract.TestSqrt(4));
-            Assert.AreEqual(1048950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048950);
         }
 
         [TestMethod]
         public void Test_Sbyte()
         {
             Assert.AreEqual(127, Contract.Testsbyte(127));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.AreEqual(-128, Contract.Testsbyte(-128));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.ThrowsException<TestException>(() => Contract.Testsbyte(128));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
             Assert.ThrowsException<TestException>(() => Contract.Testsbyte(-129));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
         }
 
         [TestMethod]
         public void Test_byte()
         {
             Assert.AreEqual(0, Contract.Testbyte(0));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.AreEqual(255, Contract.Testbyte(255));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.ThrowsException<TestException>(() => Contract.Testbyte(-1));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
             Assert.ThrowsException<TestException>(() => Contract.Testbyte(256));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
         }
 
         [TestMethod]
         public void Test_short()
         {
             Assert.AreEqual(32767, Contract.Testshort(32767));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.AreEqual(-32768, Contract.Testshort(-32768));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.ThrowsException<TestException>(() => Contract.Testshort(32768));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
             Assert.ThrowsException<TestException>(() => Contract.Testshort(-32769));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
         }
 
         [TestMethod]
         public void Test_ushort()
         {
             Assert.AreEqual(0, Contract.Testushort(0));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.AreEqual(65535, Contract.Testushort(65535));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.ThrowsException<TestException>(() => Contract.Testushort(-1));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
             Assert.ThrowsException<TestException>(() => Contract.Testushort(65536));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
         }
 
         [TestMethod]
         public void Test_int()
         {
             Assert.AreEqual(-2147483648, Contract.Testint(-2147483648));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.AreEqual(2147483647, Contract.Testint(2147483647));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.ThrowsException<TestException>(() => Contract.Testint(-2147483649));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
             Assert.ThrowsException<TestException>(() => Contract.Testint(2147483648));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
         }
 
         [TestMethod]
         public void Test_uint()
         {
             Assert.AreEqual(0, Contract.Testuint(0));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.AreEqual(4294967295, Contract.Testuint(4294967295));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.ThrowsException<TestException>(() => Contract.Testuint(-1));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
             Assert.ThrowsException<TestException>(() => Contract.Testuint(4294967296));
-            Assert.AreEqual(1078590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078590);
         }
 
         [TestMethod]
         public void Test_long()
         {
             Assert.AreEqual(-9223372036854775808, Contract.Testlong(-9223372036854775808));
-            Assert.AreEqual(1047900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047900);
             Assert.AreEqual(9223372036854775807, Contract.Testlong(9223372036854775807));
-            Assert.AreEqual(1047900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047900);
             Assert.ThrowsException<TestException>(() => Contract.Testlong(BigInteger.Parse("-9223372036854775809")));
-            Assert.AreEqual(1078770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078770);
             Assert.ThrowsException<TestException>(() => Contract.Testlong(9223372036854775808));
-            Assert.AreEqual(1078770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078770);
         }
 
         [TestMethod]
         public void Test_ulong()
         {
             Assert.AreEqual(0, Contract.Testulong(0));
-            Assert.AreEqual(1047900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047900);
             Assert.AreEqual(18446744073709551615, Contract.Testulong(18446744073709551615));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.ThrowsException<TestException>(() => Contract.Testulong(BigInteger.Parse("18446744073709551616")));
-            Assert.AreEqual(1078770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078770);
             Assert.ThrowsException<TestException>(() => Contract.Testulong(-1));
-            Assert.AreEqual(1078680, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1078680);
         }
 
         [TestMethod]
@@ -145,87 +145,87 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test 0
             Assert.AreEqual(new BigInteger(0).IsEven, Contract.TestIsEven(0));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
 
             // Test 1
             Assert.AreEqual(new BigInteger(1).IsEven, Contract.TestIsEven(1));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
 
             // Test 2
             Assert.AreEqual(new BigInteger(2).IsEven, Contract.TestIsEven(2));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
 
             // Test -1
             Assert.AreEqual(new BigInteger(-1).IsEven, Contract.TestIsEven(-1));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
 
             // Test -2
             Assert.AreEqual(new BigInteger(-2).IsEven, Contract.TestIsEven(-2));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
         }
 
         [TestMethod]
         public void Test_Add()
         {
             Assert.AreEqual(new BigInteger(1111111110), Contract.TestAdd(123456789, 987654321));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void Test_Subtract()
         {
             Assert.AreEqual(new BigInteger(-864197532), Contract.TestSubtract(123456789, 987654321));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void Test_Multiply()
         {
             Assert.AreEqual(new BigInteger(39483), Contract.TestMultiply(123, 321));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void Test_Divide()
         {
             Assert.AreEqual(BigInteger.Divide(123456, 123), Contract.TestDivide(123456, 123));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void Test_Negate()
         {
             Assert.AreEqual(new BigInteger(-123456), Contract.TestNegate(123456));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
         }
 
         [TestMethod]
         public void Test_Remainder()
         {
             Assert.AreEqual(BigInteger.Remainder(123456, 123), Contract.TestRemainder(123456, 123));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void Test_Compare()
         {
             Assert.AreEqual(BigInteger.Compare(123, 321), Contract.TestCompare(123, 321));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
             Assert.AreEqual(BigInteger.Compare(123, 123), Contract.TestCompare(123, 123));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
             Assert.AreEqual(BigInteger.Compare(123, -321), Contract.TestCompare(123, -321));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
         }
 
         [TestMethod]
         public void Test_GreatestCommonDivisor()
         {
             Assert.AreEqual(BigInteger.GreatestCommonDivisor(48, 18), Contract.TestGreatestCommonDivisor(48, 18));
-            Assert.AreEqual(1049730, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049730);
             Assert.AreEqual(BigInteger.GreatestCommonDivisor(-48, -18), Contract.TestGreatestCommonDivisor(-48, -18));
-            Assert.AreEqual(1049730, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049730);
             Assert.AreEqual(BigInteger.GreatestCommonDivisor(24, 12), Contract.TestGreatestCommonDivisor(24, 12));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
         }
 
         // New test methods
@@ -241,7 +241,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             Assert.IsTrue(Contract.TestEquals(123, 123));
             Assert.IsFalse(Contract.TestEquals(123, 321));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
@@ -250,7 +250,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsTrue(Contract.TestIsOne(1));
             Assert.IsFalse(Contract.TestIsOne(0));
             Assert.IsFalse(Contract.TestIsOne(-1));
-            Assert.AreEqual(1047300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047300);
         }
 
         [TestMethod]
@@ -259,7 +259,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsTrue(Contract.TestIsZero(0));
             Assert.IsFalse(Contract.TestIsZero(1));
             Assert.IsFalse(Contract.TestIsZero(-1));
-            Assert.AreEqual(1047300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047300);
         }
 
         [TestMethod]
@@ -267,7 +267,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test with number = 10, exponent = 3, modulus = 30
             Assert.AreEqual(BigInteger.ModPow(10, 3, 30), Contract.TestModPow());
-            Assert.AreEqual(1047840, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047840);
         }
 
         [TestMethod]
@@ -276,7 +276,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(1, Contract.TestSign(10)); // Positive number
             Assert.AreEqual(0, Contract.TestSign(0)); // Zero
             Assert.AreEqual(-1, Contract.TestSign(-10)); // Negative number
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Boolean.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Boolean.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_BooleanOr()
         {
             Assert.AreEqual(true, Contract.TestBooleanOr());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ByteArrayAssignment.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ByteArrayAssignment.cs
@@ -12,37 +12,37 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ByteArrayAssignment()
         {
             CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x04 }, Contract.TestAssignment());
-            Assert.AreEqual(1724190, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1724190);
         }
 
         [TestMethod]
         public void Test_ByteArrayAssignmentOutOfBounds()
         {
             Assert.ThrowsException<TestException>(Contract.TestAssignmentOutOfBounds);
-            Assert.AreEqual(1724070, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1724070);
         }
 
         [TestMethod]
         public void Test_ByteArrayAssignmentOverflow()
         {
             CollectionAssert.AreEqual(new byte[] { 0xff, 0x02, 0x03 }, Contract.TestAssignmentOverflow());
-            Assert.AreEqual(1478820, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1478820);
         }
 
         [TestMethod]
         public void Test_ByteArrayAssignmentWrongCasting()
         {
             var exception = Assert.ThrowsException<TestException>(Contract.TestAssignmentWrongCasting);
-            Assert.AreEqual(1478340, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1478340);
             Assert.IsInstanceOfType<InvalidOperationException>(exception.InnerException);
-            Assert.AreEqual(1478340, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1478340);
         }
 
         [TestMethod]
         public void Test_ByteArrayAssignmentDynamic()
         {
             CollectionAssert.AreEqual(new byte[] { 0x01, 0x0a }, Contract.TestAssignmentDynamic(10));
-            Assert.AreEqual(1546590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1546590);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
@@ -25,117 +25,117 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestCharProperties(char c, bool isDigit, bool isLetter, bool isWhiteSpace, bool isLower, bool isUpper)
         {
             Assert.AreEqual(isDigit, Contract.TestCharIsDigit(c), $"IsDigit failed for '{c}'");
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.AreEqual(isLetter, Contract.TestCharIsLetter(c), $"IsLetter failed for '{c}'");
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.AreEqual(isWhiteSpace, Contract.TestCharIsWhiteSpace(c), $"IsWhiteSpace failed for '{c}'");
             Assert.AreEqual(isLower, Contract.TestCharIsLower(c), $"IsLower failed for '{c}'");
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.AreEqual(isUpper, Contract.TestCharIsUpper(c), $"IsUpper failed for '{c}'");
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
         }
 
         [TestMethod]
         public void TestCharGetNumericValue()
         {
             Assert.AreEqual(0, Contract.TestCharGetNumericValue('0'));
-            Assert.AreEqual(1047720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047720);
             Assert.AreEqual(9, Contract.TestCharGetNumericValue('9'));
-            Assert.AreEqual(1047720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047720);
             Assert.AreEqual(-1, Contract.TestCharGetNumericValue('a'));
-            Assert.AreEqual(1047600, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047600);
             Assert.AreEqual(-1, Contract.TestCharGetNumericValue('$'));
-            Assert.AreEqual(1047600, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047600);
         }
 
         [TestMethod]
         public void TestCharSpecialCategories()
         {
             Assert.IsTrue(Contract.TestCharIsPunctuation('.'));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.IsTrue(Contract.TestCharIsPunctuation(','));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.IsFalse(Contract.TestCharIsPunctuation('a'));
-            Assert.AreEqual(1048590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048590);
 
             Assert.IsTrue(Contract.TestCharIsSymbol('$'));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.IsTrue(Contract.TestCharIsSymbol('+'));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.IsFalse(Contract.TestCharIsSymbol('a'));
-            Assert.AreEqual(1049010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049010);
 
             Assert.IsTrue(Contract.TestCharIsControl('\n'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.IsTrue(Contract.TestCharIsControl('\0'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.IsFalse(Contract.TestCharIsControl('a'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
         }
 
         [TestMethod]
         public void TestCharSurrogates()
         {
             Assert.IsTrue(Contract.TestCharIsSurrogate('\uD800'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.IsTrue(Contract.TestCharIsSurrogate('\uDFFF'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.IsFalse(Contract.TestCharIsSurrogate('a'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
 
             Assert.IsTrue(Contract.TestCharIsHighSurrogate('\uD800'));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.IsFalse(Contract.TestCharIsHighSurrogate('\uDC00'));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.IsFalse(Contract.TestCharIsHighSurrogate('a'));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
 
             Assert.IsTrue(Contract.TestCharIsLowSurrogate('\uDC00'));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.IsFalse(Contract.TestCharIsLowSurrogate('\uD800'));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.IsFalse(Contract.TestCharIsLowSurrogate('a'));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
         }
 
         [TestMethod]
         public void TestCharConversions()
         {
             Assert.AreEqual('A', Contract.TestCharToUpper('a'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.AreEqual('A', Contract.TestCharToUpper('A'));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual('a', Contract.TestCharToLower('A'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.AreEqual('a', Contract.TestCharToLower('a'));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
         }
 
         [TestMethod]
         public void TestCharIsLetterOrDigit()
         {
             Assert.IsTrue(Contract.TestCharIsLetterOrDigit('a'));
-            Assert.AreEqual(1048170, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048170);
             Assert.IsTrue(Contract.TestCharIsLetterOrDigit('A'));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
             Assert.IsTrue(Contract.TestCharIsLetterOrDigit('0'));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.IsFalse(Contract.TestCharIsLetterOrDigit('$'));
-            Assert.AreEqual(1048170, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048170);
         }
 
         [TestMethod]
         public void TestCharIsBetween()
         {
             Assert.IsTrue(Contract.TestCharIsBetween('a', 'a', 'z'));
-            Assert.AreEqual(1047930, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047930);
             Assert.IsTrue(Contract.TestCharIsBetween('z', 'a', 'z'));
-            Assert.AreEqual(1047930, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047930);
 
             Assert.IsFalse(Contract.TestCharIsBetween('A', 'a', 'z'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
             Assert.IsFalse(Contract.TestCharIsBetween('0', 'a', 'z'));
-            Assert.AreEqual(1047990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047990);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CheckedUnchecked.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CheckedUnchecked.cs
@@ -11,65 +11,65 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestAddChecked()
         {
             Assert.ThrowsException<TestException>(() => Contract.AddChecked(int.MaxValue, 1));
-            Assert.AreEqual(1063020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063020);
         }
 
         [TestMethod]
         public void TestAddUnchecked()
         {
             Assert.AreEqual(int.MinValue, Contract.AddUnchecked(int.MaxValue, 1));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestCastChecked()
         {
             Assert.ThrowsException<TestException>(() => Contract.CastChecked(-1));
-            Assert.AreEqual(1062540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062540);
 
             Assert.ThrowsException<TestException>(() => Contract.CastChecked(int.MinValue));
-            Assert.AreEqual(1062540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062540);
 
             Assert.AreEqual(2147483647, Contract.CastChecked(int.MaxValue));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
 
             Assert.AreEqual(0, Contract.CastChecked(ulong.MinValue));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
 
             Assert.ThrowsException<TestException>(() => Contract.CastChecked(ulong.MaxValue));
-            Assert.AreEqual(1062780, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062780);
 
             Assert.ThrowsException<TestException>(() => Contract.CastChecked(long.MinValue));
-            Assert.AreEqual(1062540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062540);
 
             Assert.ThrowsException<TestException>(() => Contract.CastChecked(long.MaxValue));
-            Assert.AreEqual(1062690, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062690);
         }
 
         [TestMethod]
         public void TestCastUnchecked()
         {
             Assert.AreEqual(uint.MaxValue, Contract.CastUnchecked(-1));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
 
 
             Assert.AreEqual(2147483648, Contract.CastUnchecked(int.MinValue));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
 
             Assert.AreEqual(2147483647, Contract.CastUnchecked(int.MaxValue));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
 
             Assert.AreEqual(0, Contract.CastUnchecked(ulong.MinValue));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
 
             Assert.AreEqual(4294967295, Contract.CastUnchecked(ulong.MaxValue));
-            Assert.AreEqual(1047690, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047690);
 
             Assert.AreEqual(0, Contract.CastUnchecked(long.MinValue));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
 
             Assert.AreEqual(4294967295, Contract.CastUnchecked(long.MaxValue));
-            Assert.AreEqual(1047600, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047600);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Concat.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Concat.cs
@@ -10,28 +10,28 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestStringAdd1()
         {
             Assert.AreEqual("ahello", Contract.TestStringAdd1("a"));
-            Assert.AreEqual(1354680, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1354680);
         }
 
         [TestMethod]
         public void TestStringAdd2()
         {
             Assert.AreEqual("abhello", Contract.TestStringAdd2("a", "b"));
-            Assert.AreEqual(1662180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1662180);
         }
 
         [TestMethod]
         public void TestStringAdd3()
         {
             Assert.AreEqual("abchello", Contract.TestStringAdd3("a", "b", "c"));
-            Assert.AreEqual(1969680, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1969680);
         }
 
         [TestMethod]
         public void TestStringAdd4()
         {
             Assert.AreEqual("abcdhello", Contract.TestStringAdd4("a", "b", "c", "d"));
-            Assert.AreEqual(2277180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2277180);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ConcatByteStringAddAssign.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ConcatByteStringAddAssign.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ByteStringAdd()
         {
             Assert.AreEqual("abc", Encoding.ASCII.GetString(Contract.ByteStringAddAssign(Encoding.ASCII.GetBytes("a"), Encoding.ASCII.GetBytes("b"), "c")!));
-            Assert.AreEqual(1970520, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1970520);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract1.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract1.cs
@@ -38,21 +38,21 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ByteArray_New()
         {
             CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, Contract.UnitTest_001());
-            Assert.AreEqual(1232070, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1232070);
         }
 
         [TestMethod]
         public void Test_testArgs1()
         {
             CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, Contract.TestArgs1(4));
-            Assert.AreEqual(1539180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1539180);
         }
 
         [TestMethod]
         public void Test_testArgs2()
         {
             CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, Contract.TestArgs2([1, 2, 3]));
-            Assert.AreEqual(1047240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047240);
         }
 
         [TestMethod]
@@ -60,40 +60,40 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // No errors
             Assert.AreEqual(3, Contract.TestArgs3(1, 2));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
 
             Assert.AreEqual(3, Contract.TestArgs3(BigInteger.One, BigInteger.Zero));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
 
             Assert.AreEqual(1, Contract.TestArgs3(BigInteger.MinusOne, BigInteger.MinusOne));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
 
             Assert.AreEqual(-2147483647, Contract.TestArgs3(int.MaxValue, int.MaxValue));
-            Assert.AreEqual(1048560, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048560);
 
             Assert.AreEqual(-2147483646, Contract.TestArgs3(int.MinValue, int.MaxValue));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
         }
 
         [TestMethod]
         public void Test_testArgs4()
         {
             Assert.AreEqual(5, Contract.TestArgs4(1, 2));
-            Assert.AreEqual(1048470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048470);
 
             Assert.AreEqual(3, Contract.TestArgs4(BigInteger.One, BigInteger.Zero));
-            Assert.AreEqual(1048470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048470);
 
 
             Assert.AreEqual(0, Contract.TestArgs4(BigInteger.MinusOne, BigInteger.MinusOne));
-            Assert.AreEqual(1048470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048470);
 
 
             Assert.AreEqual(0, Contract.TestArgs4(int.MaxValue, int.MaxValue));
-            Assert.AreEqual(1049160, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049160);
 
             Assert.AreEqual(1, Contract.TestArgs4(int.MinValue, int.MaxValue));
-            Assert.AreEqual(1048470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048470);
         }
 
         [TestMethod]
@@ -101,7 +101,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // No errors
             Contract.TestVoid();
-            Assert.AreEqual(1232010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1232010);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract2.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract2.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ByteArrayPick()
         {
             Assert.AreEqual(3, Contract.UnitTest_002("hello", 1));
-            Assert.AreEqual(1295280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1295280);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractCall.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractCall.cs
@@ -18,14 +18,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ContractCall()
         {
             CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, Contract.TestContractCall());
-            Assert.AreEqual(2461230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2461230);
         }
 
         [TestMethod]
         public void Test_ContractCall_Void()
         {
             Contract.TestContractCallVoid(); // No error
-            Assert.AreEqual(2215050, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2215050);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract_ComplexAssign.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract_ComplexAssign.cs
@@ -12,14 +12,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_AddAssign_Checked()
         {
             Assert.ThrowsException<TestException>(Contract.UnitTest_Add_Assign_Checked);
-            Assert.AreEqual(1002120, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002120);
         }
 
         [TestMethod]
         public void Test_AddAssign_UnChecked()
         {
             var values = Contract.UnitTest_Add_Assign_UnChecked()!;
-            Assert.AreEqual(1480950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1480950);
             // Asserting the expected values after overflow
             Assert.AreEqual(BigInteger.Zero, values[0]); // uint.MaxValue + 1 overflows to 0
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue + 1)), values[1]); // int.MaxValue + 1 overflows to int.MinValue
@@ -29,14 +29,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_SubAssign_Checked()
         {
             Assert.ThrowsException<TestException>(Contract.UnitTest_Sub_Assign_Checked);
-            Assert.AreEqual(1001970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1001970);
         }
 
         [TestMethod]
         public void Test_SubAssign_UnChecked()
         {
             var values = Contract.UnitTest_Sub_Assign_UnChecked()!;
-            Assert.AreEqual(1480500, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1480500);
             // Asserting the expected values after underflow
             Assert.AreEqual(new BigInteger(uint.MaxValue), values[0]); // uint.MinValue - 1 underflows to uint.MaxValue
             Assert.AreEqual(new BigInteger(unchecked(int.MinValue - 1)), values[1]); // int.MinValue - 1 underflows to int.MaxValue
@@ -46,14 +46,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_MulAssign_Checked()
         {
             Assert.ThrowsException<TestException>(Contract.UnitTest_Mul_Assign_Checked);
-            Assert.AreEqual(1002120, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002120);
         }
 
         [TestMethod]
         public void Test_MulAssign_UnChecked()
         {
             var values = Contract.UnitTest_Mul_Assign_UnChecked()!;
-            Assert.AreEqual(1480950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1480950);
             Assert.AreEqual(new BigInteger(unchecked(uint.MaxValue * 2)), values[0]); // Multiplying by 2 should not change the value
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue * 2)), values[1]); // Same here
         }
@@ -62,14 +62,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_LeftShiftAssign_Checked()
         {
             Assert.ThrowsException<TestException>(Contract.UnitTest_Left_Shift_Assign_Checked);
-            Assert.AreEqual(1002120, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002120);
         }
 
         [TestMethod]
         public void Test_LeftShiftAssign_UnChecked()
         {
             var values = Contract.UnitTest_Left_Shift_Assign_UnChecked()!;
-            Assert.AreEqual(1480950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1480950);
             Assert.AreEqual(new BigInteger(unchecked(uint.MaxValue << 1)), values[0]);
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue << 1)), values[1]);
         }
@@ -78,7 +78,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_RightShiftAssign_Checked()
         {
             var values = Contract.UnitTest_Right_Shift_Assign_Checked()!;
-            Assert.AreEqual(1479990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1479990);
             Assert.AreEqual(new BigInteger(checked(uint.MinValue >> 1)), values[0]);
             Assert.AreEqual(new BigInteger(checked(int.MinValue >> 1)), values[1]);
         }
@@ -87,7 +87,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_RightShiftAssign_UnChecked()
         {
             var values = Contract.UnitTest_Right_Shift_Assign_UnChecked()!;
-            Assert.AreEqual(1479990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1479990);
             Assert.AreEqual(new BigInteger(unchecked(uint.MinValue >> 1)), values[0]);
             Assert.AreEqual(new BigInteger(unchecked(int.MinValue >> 1)), values[1]);
         }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Delegate.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Delegate.cs
@@ -10,14 +10,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestFunc()
         {
             Assert.AreEqual(5, Contract.SumFunc(2, 3));
-            Assert.AreEqual(1065300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065300);
         }
 
         [TestMethod]
         public void TestDelegate()
         {
             Contract.TestDelegate();
-            Assert.AreEqual(3436020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3436020);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DirectInit.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DirectInit.cs
@@ -10,28 +10,28 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_GetUInt160()
         {
             Assert.AreEqual(Contract.TestGetUInt160()?.ToString(), "0x71a87191aef3fcf5e4441d791ded67ebab1aee7e");
-            Assert.AreEqual(985770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985770);
         }
 
         [TestMethod]
         public void Test_GetECPoint()
         {
             Assert.AreEqual(Contract.TestGetECPoint()?.ToString(), "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9");
-            Assert.AreEqual(985770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985770);
         }
 
         [TestMethod]
         public void Test_GetUInt256()
         {
             Assert.AreEqual(Contract.TestGetUInt256()?.ToString(), "0x25898c9489b9c7f07adab10f995b3e492a23dbd79ae24f1a91c24e107986cfed");
-            Assert.AreEqual(985770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985770);
         }
 
         [TestMethod]
         public void Test_GetString()
         {
             Assert.AreEqual(Contract.TestGetString(), "hello world");
-            Assert.AreEqual(985770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985770);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Extensions.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestSum()
         {
             Assert.AreEqual(5, Contract.TestSum(3, 2));
-            Assert.AreEqual(1065060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Foreach.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Foreach.cs
@@ -14,46 +14,46 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void IntForeachTest()
         {
             Assert.AreEqual(10, Contract.IntForeach());
-            Assert.AreEqual(1124550, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1124550);
             Assert.AreEqual(6, Contract.IntForeachBreak(3));
-            Assert.AreEqual(1188330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1188330);
         }
 
         [TestMethod]
         public void IntForloopTest()
         {
             Assert.AreEqual(10, Contract.IntForloop());
-            Assert.AreEqual(1127310, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1127310);
             Assert.AreEqual(6, Contract.IntForeachBreak(3));
-            Assert.AreEqual(1188330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1188330);
         }
 
         [TestMethod]
         public void StringForeachTest()
         {
             Assert.AreEqual("abcdefhij", Contract.StringForeach());
-            Assert.AreEqual(2041980, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2041980);
         }
 
         [TestMethod]
         public void ByteStringEmptyTest()
         {
             Assert.AreEqual(0, Contract.ByteStringEmpty());
-            Assert.AreEqual(1049100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049100);
         }
 
         [TestMethod]
         public void BytestringForeachTest()
         {
             Assert.AreEqual("abcdefhij", Encoding.ASCII.GetString(Contract.ByteStringForeach()!));
-            Assert.AreEqual(2662500, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2662500);
         }
 
         [TestMethod]
         public void StructForeachTest()
         {
             var map = Contract.StructForeach()!;
-            Assert.AreEqual(3620220, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3620220);
 
             Assert.AreEqual(map[(ByteString)"test1"], new BigInteger(1));
             Assert.AreEqual(map[(ByteString)"test2"], new BigInteger(2));
@@ -63,7 +63,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void ByteArrayForeachTest()
         {
             var array = Contract.ByteArrayForeach()!;
-            Assert.AreEqual(2041170, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2041170);
 
             Assert.AreEqual(array[0], new BigInteger(1));
             Assert.AreEqual(array[1], new BigInteger(10));
@@ -74,7 +74,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Uint160ForeachTest()
         {
             var array = Contract.UInt160Foreach()!;
-            Assert.AreEqual(1608720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1608720);
 
             Assert.AreEqual(array.Count, 2);
             Assert.AreEqual((array[0] as ByteString)!.GetSpan().ToHexString(), "0000000000000000000000000000000000000000");
@@ -85,7 +85,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Uint256ForeachTest()
         {
             var array = Contract.UInt256Foreach()!;
-            Assert.AreEqual(1608720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1608720);
 
             Assert.AreEqual(array.Count, 2);
             Assert.AreEqual((array[0] as ByteString)!.GetSpan().ToHexString(), "0000000000000000000000000000000000000000000000000000000000000000");
@@ -96,7 +96,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void EcpointForeachTest()
         {
             var array = Contract.ECPointForeach()!;
-            Assert.AreEqual(2100780, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2100780);
 
             Assert.AreEqual(array.Count, 2);
             Assert.AreEqual((array[0] as ByteString)!.GetSpan().ToHexString(), "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9");
@@ -107,7 +107,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void BigintegerForeachTest()
         {
             var array = Contract.BigIntegerForeach()!;
-            Assert.AreEqual(2105160, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2105160);
             BigInteger[] expected = [10_000, 1000_000, 1000_000_000, 1000_000_000_000_000_000];
 
             Assert.AreEqual(array.Count, 4);
@@ -121,7 +121,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void ObjectarrayForeachTest()
         {
             var array = Contract.ObjectArrayForeach()!;
-            Assert.AreEqual(2102910, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2102910);
 
             Assert.AreEqual(array.Count, 3);
             CollectionAssert.AreEqual(array[0] as byte[], new byte[] { 0x01, 0x02 });

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_GoTo.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_GoTo.cs
@@ -10,9 +10,9 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test()
         {
             Assert.AreEqual(3, Contract.Test());
-            Assert.AreEqual(989760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(989760);
             Assert.AreEqual(3, Contract.TestTry());
-            Assert.AreEqual(990180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(990180);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Inc_Dec.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Inc_Dec.cs
@@ -12,108 +12,108 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Property_Inc_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Property_Inc_Checked());
-            Assert.AreEqual(1000560, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1000560);
         }
 
         [TestMethod]
         public void Test_Property_Inc_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(uint.MaxValue + 2)), Contract.UnitTest_Property_Inc_UnChecked());
-            Assert.AreEqual(986370, Engine.FeeConsumed.Value);
+            AssertGasConsumed(986370);
         }
 
         [TestMethod]
         public void Test_Property_Dec_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Property_Dec_Checked());
-            Assert.AreEqual(1000410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1000410);
         }
 
         [TestMethod]
         public void Test_Property_Dec_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(uint.MinValue - 2)), Contract.UnitTest_Property_Dec_UnChecked());
-            Assert.AreEqual(986280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(986280);
         }
 
         [TestMethod]
         public void Test_Local_Inc_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Local_Inc_Checked());
-            Assert.AreEqual(1002360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002360);
         }
 
         [TestMethod]
         public void Test_Local_Inc_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(uint.MaxValue + 2)), Contract.UnitTest_Local_Inc_UnChecked());
-            Assert.AreEqual(988170, Engine.FeeConsumed.Value);
+            AssertGasConsumed(988170);
         }
 
         [TestMethod]
         public void Test_Local_Dec_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Local_Dec_Checked());
-            Assert.AreEqual(1002210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002210);
         }
 
         [TestMethod]
         public void Test_Local_Dec_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(uint.MinValue - 2)), Contract.UnitTest_Local_Dec_UnChecked());
-            Assert.AreEqual(988080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(988080);
         }
 
         [TestMethod]
         public void Test_Param_Inc_Checked()
         {
             Contract.UnitTest_Param_Inc_Checked(0);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
         }
 
         [TestMethod]
         public void Test_Param_Inc_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(uint.MinValue + 2)), Contract.UnitTest_Param_Inc_UnChecked(0));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
         }
 
         [TestMethod]
         public void Test_Param_Dec_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Param_Dec_Checked(0));
-            Assert.AreEqual(1063140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063140);
 
             Contract.UnitTest_Param_Dec_Checked(uint.MaxValue);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Param_Dec_Checked(uint.MinValue));
-            Assert.AreEqual(1063140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063140);
 
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Param_Dec_Checked(-1));
-            Assert.AreEqual(1063140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063140);
 
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Param_Dec_Checked(1));
-            Assert.AreEqual(1063860, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063860);
         }
 
         [TestMethod]
         public void Test_Param_Dec_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(uint.MinValue - 2)), Contract.UnitTest_Param_Dec_UnChecked(0));
-            Assert.AreEqual(1049010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049010);
 
             Contract.UnitTest_Param_Dec_UnChecked(uint.MaxValue);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Contract.UnitTest_Param_Dec_UnChecked(uint.MinValue);
-            Assert.AreEqual(1049010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049010);
 
             Contract.UnitTest_Param_Dec_UnChecked(-1);
-            Assert.AreEqual(1049010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049010);
 
             Contract.UnitTest_Param_Dec_UnChecked(1);
-            Assert.AreEqual(1049010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049010);
         }
 
         // Test Methods for int type
@@ -121,28 +121,28 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_IntProperty_Inc_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Property_Inc_Checked_Int());
-            Assert.AreEqual(1000560, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1000560);
         }
 
         [TestMethod]
         public void Test_IntProperty_Inc_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue + 2)), Contract.UnitTest_Property_Inc_UnChecked_Int());
-            Assert.AreEqual(986790, Engine.FeeConsumed.Value);
+            AssertGasConsumed(986790);
         }
 
         [TestMethod]
         public void Test_IntProperty_Dec_Checked()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Property_Dec_Checked_Int());
-            Assert.AreEqual(1000410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1000410);
         }
 
         [TestMethod]
         public void Test_IntProperty_Dec_UnChecked()
         {
             Assert.AreEqual(new BigInteger(unchecked(int.MinValue - 2)), Contract.UnitTest_Property_Dec_UnChecked_Int());
-            Assert.AreEqual(986430, Engine.FeeConsumed.Value);
+            AssertGasConsumed(986430);
         }
 
         // Local Variable Tests for int
@@ -150,28 +150,28 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Local_Inc_Checked_Int()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Local_Inc_Checked_Int());
-            Assert.AreEqual(1002360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002360);
         }
 
         [TestMethod]
         public void Test_Local_Inc_UnChecked_Int()
         {
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue + 2)), Contract.UnitTest_Local_Inc_UnChecked_Int());
-            Assert.AreEqual(988590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(988590);
         }
 
         [TestMethod]
         public void Test_Local_Dec_Checked_Int()
         {
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Local_Dec_Checked_Int());
-            Assert.AreEqual(1002210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1002210);
         }
 
         [TestMethod]
         public void Test_Local_Dec_UnChecked_Int()
         {
             Assert.AreEqual(new BigInteger(unchecked(int.MinValue - 2)), Contract.UnitTest_Local_Dec_UnChecked_Int());
-            Assert.AreEqual(988230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(988230);
         }
 
         // Parameter Tests for int
@@ -179,83 +179,83 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Param_Inc_Checked_Int()
         {
             Assert.AreEqual(new BigInteger(checked(0 + 2)), Contract.UnitTest_Param_Inc_Checked_Int(0));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Param_Inc_Checked_Int(int.MaxValue));
-            Assert.AreEqual(1063290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063290);
 
             Assert.AreEqual(new BigInteger(checked(int.MinValue + 2)), Contract.UnitTest_Param_Inc_Checked_Int(int.MinValue));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(checked(-1 + 2)), Contract.UnitTest_Param_Inc_Checked_Int(-1));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(checked(1 + 2)), Contract.UnitTest_Param_Inc_Checked_Int(1));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
         }
 
         [TestMethod]
         public void Test_Param_Inc_UnChecked_Int()
         {
             Assert.AreEqual(new BigInteger(unchecked(0 + 2)), Contract.UnitTest_Param_Inc_UnChecked_Int(0));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue + 2)), Contract.UnitTest_Param_Inc_UnChecked_Int(int.MaxValue));
-            Assert.AreEqual(1049520, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049520);
 
             Assert.AreEqual(new BigInteger(unchecked(int.MinValue + 2)), Contract.UnitTest_Param_Inc_UnChecked_Int(int.MinValue));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(unchecked(2 + 2)), Contract.UnitTest_Param_Inc_UnChecked_Int(2));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(unchecked(-2 + 2)), Contract.UnitTest_Param_Inc_UnChecked_Int(-2));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
         }
 
         [TestMethod]
         public void Test_Param_Dec_Checked_Int()
         {
             Contract.UnitTest_Param_Dec_Checked_Int(0);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Contract.UnitTest_Param_Dec_Checked_Int(int.MaxValue);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.ThrowsException<TestException>(() => Contract.UnitTest_Param_Dec_Checked_Int(int.MinValue));
-            Assert.AreEqual(1063140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063140);
 
             Contract.UnitTest_Param_Dec_Checked_Int(1);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Contract.UnitTest_Param_Dec_Checked_Int(-1);
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
         }
 
         [TestMethod]
         public void Test_Param_Dec_UnChecked_Int()
         {
             Assert.AreEqual(new BigInteger(unchecked(0 - 2)), Contract.UnitTest_Param_Dec_UnChecked_Int(0));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(unchecked(int.MaxValue - 2)), Contract.UnitTest_Param_Dec_UnChecked_Int(int.MaxValue));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(unchecked(int.MinValue - 2)), Contract.UnitTest_Param_Dec_UnChecked_Int(int.MinValue));
-            Assert.AreEqual(1049160, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049160);
 
             Assert.AreEqual(new BigInteger(unchecked(2 - 2)), Contract.UnitTest_Param_Dec_UnChecked_Int(2));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Assert.AreEqual(new BigInteger(unchecked(-2 - 2)), Contract.UnitTest_Param_Dec_UnChecked_Int(-2));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
         }
 
         [TestMethod]
         public void Test_Not_DeadLoop()
         {
             Contract.UnitTest_Not_DeadLoop(); // No error
-            Assert.AreEqual(993450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(993450);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_IndexOrRange.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_IndexOrRange.cs
@@ -13,7 +13,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var logs = new Queue<string>();
             Contract.OnRuntimeLog += (sender, log) => logs.Enqueue(log);
             Contract.TestMain();
-            Assert.AreEqual(32096340, Engine.FeeConsumed.Value);
+            AssertGasConsumed(32096340);
 
             // Check logs
             Assert.AreEqual(18, logs.Count);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Initializer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Initializer.cs
@@ -10,11 +10,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Initializer_Test()
         {
             Assert.AreEqual(3, Contract.Sum());
-            Assert.AreEqual(1596420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1596420);
             Assert.AreEqual(12, Contract.Sum1(5, 7));
-            Assert.AreEqual(2149290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2149290);
             Assert.AreEqual(12, Contract.Sum2(5, 7));
-            Assert.AreEqual(2149650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2149650);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Inline.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Inline.cs
@@ -11,29 +11,29 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Inline()
         {
             Assert.AreEqual(BigInteger.One, Contract.TestInline("inline"));
-            Assert.AreEqual(1048710, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048710);
             Assert.AreEqual(new BigInteger(3), Contract.TestInline("inline_with_one_parameters"));
-            Assert.AreEqual(1050030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050030);
             Assert.AreEqual(new BigInteger(5), Contract.TestInline("inline_with_multi_parameters"));
-            Assert.AreEqual(1051920, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1051920);
         }
 
         [TestMethod]
         public void Test_NoInline()
         {
             Assert.AreEqual(BigInteger.One, Contract.TestInline("not_inline"));
-            Assert.AreEqual(1068030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1068030);
             Assert.AreEqual(new BigInteger(3), Contract.TestInline("not_inline_with_one_parameters"));
-            Assert.AreEqual(1071330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1071330);
             Assert.AreEqual(new BigInteger(5), Contract.TestInline("not_inline_with_multi_parameters"));
-            Assert.AreEqual(1073280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1073280);
         }
 
         [TestMethod]
         public void Test_NestedInline()
         {
             Assert.AreEqual(new BigInteger(3), Contract.TestInline("inline_nested"));
-            Assert.AreEqual(1071990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1071990);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Instance.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Instance.cs
@@ -10,11 +10,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestFunc()
         {
             Assert.AreEqual(3, Contract.Sum(2));
-            Assert.AreEqual(1640160, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1640160);
             Assert.AreEqual(4, Contract.Sum(3));
-            Assert.AreEqual(1640160, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1640160);
             Assert.AreEqual(8, Contract.Sum2(3));
-            Assert.AreEqual(1678110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1678110);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Integer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Integer.cs
@@ -15,7 +15,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = byte.DivRem(10, 4);
             Assert.AreEqual(expected.Remainder, (byte)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (byte)(BigInteger)result[1]);
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -25,7 +25,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = short.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, checked((short)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((short)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = int.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (int)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (int)(BigInteger)result[1]);
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -45,7 +45,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = long.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (long)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (long)(BigInteger)result[1]);
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -55,7 +55,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = sbyte.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (sbyte)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (sbyte)(BigInteger)result[1]);
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ushort.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (ushort)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ushort)(BigInteger)result[1]);
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = uint.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (uint)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (uint)(BigInteger)result[1]);
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -85,14 +85,14 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
         public void divRemZeroU_test()
         {
             Assert.ThrowsException<TestException>(() => Contract.DivRemUint((uint)10, (uint)0));
-            Assert.AreEqual(1047540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047540);
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(10, 3);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -112,7 +112,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(ulong.MaxValue, 2);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(ulong.MaxValue, 1);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -132,7 +132,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(3, 10);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -142,7 +142,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(10, ulong.MaxValue);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -166,7 +166,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(ulong.MaxValue, ulong.MaxValue);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -176,7 +176,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(ulong.MaxValue - 1, ulong.MaxValue);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -186,7 +186,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(ulong.MaxValue, 2UL);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -198,7 +198,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(large1, large2);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -210,7 +210,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(large1, large2);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -222,7 +222,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(dividend, divisor);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -234,7 +234,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(dividend, divisor);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -246,7 +246,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(largePrime1, largePrime2);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -271,145 +271,145 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = ulong.DivRem(alternatingBits, 3);
             Assert.AreEqual(expected.Remainder, (ulong)(BigInteger)result[0]);
             Assert.AreEqual(expected.Quotient, (ulong)(BigInteger)result[1]);
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
         public void TestClampByte()
         {
             Assert.AreEqual((byte)5, Contract.ClampByte(5, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.ThrowsException<TestException>(() => Contract.ClampByte(5, 10, 0));
-            Assert.AreEqual(1062870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062870);
             Assert.AreEqual((byte)5, Contract.ClampByte(0, 5, 10));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((byte)5, Contract.ClampByte(10, 0, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)0, Contract.ClampByte(0, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)10, Contract.ClampByte(10, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)10, Contract.ClampByte(255, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)10, Contract.ClampByte(20, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampSByte()
         {
             Assert.AreEqual((sbyte)0, Contract.ClampSByte(0, -5, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((sbyte)-5, Contract.ClampSByte(-10, -5, 5));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((sbyte)5, Contract.ClampSByte(10, -5, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((sbyte)-5, Contract.ClampSByte(sbyte.MinValue, -5, 5));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((sbyte)5, Contract.ClampSByte(sbyte.MaxValue, -5, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampShort()
         {
             Assert.AreEqual((short)0, Contract.ClampShort(0, -1000, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((short)-1000, Contract.ClampShort(-2000, -1000, 1000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((short)1000, Contract.ClampShort(2000, -1000, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((short)-1000, Contract.ClampShort(short.MinValue, -1000, 1000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((short)1000, Contract.ClampShort(short.MaxValue, -1000, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampUShort()
         {
             Assert.AreEqual((ushort)500, Contract.ClampUShort(500, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((ushort)0, Contract.ClampUShort(0, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((ushort)1000, Contract.ClampUShort(1000, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((ushort)1000, Contract.ClampUShort(ushort.MaxValue, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampInt()
         {
             Assert.AreEqual(0, Contract.ClampInt(0, -1000000, 1000000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000, Contract.ClampInt(-2000000, -1000000, 1000000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000, Contract.ClampInt(2000000, -1000000, 1000000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000, Contract.ClampInt(int.MinValue, -1000000, 1000000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000, Contract.ClampInt(int.MaxValue, -1000000, 1000000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampUInt()
         {
             Assert.AreEqual(500000U, Contract.ClampUInt(500000U, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(0U, Contract.ClampUInt(0U, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000U, Contract.ClampUInt(1000000U, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000U, Contract.ClampUInt(uint.MaxValue, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampLong()
         {
             Assert.AreEqual(0L, Contract.ClampLong(0L, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000000000L, Contract.ClampLong(-2000000000000L, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000000000L, Contract.ClampLong(2000000000000L, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000000000L, Contract.ClampLong(long.MinValue, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000000000L, Contract.ClampLong(long.MaxValue, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampULong()
         {
             Assert.AreEqual(500000000000UL, Contract.ClampULong(500000000000UL, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(0UL, Contract.ClampULong(0UL, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000000000UL, Contract.ClampULong(1000000000000UL, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000000000UL, Contract.ClampULong(ulong.MaxValue, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048440, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048440);
         }
 
         [TestMethod]
         public void TestClampBigInteger()
         {
             Assert.AreEqual(BigInteger.Zero, Contract.ClampBigInteger(BigInteger.Zero, BigInteger.MinusOne, BigInteger.One));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(BigInteger.MinusOne, Contract.ClampBigInteger(BigInteger.MinusOne, BigInteger.MinusOne, BigInteger.One));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(BigInteger.One, Contract.ClampBigInteger(BigInteger.One, BigInteger.MinusOne, BigInteger.One));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.ThrowsException<TestException>(() => Contract.ClampBigInteger(BigInteger.MinusOne, BigInteger.MinusOne, BigInteger.MinusOne));
-            Assert.AreEqual(1062870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062870);
             Assert.AreEqual(BigInteger.One, Contract.ClampBigInteger(BigInteger.One, BigInteger.MinusOne, BigInteger.One));
             Assert.ThrowsException<TestException>(() => Contract.ClampBigInteger(BigInteger.MinusOne, BigInteger.One, BigInteger.MinusOne));
-            Assert.AreEqual(1062870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062870);
             Assert.ThrowsException<TestException>(() => Contract.ClampBigInteger(BigInteger.One, BigInteger.One, BigInteger.MinusOne));
-            Assert.AreEqual(1062870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062870);
         }
 
         [TestMethod]
@@ -417,40 +417,40 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test with notmal and edge cases
             Assert.AreEqual(int.CopySign(5, 1), Contract.CopySignInt(5, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(int.CopySign(5, -1), Contract.CopySignInt(5, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.AreEqual(int.CopySign(-5, 1), Contract.CopySignInt(-5, 1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.AreEqual(int.CopySign(-5, -1), Contract.CopySignInt(-5, -1));
-            Assert.AreEqual(1049280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049280);
 
 
             // Test with max values
             Assert.AreEqual(int.CopySign(int.MaxValue, 1), Contract.CopySignInt(int.MaxValue, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(int.CopySign(int.MaxValue, -1), Contract.CopySignInt(int.MaxValue, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.ThrowsException<TestException>(() => Contract.CopySignInt(int.MinValue, 1));
-            Assert.AreEqual(1064850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1064850);
             Assert.AreEqual(int.CopySign(int.MinValue, -1), Contract.CopySignInt(int.MinValue, -1));
-            Assert.AreEqual(1049280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049280);
 
             // Test with min values
             Assert.AreEqual(int.MaxValue, Contract.CopySignInt(int.MaxValue, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(-int.MaxValue, Contract.CopySignInt(int.MaxValue, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.ThrowsException<TestException>(() => Contract.CopySignInt(int.MinValue, 1));
-            Assert.AreEqual(1064850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1064850);
             Assert.AreEqual(int.MinValue, Contract.CopySignInt(int.MinValue, -1));
-            Assert.AreEqual(1049280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049280);
 
             // Test with zero
             Assert.AreEqual(0, Contract.CopySignInt(0, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(0, Contract.CopySignInt(0, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
         }
 
 
@@ -459,29 +459,29 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test with notmal and edge cases
             Assert.AreEqual(sbyte.CopySign(5, 1), Contract.CopySignSbyte(5, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(sbyte.CopySign(5, 0), Contract.CopySignSbyte(5U, 0));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
 
             // Test with max values
             Assert.AreEqual(sbyte.CopySign(sbyte.MaxValue, 1), Contract.CopySignSbyte(sbyte.MaxValue, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(sbyte.CopySign(sbyte.MaxValue, 0), Contract.CopySignSbyte(sbyte.MaxValue, 0));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.ThrowsException<TestException>(() => Contract.CopySignSbyte(sbyte.MinValue, 0));
-            Assert.AreEqual(1064850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1064850);
             Assert.AreEqual(sbyte.CopySign(sbyte.MaxValue, 0), Contract.CopySignSbyte(sbyte.MaxValue, 0));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
 
             // Test with zero
             Assert.AreEqual(0U, Contract.CopySignSbyte(0U, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(0U, Contract.CopySignSbyte(0U, 0));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
 
             // Test with negative values
             Assert.AreEqual(sbyte.CopySign(5, -1), Contract.CopySignSbyte(5U, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
         }
 
         [TestMethod]
@@ -489,23 +489,23 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test with notmal and edge cases
             Assert.AreEqual(short.CopySign(5, 1), Contract.CopySignShort(5, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(short.CopySign(5, -1), Contract.CopySignShort(5, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.AreEqual(short.CopySign(-5, 1), Contract.CopySignShort(-5, 1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.AreEqual(short.CopySign(-5, -1), Contract.CopySignShort(-5, -1));
-            Assert.AreEqual(1049280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049280);
 
             // Test with max values
             Assert.AreEqual(short.CopySign(short.MaxValue, 1), Contract.CopySignShort(short.MaxValue, 1));
-            Assert.AreEqual(1049460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049460);
             Assert.AreEqual(short.CopySign(short.MaxValue, -1), Contract.CopySignShort(short.MaxValue, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.ThrowsException<TestException>(() => Contract.CopySignShort(short.MinValue, 1));
-            Assert.AreEqual(1064850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1064850);
             Assert.AreEqual(short.CopySign(short.MinValue, -1), Contract.CopySignShort(short.MinValue, -1));
-            Assert.AreEqual(1049280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049280);
         }
 
         [TestMethod]
@@ -513,38 +513,38 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test with notmal and edge cases
             Assert.AreEqual(int.CreateChecked(5), Contract.CreateCheckedInt(5));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(int.CreateChecked(0), Contract.CreateCheckedInt(0));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(int.CreateChecked(-5), Contract.CreateCheckedInt(-5));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
 
             // Test with max values
             Assert.AreEqual(int.CreateChecked(int.MaxValue), Contract.CreateCheckedInt(int.MaxValue));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(int.CreateChecked(int.MinValue), Contract.CreateCheckedInt(int.MinValue));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
 
             // Test with min values
             Assert.AreEqual(int.CreateChecked(int.MaxValue), Contract.CreateCheckedInt(int.MaxValue));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(int.CreateChecked(int.MinValue), Contract.CreateCheckedInt(int.MinValue));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
         }
 
         [TestMethod]
         public void TestMethodShortCreateChecked()
         {
             Assert.AreEqual(short.CreateChecked(5), Contract.CreateCheckedShort(5));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(short.CreateChecked(0), Contract.CreateCheckedShort(0));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(short.CreateChecked(-5), Contract.CreateCheckedShort(-5));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(short.CreateChecked(short.MaxValue), Contract.CreateCheckedShort(short.MaxValue));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(short.CreateChecked(short.MinValue), Contract.CreateCheckedShort(short.MinValue));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
         }
 
         [TestMethod]
@@ -552,15 +552,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             // Test with notmal and edge cases
             Assert.AreEqual(int.CreateSaturating(5), Contract.CreateSaturatingInt(5));
-            Assert.AreEqual(1048230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048230);
             Assert.AreEqual(int.CreateSaturating(0), Contract.CreateSaturatingInt(0));
-            Assert.AreEqual(1048230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048230);
             Assert.AreEqual(int.CreateSaturating(-5), Contract.CreateSaturatingInt(-5));
-            Assert.AreEqual(1048230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048230);
 
             // Test with max values
             Assert.AreEqual(int.MaxValue, Contract.CreateSaturatingInt(int.MaxValue));
-            Assert.AreEqual(1048230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048230);
         }
 
 
@@ -568,104 +568,104 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestMethodIntIsEvenInteger()
         {
             Assert.AreEqual(int.IsEvenInteger(0), Contract.IsEvenIntegerInt(0));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsEvenInteger(1), Contract.IsEvenIntegerInt(1));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsEvenInteger(2), Contract.IsEvenIntegerInt(2));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsEvenInteger(3), Contract.IsEvenIntegerInt(3));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsEvenInteger(4), Contract.IsEvenIntegerInt(4));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsEvenInteger(5), Contract.IsEvenIntegerInt(5));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
         }
 
         [TestMethod]
         public void TestIsOddIntegerInt()
         {
             Assert.AreEqual(false, Contract.IsOddIntegerInt(0));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(true, Contract.IsOddIntegerInt(1));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(false, Contract.IsOddIntegerInt(2));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(true, Contract.IsOddIntegerInt(3));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(false, Contract.IsOddIntegerInt(4));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(true, Contract.IsOddIntegerInt(5));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
         }
 
         [TestMethod]
         public void TestIsNegativeInt()
         {
             Assert.AreEqual(int.IsNegative(0), Contract.IsNegativeInt(0));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsNegative(1), Contract.IsNegativeInt(1));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsNegative(-1), Contract.IsNegativeInt(-1));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsNegative(int.MaxValue), Contract.IsNegativeInt(int.MaxValue));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsNegative(int.MinValue), Contract.IsNegativeInt(int.MinValue));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
         }
 
         [TestMethod]
         public void TestIsPositiveInt()
         {
             Assert.AreEqual(int.IsPositive(0), Contract.IsPositiveInt(0));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsPositive(1), Contract.IsPositiveInt(1));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsPositive(-1), Contract.IsPositiveInt(-1));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsPositive(int.MaxValue), Contract.IsPositiveInt(int.MaxValue));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsPositive(int.MinValue), Contract.IsPositiveInt(int.MinValue));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
         }
 
         [TestMethod]
         public void TestIsPow2Int()
         {
             Assert.AreEqual(int.IsPow2(0), Contract.IsPow2Int(0));
-            Assert.AreEqual(1047390, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047390);
             Assert.AreEqual(int.IsPow2(1), Contract.IsPow2Int(1));
-            Assert.AreEqual(1047960, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047960);
             Assert.AreEqual(int.IsPow2(2), Contract.IsPow2Int(2));
-            Assert.AreEqual(1047960, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047960);
             Assert.AreEqual(int.IsPow2(3), Contract.IsPow2Int(3));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
             Assert.AreEqual(int.IsPow2(4), Contract.IsPow2Int(4));
-            Assert.AreEqual(1047960, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047960);
         }
 
         [TestMethod]
         public void TestMethodsInt()
         {
             Assert.AreEqual(int.CopySign(5, -1), Contract.CopySignInt(5, -1));
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.AreEqual(int.CreateChecked(5), Contract.CreateCheckedInt(5));
-            Assert.AreEqual(1047450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047450);
             Assert.AreEqual(int.CreateSaturating(5), Contract.CreateSaturatingInt(5));
-            Assert.AreEqual(1048230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048230);
             Assert.AreEqual(int.IsEvenInteger(5), Contract.IsEvenIntegerInt(5));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsOddInteger(5), Contract.IsOddIntegerInt(5));
-            Assert.AreEqual(1047570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047570);
             Assert.AreEqual(int.IsNegative(5), Contract.IsNegativeInt(5));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsPositive(5), Contract.IsPositiveInt(5));
-            Assert.AreEqual(1047420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047420);
             Assert.AreEqual(int.IsPow2(5), Contract.IsPow2Int(5));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
             Assert.AreEqual(int.LeadingZeroCount(5), Contract.LeadingZeroCountInt(5));
-            Assert.AreEqual(1049970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049970);
             Assert.AreEqual(int.Log2(5), Contract.Log2Int(5));
-            Assert.AreEqual(1049850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049850);
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_IntegerParse.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_IntegerParse.cs
@@ -12,200 +12,200 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void SByteParse_Test()
         {
             Assert.AreEqual(new BigInteger(sbyte.MaxValue), Contract.TestSbyteparse("127"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
             Assert.AreEqual(new BigInteger(sbyte.MinValue), Contract.TestSbyteparse("-128"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("128"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("-129"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void ByteParse_Test()
         {
             Assert.AreEqual(new BigInteger(byte.MinValue), Contract.TestByteparse("0"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
             Assert.AreEqual(new BigInteger(byte.MaxValue), Contract.TestByteparse("255"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse("-1"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse("256"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestByteparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void UShortParse_Test()
         {
             Assert.AreEqual(new BigInteger(ushort.MinValue), Contract.TestUshortparse("0"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
             Assert.AreEqual(new BigInteger(ushort.MaxValue), Contract.TestUshortparse("65535"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse("-1"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse("65536"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUshortparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void ShortParse_Test()
         {
             Assert.AreEqual(new BigInteger(short.MinValue), Contract.TestShortparse("-32768"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
             Assert.AreEqual(new BigInteger(short.MaxValue), Contract.TestShortparse("32767"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("-32769"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("32768"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void ULongParse_Test()
         {
             Assert.AreEqual(new BigInteger(ulong.MinValue), Contract.TestUlongparse("0"));
-            Assert.AreEqual(2032740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032740);
             Assert.AreEqual(new BigInteger(ulong.MaxValue), Contract.TestUlongparse("18446744073709551615"));
-            Assert.AreEqual(2032740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032740);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse("-1"));
-            Assert.AreEqual(2048100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048100);
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse("18446744073709551616"));
-            Assert.AreEqual(2048100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048100);
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUlongparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void LongParse_Test()
         {
             Assert.AreEqual(new BigInteger(long.MinValue), Contract.TestLongparse("-9223372036854775808"));
-            Assert.AreEqual(2032740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032740);
             Assert.AreEqual(new BigInteger(long.MaxValue), Contract.TestLongparse("9223372036854775807"));
-            Assert.AreEqual(2032740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032740);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("-9223372036854775809"));
-            Assert.AreEqual(2048100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048100);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("9223372036854775808"));
-            Assert.AreEqual(2048100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048100);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void UIntParse_Test()
         {
             Assert.AreEqual(new BigInteger(uint.MinValue), Contract.TestUintparse("0"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
             Assert.AreEqual(new BigInteger(uint.MaxValue), Contract.TestUintparse("4294967295"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse("-1"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse("4294967296"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestUintparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
 
         [TestMethod]
         public void IntParse_Test()
         {
             Assert.AreEqual(new BigInteger(int.MinValue), Contract.TestIntparse("-2147483648"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
             Assert.AreEqual(new BigInteger(int.MaxValue), Contract.TestIntparse("2147483647"));
-            Assert.AreEqual(2032650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032650);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse(" 20 "));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("-2147483649"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("2147483648"));
-            Assert.AreEqual(2048010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048010);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse(""));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("abc"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("@"));
-            Assert.AreEqual(2032230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032230);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Invoke.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Invoke.cs
@@ -11,21 +11,21 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Return_Integer()
         {
             Assert.AreEqual(new BigInteger(42), Contract.ReturnInteger());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Test_Return_String()
         {
             Assert.AreEqual("hello world", Contract.ReturnString());
-            Assert.AreEqual(984270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984270);
         }
 
         [TestMethod]
         public void Test_Main()
         {
             Assert.AreEqual(new BigInteger(22), Contract.TestMain());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Lambda.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Lambda.cs
@@ -18,12 +18,12 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = Contract.AnyGreatThanZero(array);
-            Assert.AreEqual(1188840, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1188840);
             Assert.AreEqual(false, result);
 
             array.Add(1);
             result = Contract.AnyGreatThanZero(array);
-            Assert.AreEqual(1208760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1208760);
             Assert.AreEqual(true, result);
         }
 
@@ -37,16 +37,16 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = Contract.AnyGreatThan(array, 0);
-            Assert.AreEqual(1189080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1189080);
             Assert.AreEqual(false, result);
 
             array.Add(1);
             result = Contract.AnyGreatThan(array, 0);
-            Assert.AreEqual(1209030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1209030);
             Assert.AreEqual(true, result);
 
             result = Contract.AnyGreatThan(array, 100);
-            Assert.AreEqual(1209450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1209450);
             Assert.AreEqual(false, result);
         }
 
@@ -60,7 +60,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = Contract.WhereGreaterThanZero(array);
-            Assert.AreEqual(1189410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1189410);
             Assert.AreEqual(0, result!.Count);
 
             array.Add(1);
@@ -69,7 +69,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(56);
 
             result = Contract.WhereGreaterThanZero(array);
-            Assert.AreEqual(2008410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2008410);
             Assert.AreEqual(3, result!.Count);
             Assert.AreEqual(new BigInteger(1), result[0]);
             Assert.AreEqual(new BigInteger(100), result[1]);
@@ -86,7 +86,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = Contract.ForEachVar(array);
-            Assert.AreEqual(2649390, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2649390);
             Assert.AreEqual(array.Count, result!.Count);
             Assert.AreEqual(new BigInteger(-100), result[0]);
         }
@@ -101,7 +101,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = Contract.ForVar(array);
-            Assert.AreEqual(2651730, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2651730);
             Assert.AreEqual(array.Count, result!.Count);
             Assert.AreEqual(new BigInteger(-100), result[0]);
         }
@@ -110,7 +110,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ChangeName()
         {
             var result = Contract.ChangeName("L");
-            Assert.AreEqual(1371810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1371810);
             Assert.AreEqual("L !!!", result);
         }
 
@@ -118,7 +118,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ChangeName2()
         {
             var result = Contract.ChangeName2("L");
-            Assert.AreEqual(1387590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1387590);
             Assert.AreEqual("L !!!", result);
         }
 
@@ -126,7 +126,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_InvokeSum()
         {
             var result = Contract.InvokeSum(2, 3);
-            Assert.AreEqual(1066290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066290);
             Assert.AreEqual(5, result);
         }
 
@@ -134,7 +134,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_InvokeSum2()
         {
             var result = Contract.InvokeSum2(2, 3);
-            Assert.AreEqual(1084680, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084680);
             Assert.AreEqual(6, result);
         }
 
@@ -142,15 +142,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Fibo()
         {
             var result = Contract.Fibo(2);
-            Assert.AreEqual(1103940, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1103940);
             Assert.AreEqual(1, result);
 
             result = Contract.Fibo(3);
-            Assert.AreEqual(1141320, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1141320);
             Assert.AreEqual(2, result);
 
             result = Contract.Fibo(4);
-            Assert.AreEqual(1216080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1216080);
             Assert.AreEqual(3, result);
         }
 
@@ -158,15 +158,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_CheckZero()
         {
             var result = Contract.CheckZero(0);
-            Assert.AreEqual(1066620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066620);
             Assert.AreEqual(true, result);
 
             result = Contract.CheckZero(1);
-            Assert.AreEqual(1066620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066620);
             Assert.AreEqual(false, result);
 
             result = Contract.CheckZero(-1);
-            Assert.AreEqual(1066620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066620);
             Assert.AreEqual(false, result);
         }
 
@@ -174,15 +174,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_CheckZero2()
         {
             var result = Contract.CheckZero2(0);
-            Assert.AreEqual(1084080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084080);
             Assert.AreEqual(true, result);
 
             result = Contract.CheckZero2(1);
-            Assert.AreEqual(1084080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084080);
             Assert.AreEqual(false, result);
 
             result = Contract.CheckZero2(-1);
-            Assert.AreEqual(1084080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084080);
             Assert.AreEqual(false, result);
         }
 
@@ -190,15 +190,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_CheckZero3()
         {
             var result = Contract.CheckZero3(0);
-            Assert.AreEqual(1084350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084350);
             Assert.AreEqual(true, result);
 
             result = Contract.CheckZero3(1);
-            Assert.AreEqual(1084350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084350);
             Assert.AreEqual(false, result);
 
             result = Contract.CheckZero3(-1);
-            Assert.AreEqual(1084350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084350);
             Assert.AreEqual(false, result);
         }
 
@@ -206,19 +206,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_CheckPositiveOdd()
         {
             var result = Contract.CheckPositiveOdd(3);
-            Assert.AreEqual(1067250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1067250);
             Assert.AreEqual(true, result);
 
             result = Contract.CheckPositiveOdd(0);
-            Assert.AreEqual(1066020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066020);
             Assert.AreEqual(false, result);
 
             result = Contract.CheckPositiveOdd(2);
-            Assert.AreEqual(1067250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1067250);
             Assert.AreEqual(false, result);
 
             result = Contract.CheckPositiveOdd(-1);
-            Assert.AreEqual(1066020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066020);
             Assert.AreEqual(false, result);
         }
 
@@ -226,15 +226,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_LambdaDefault()
         {
             var result = Contract.TestLambdaDefault(3);
-            Assert.AreEqual(1066410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066410);
             Assert.AreEqual(4, result);
 
             result = Contract.TestLambdaDefault(5);
-            Assert.AreEqual(1066410, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066410);
             Assert.AreEqual(6, result);
 
             result = Contract.TestLambdaNotDefault(5, 3);
-            Assert.AreEqual(1066470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066470);
             Assert.AreEqual(8, result);
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Linq.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Linq.cs
@@ -20,14 +20,14 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.AreEqual(new BigInteger(-101), Contract.AggregateSum(array));
-            Assert.AreEqual(1226940, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1226940);
 
             array.Add(1);
             array.Add(5);
             array.Add(100);
 
             Assert.AreEqual(new BigInteger(5), Contract.AggregateSum(array));
-            Assert.AreEqual(1289490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1289490);
         }
 
         [TestMethod]
@@ -39,10 +39,10 @@ namespace Neo.Compiler.CSharp.UnitTests
                 100
             };
             Assert.IsTrue(Contract.AllGreaterThanZero(array));
-            Assert.AreEqual(1205250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1205250);
             array.Add(0);
             Assert.IsFalse(Contract.AllGreaterThanZero(array));
-            Assert.AreEqual(1225290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1225290);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var array = new List<object>();
 
             Assert.IsTrue(Contract.IsEmpty(array));
-            Assert.AreEqual(1084650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1084650);
 
             array.Add(1);
             array.Add(0);
@@ -59,7 +59,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(-100);
 
             Assert.IsFalse(Contract.IsEmpty(array));
-            Assert.AreEqual(1147860, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1147860);
         }
 
         [TestMethod]
@@ -72,10 +72,10 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.IsFalse(Contract.AnyGreaterThanZero(array));
-            Assert.AreEqual(1225350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1225350);
             array.Add(1);
             Assert.IsTrue(Contract.AnyGreaterThanZero(array));
-            Assert.AreEqual(1245270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1245270);
         }
 
         [TestMethod]
@@ -88,13 +88,13 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.IsFalse(Contract.AnyGreaterThan(array, 0));
-            Assert.AreEqual(1225590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1225590);
 
             array.Add(1);
             Assert.IsTrue(Contract.AnyGreaterThan(array, 0));
-            Assert.AreEqual(1245540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1245540);
             Assert.IsFalse(Contract.AnyGreaterThan(array, 100));
-            Assert.AreEqual(1245960, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1245960);
         }
 
         [TestMethod]
@@ -103,7 +103,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var array = new List<object>();
 
             var exception = Assert.ThrowsException<TestException>(() => Contract.Average(array));
-            Assert.AreEqual(1101270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1101270);
             Assert.AreEqual("An unhandled exception was thrown. source is empty", exception.InnerException?.Message);
 
             array.Add(0);
@@ -111,10 +111,10 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(2);
 
             Assert.AreEqual(1, Contract.Average(array));
-            Assert.AreEqual(1159290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1159290);
             array.Add(3);
             Assert.AreEqual(1, Contract.Average(array));
-            Assert.AreEqual(1163340, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1163340);
         }
 
         [TestMethod]
@@ -123,17 +123,17 @@ namespace Neo.Compiler.CSharp.UnitTests
             var array = new List<object>();
 
             var exception = Assert.ThrowsException<TestException>(() => Contract.AverageTwice(array));
-            Assert.AreEqual(1120080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1120080);
             Assert.AreEqual("An unhandled exception was thrown. source is empty", exception.InnerException?.Message);
 
             array.Add(0);
             array.Add(1);
             array.Add(2);
             Assert.AreEqual(2, Contract.AverageTwice(array));
-            Assert.AreEqual(1232010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1232010);
             array.Add(3);
             Assert.AreEqual(3, Contract.AverageTwice(array));
-            Assert.AreEqual(1254030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1254030);
         }
 
         [TestMethod]
@@ -146,7 +146,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.AreEqual(3, Contract.Count(array));
-            Assert.AreEqual(1155270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1155270);
 
             array.Add(1);
             array.Add(-8);
@@ -154,7 +154,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(56);
 
             Assert.AreEqual(7, Contract.Count(array));
-            Assert.AreEqual(1168110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1168110);
         }
 
         [TestMethod]
@@ -167,7 +167,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.AreEqual(0, Contract.CountGreaterThanZero(array));
-            Assert.AreEqual(1225470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1225470);
 
             array.Add(1);
             array.Add(-8);
@@ -175,7 +175,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(56);
 
             Assert.AreEqual(3, Contract.CountGreaterThanZero(array));
-            Assert.AreEqual(1308810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1308810);
         }
 
         [TestMethod]
@@ -188,12 +188,12 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.IsTrue(Contract.Contains(array, 0));
-            Assert.AreEqual(1202670, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1202670);
             array.Add(1);
             Assert.IsFalse(Contract.Contains(array, 9));
-            Assert.AreEqual(1266300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1266300);
             Assert.IsTrue(Contract.Contains(array, 1));
-            Assert.AreEqual(1265880, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1265880);
         }
 
         [TestMethod]
@@ -206,9 +206,9 @@ namespace Neo.Compiler.CSharp.UnitTests
                 "bbb"
             };
             Assert.IsTrue(Contract.ContainsText(array, "bbb"));
-            Assert.AreEqual(1245630, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1245630);
             Assert.IsFalse(Contract.ContainsText(array, "c"));
-            Assert.AreEqual(1246050, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1246050);
         }
 
         [TestMethod]
@@ -221,12 +221,12 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.IsFalse(Contract.ContainsPerson(array, 0));
-            Assert.AreEqual(9682080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(9682080);
             array.Add(1);
             Assert.IsFalse(Contract.ContainsPerson(array, 1));
-            Assert.AreEqual(11874150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(11874150);
             Assert.IsTrue(Contract.ContainsPersonIndex(array, 0));
-            Assert.AreEqual(9889950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(9889950);
         }
 
         [TestMethod]
@@ -239,12 +239,12 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.IsTrue(Contract.ContainsPersonS(array, 0));
-            Assert.AreEqual(10378620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(10378620);
             array.Add(1);
             Assert.IsFalse(Contract.ContainsPersonS(array, 10));
-            Assert.AreEqual(12798000, Engine.FeeConsumed.Value);
+            AssertGasConsumed(12798000);
             Assert.IsTrue(Contract.ContainsPersonS(array, -100));
-            Assert.AreEqual(12776520, Engine.FeeConsumed.Value);
+            AssertGasConsumed(12776520);
         }
 
         [TestMethod]
@@ -258,7 +258,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 1
             };
             Assert.AreEqual(1, Contract.FirstGreaterThanZero(array));
-            Assert.AreEqual(1245330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1245330);
 
             array.Clear();
             array.Add(2);
@@ -266,7 +266,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(-1);
             array.Add(-100);
             Assert.AreEqual(2, Contract.FirstGreaterThanZero(array));
-            Assert.AreEqual(1184400, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1184400);
         }
 
         [TestMethod]
@@ -279,12 +279,12 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = (Array)Contract.SelectTwice(array)!;
-            Assert.AreEqual(1964100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1964100);
             Assert.AreEqual(3, result.Count);
 
             array.Add(5);
             result = (Array)Contract.SelectTwice(array)!;
-            Assert.AreEqual(2230500, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2230500);
             Assert.AreEqual(4, result.Count);
             Assert.AreEqual(0, result[0]);
             Assert.AreEqual(-2, result[1]);
@@ -303,7 +303,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 new BigInteger(5)
             };
             var result = (Array)Contract.SelectPersonS(array)!;
-            Assert.AreEqual(14934570, Engine.FeeConsumed.Value);
+            AssertGasConsumed(14934570);
             Assert.AreEqual(4, result.Count);
             Assert.AreEqual(array[0], ((Struct)result[0])[1].GetInteger());
             Assert.AreEqual(array[1], ((Struct)result[1])[1].GetInteger());
@@ -321,7 +321,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 new BigInteger(-100)
             };
             var result = (Array)Contract.Skip(array, 0)!;
-            Assert.AreEqual(1892640, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1892640);
             Assert.AreEqual(3, result.Count);
 
             array.Add(new BigInteger(1));
@@ -329,7 +329,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(new BigInteger(100));
 
             result = (Array)Contract.Skip(array, 2)!;
-            Assert.AreEqual(2148780, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2148780);
             Assert.AreEqual(4, result.Count);
             Assert.AreEqual(-100, result[0]);
             Assert.AreEqual(100, result[3].GetInteger());
@@ -346,16 +346,16 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             Assert.AreEqual(-101, Contract.Sum(array));
-            Assert.AreEqual(1155810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1155810);
 
             array.Add(1);
             array.Add(5);
             array.Add(100);
 
             Assert.AreEqual(5, Contract.Sum(array));
-            Assert.AreEqual(1165980, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1165980);
             Assert.AreEqual(10, Contract.SumTwice(array));
-            Assert.AreEqual(1292610, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1292610);
         }
 
         [TestMethod]
@@ -368,7 +368,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = (Array)Contract.Take(array, 0)!;
-            Assert.AreEqual(1148820, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1148820);
             Assert.AreEqual(0, result.Count);
 
             array.Add(1);
@@ -376,7 +376,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(100);
 
             result = (Array)Contract.Take(array, 2)!;
-            Assert.AreEqual(1647810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1647810);
             Assert.AreEqual(2, result.Count);
             Assert.AreEqual(0, result[0]);
         }
@@ -392,7 +392,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 new BigInteger(5)
             };
             var result = (Map)Contract.ToMap(array)!;
-            Assert.AreEqual(11873760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(11873760);
             Assert.AreEqual(4, result.Count);
             Assert.AreEqual(array[0], ((Struct)result[array[0]!.ToString()!])[1].GetInteger());
             Assert.AreEqual(array[1], ((Struct)result[array[1]!.ToString()!])[1].GetInteger());
@@ -410,7 +410,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 -100
             };
             var result = (Array)Contract.WhereGreaterThanZero(array)!;
-            Assert.AreEqual(1225920, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1225920);
             Assert.AreEqual(0, result.Count);
 
             array.Add(1);
@@ -419,7 +419,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             array.Add(56);
 
             result = (Array)Contract.WhereGreaterThanZero(array)!;
-            Assert.AreEqual(2044920, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2044920);
             Assert.AreEqual(3, result.Count);
             Assert.AreEqual(1, result[0]);
             Assert.AreEqual(100, result[1]);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
@@ -11,19 +11,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TestConditionalLogicalAnd(true, true);
             Assert.AreEqual(true && true, result);
-            Assert.AreEqual(1047180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047180);
 
             result = Contract.TestConditionalLogicalAnd(true, false);
             Assert.AreEqual(true && false, result);
-            Assert.AreEqual(1047180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047180);
 
             result = Contract.TestConditionalLogicalAnd(false, true);
             Assert.AreEqual(false && true, result);
-            Assert.AreEqual(1047210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047210);
 
             result = Contract.TestConditionalLogicalAnd(false, false);
             Assert.AreEqual(false && false, result);
-            Assert.AreEqual(1047210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047210);
         }
 
         [TestMethod]
@@ -31,19 +31,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TestConditionalLogicalOr(true, true);
             Assert.AreEqual(true || true, result);
-            Assert.AreEqual(1047210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047210);
 
             result = Contract.TestConditionalLogicalOr(true, false);
             Assert.AreEqual(true || false, result);
-            Assert.AreEqual(1047210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047210);
 
             result = Contract.TestConditionalLogicalOr(false, true);
             Assert.AreEqual(false || true, result);
-            Assert.AreEqual(1047180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047180);
 
             result = Contract.TestConditionalLogicalOr(false, false);
             Assert.AreEqual(false || false, result);
-            Assert.AreEqual(1047180, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047180);
         }
 
         [TestMethod]
@@ -54,7 +54,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 {
                     var result = Contract.TestLogicalExclusiveOr(x, y);
                     Assert.AreEqual(x ^ y, result);
-                    Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+                    AssertGasConsumed(1047360);
                 }
         }
 
@@ -63,10 +63,10 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TestLogicalNegation(true);
             Assert.IsFalse(result);
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
             result = Contract.TestLogicalNegation(false);
             Assert.IsTrue(result);
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 {
                     var result = Contract.TestLogicalAnd(x, y);
                     Assert.AreEqual(x & y, result);
-                    Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+                    AssertGasConsumed(1047360);
                 }
         }
 
@@ -89,7 +89,7 @@ namespace Neo.Compiler.CSharp.UnitTests
                 {
                     var result = Contract.TestLogicalOr(x, y);
                     Assert.AreEqual(x | y, result);
-                    Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+                    AssertGasConsumed(1047360);
                 }
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Math.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Math.cs
@@ -13,51 +13,51 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void max_test()
         {
             Assert.AreEqual(2, Contract.Max(1, 2));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
             Assert.AreEqual(3, Contract.Max(3, 1));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void min_test()
         {
             Assert.AreEqual(1, Contract.Min(1, 2));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
             Assert.AreEqual(1, Contract.Min(3, 1));
-            Assert.AreEqual(1047360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047360);
         }
 
         [TestMethod]
         public void sign_test()
         {
             Assert.AreEqual(1, Contract.Sign(1));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
             Assert.AreEqual(-1, Contract.Sign(-1));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
             Assert.AreEqual(0, Contract.Sign(0));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
         }
 
         [TestMethod]
         public void abs_test()
         {
             Assert.AreEqual(1, Contract.Abs(1));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
             Assert.AreEqual(1, Contract.Abs(-1));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
             Assert.AreEqual(0, Contract.Abs(0));
-            Assert.AreEqual(1047150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047150);
         }
 
         [TestMethod]
         public void bigMul_test()
         {
             Assert.AreEqual(((long)int.MaxValue) * int.MaxValue, Contract.BigMul(int.MaxValue, int.MaxValue));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
             Assert.AreEqual(((long)int.MinValue) * int.MinValue, Contract.BigMul(int.MinValue, int.MinValue));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
             Assert.ThrowsException<TestException>(() => Contract.BigMul(long.MaxValue, long.MaxValue));
-            Assert.AreEqual(1063230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063230);
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((byte)10, (byte)4);
             Assert.AreEqual(expected.Remainder, checked((byte)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((byte)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((short)10, (short)3);
             Assert.AreEqual(expected.Remainder, checked((short)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((short)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -87,7 +87,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((int)10, (int)3);
             Assert.AreEqual(expected.Remainder, checked((int)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((int)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((long)10, (long)3);
             Assert.AreEqual(expected.Remainder, checked((long)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((long)(BigInteger)result[1]));
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((sbyte)10, (sbyte)3);
             Assert.AreEqual(expected.Remainder, checked((sbyte)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((sbyte)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((ushort)10, (ushort)3);
             Assert.AreEqual(expected.Remainder, checked((ushort)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ushort)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -127,7 +127,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((uint)10, (uint)3);
             Assert.AreEqual(expected.Remainder, checked((uint)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((uint)(BigInteger)result[1]));
-            Assert.AreEqual(1110150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110150);
         }
 
         [TestMethod]
@@ -137,14 +137,14 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((ulong)10, (ulong)3);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
         public void divRemZeroU_test()
         {
             Assert.ThrowsException<TestException>(() => Contract.DivRemUint((uint)10, (uint)0));
-            Assert.AreEqual(1047540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047540);
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((ulong)10, (ulong)3);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -164,7 +164,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(ulong.MaxValue, (ulong)2);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -174,7 +174,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(ulong.MaxValue, (ulong)1);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -184,7 +184,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((ulong)3, (ulong)10);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -194,7 +194,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem((ulong)10, ulong.MaxValue);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -218,7 +218,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(ulong.MaxValue, ulong.MaxValue);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -228,7 +228,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(ulong.MaxValue - 1, ulong.MaxValue);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -238,7 +238,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(ulong.MaxValue, 2UL);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -250,7 +250,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(large1, large2);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110240);
         }
 
         [TestMethod]
@@ -262,7 +262,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(large1, large2);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -274,7 +274,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(dividend, divisor);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
@@ -286,7 +286,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(dividend, divisor);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -298,7 +298,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(largePrime1, largePrime2);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110420, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110420);
         }
 
         [TestMethod]
@@ -323,127 +323,127 @@ namespace Neo.Compiler.CSharp.UnitTests
             var expected = Math.DivRem(alternatingBits, 3);
             Assert.AreEqual(expected.Remainder, checked((ulong)(BigInteger)result[0]));
             Assert.AreEqual(expected.Quotient, checked((ulong)(BigInteger)result[1]));
-            Assert.AreEqual(1110330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1110330);
         }
 
         [TestMethod]
         public void TestClampByte()
         {
             Assert.AreEqual((byte)5, Contract.ClampByte(5, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.ThrowsException<TestException>(() => Contract.ClampByte(5, 10, 0));
-            Assert.AreEqual(1062870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1062870);
             Assert.AreEqual((byte)5, Contract.ClampByte(0, 5, 10));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((byte)5, Contract.ClampByte(10, 0, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)0, Contract.ClampByte(0, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)10, Contract.ClampByte(10, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)10, Contract.ClampByte(255, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((byte)10, Contract.ClampByte(20, 0, 10));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampSByte()
         {
             Assert.AreEqual((sbyte)0, Contract.ClampSByte(0, -5, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((sbyte)-5, Contract.ClampSByte(-10, -5, 5));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((sbyte)5, Contract.ClampSByte(10, -5, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((sbyte)-5, Contract.ClampSByte(sbyte.MinValue, -5, 5));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((sbyte)5, Contract.ClampSByte(sbyte.MaxValue, -5, 5));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampShort()
         {
             Assert.AreEqual((short)0, Contract.ClampShort(0, -1000, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((short)-1000, Contract.ClampShort(-2000, -1000, 1000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((short)1000, Contract.ClampShort(2000, -1000, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((short)-1000, Contract.ClampShort(short.MinValue, -1000, 1000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual((short)1000, Contract.ClampShort(short.MaxValue, -1000, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampUShort()
         {
             Assert.AreEqual((ushort)500, Contract.ClampUShort(500, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((ushort)0, Contract.ClampUShort(0, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((ushort)1000, Contract.ClampUShort(1000, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual((ushort)1000, Contract.ClampUShort(ushort.MaxValue, 0, 1000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampInt()
         {
             Assert.AreEqual(0, Contract.ClampInt(0, -1000000, 1000000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000, Contract.ClampInt(-2000000, -1000000, 1000000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000, Contract.ClampInt(2000000, -1000000, 1000000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000, Contract.ClampInt(int.MinValue, -1000000, 1000000));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000, Contract.ClampInt(int.MaxValue, -1000000, 1000000));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampUInt()
         {
             Assert.AreEqual(500000U, Contract.ClampUInt(500000U, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(0U, Contract.ClampUInt(0U, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000U, Contract.ClampUInt(1000000U, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000U, Contract.ClampUInt(uint.MaxValue, 0U, 1000000U));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampLong()
         {
             Assert.AreEqual(0L, Contract.ClampLong(0L, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000000000L, Contract.ClampLong(-2000000000000L, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000000000L, Contract.ClampLong(2000000000000L, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(-1000000000000L, Contract.ClampLong(long.MinValue, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.AreEqual(1000000000000L, Contract.ClampLong(long.MaxValue, -1000000000000L, 1000000000000L));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
         }
 
         [TestMethod]
         public void TestClampULong()
         {
             Assert.AreEqual(500000000000UL, Contract.ClampULong(500000000000UL, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(0UL, Contract.ClampULong(0UL, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000000000UL, Contract.ClampULong(1000000000000UL, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048350, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048350);
             Assert.AreEqual(1000000000000UL, Contract.ClampULong(ulong.MaxValue, 0UL, 1000000000000UL));
-            Assert.AreEqual(1048440, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048440);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MemberAccess.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MemberAccess.cs
@@ -13,7 +13,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var logs = new Queue<string>();
             Contract.OnRuntimeLog += (sender, log) => logs.Enqueue(log);
             Contract.TestMain();
-            Assert.AreEqual(6370920, Engine.FeeConsumed.Value);
+            AssertGasConsumed(6370920);
 
             // Check logs
             Assert.AreEqual(4, logs.Count);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MultipleA.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MultipleA.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test()
         {
             Assert.IsTrue(Contract.Test());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MultipleB.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MultipleB.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test()
         {
             Assert.IsFalse(Contract.Test());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NULL.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NULL.cs
@@ -13,74 +13,74 @@ namespace Neo.Compiler.CSharp.UnitTests
             // True
 
             Assert.IsTrue(Contract.IsNull(null));
-            Assert.AreEqual(1048140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048140);
 
             // False
 
             Assert.IsFalse(Contract.IsNull(1));
-            Assert.AreEqual(1048140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048140);
         }
 
         [TestMethod]
         public void IfNull()
         {
             Assert.IsFalse(Contract.IfNull(null));
-            Assert.AreEqual(1047120, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047120);
         }
 
         [TestMethod]
         public void NullProperty()
         {
             Assert.IsTrue(Contract.NullProperty(null));
-            Assert.AreEqual(1048200, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048200);
             Assert.IsFalse(Contract.NullProperty(""));
-            Assert.AreEqual(1048530, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048530);
             Assert.IsTrue(Contract.NullProperty("123"));
-            Assert.AreEqual(1048530, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048530);
         }
 
         [TestMethod]
         public void NullPropertyGT()
         {
             Assert.IsFalse(Contract.NullPropertyGT(null));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
             Assert.IsFalse(Contract.NullPropertyGT(""));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.IsTrue(Contract.NullPropertyGT("123"));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
         }
 
         [TestMethod]
         public void NullPropertyLT()
         {
             Assert.IsFalse(Contract.NullPropertyLT(null));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
             Assert.IsFalse(Contract.NullPropertyLT(""));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.IsFalse(Contract.NullPropertyLT("123"));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
         }
 
         [TestMethod]
         public void NullPropertyGE()
         {
             Assert.IsFalse(Contract.NullPropertyGE(null));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
             Assert.IsTrue(Contract.NullPropertyGE(""));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.IsTrue(Contract.NullPropertyGE("123"));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
         }
 
         [TestMethod]
         public void NullPropertyLE()
         {
             Assert.IsFalse(Contract.NullPropertyLE(null));
-            Assert.AreEqual(1047480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047480);
             Assert.IsTrue(Contract.NullPropertyLE(""));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
             Assert.IsFalse(Contract.NullPropertyLE("123"));
-            Assert.AreEqual(1047810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047810);
         }
 
         [TestMethod]
@@ -92,13 +92,13 @@ namespace Neo.Compiler.CSharp.UnitTests
             // a123b->12
             {
                 var data = (VM.Types.ByteString)Contract.NullCoalescing("a123b")!;
-                Assert.AreEqual(1109040, Engine.FeeConsumed.Value);
+                AssertGasConsumed(1109040);
                 Assert.AreEqual("12", System.Text.Encoding.ASCII.GetString(data.GetSpan()));
             }
             // null->null
             {
                 Assert.IsNull(Contract.NullCoalescing(null));
-                Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+                AssertGasConsumed(1047330);
             }
         }
 
@@ -111,13 +111,13 @@ namespace Neo.Compiler.CSharp.UnitTests
             // nes->nes
             {
                 Assert.AreEqual("nes", Contract.NullCollation("nes"));
-                Assert.AreEqual(1047540, Engine.FeeConsumed.Value);
+                AssertGasConsumed(1047540);
             }
 
             // null->linux
             {
                 Assert.AreEqual("linux", Contract.NullCollation(null));
-                Assert.AreEqual(1047630, Engine.FeeConsumed.Value);
+                AssertGasConsumed(1047630);
             }
         }
 
@@ -125,14 +125,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void NullCollationAndCollation()
         {
             Assert.AreEqual(new BigInteger(123), ((VM.Types.ByteString)Contract.NullCollationAndCollation("nes")!).GetInteger());
-            Assert.AreEqual(2522880, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2522880);
         }
 
         [TestMethod]
         public void NullCollationAndCollation2()
         {
             Assert.AreEqual("111", ((VM.Types.ByteString)Contract.NullCollationAndCollation2("nes")!).GetString());
-            Assert.AreEqual(3614460, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3614460);
         }
 
         [TestMethod]
@@ -141,22 +141,22 @@ namespace Neo.Compiler.CSharp.UnitTests
             // True
 
             Assert.IsTrue(Contract.EqualNullA(null));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
 
             // False
 
             Assert.IsFalse(Contract.EqualNullA(1));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
 
             // True
 
             Assert.IsTrue(Contract.EqualNullB(null));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
 
             // False
 
             Assert.IsFalse(Contract.EqualNullB(1));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
         }
 
         [TestMethod]
@@ -165,29 +165,29 @@ namespace Neo.Compiler.CSharp.UnitTests
             // True
 
             Assert.IsFalse(Contract.EqualNotNullA(null));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
 
             // False
 
             Assert.IsTrue(Contract.EqualNotNullA(1));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
 
             // True
 
             Assert.IsFalse(Contract.EqualNotNullB(null));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
 
             // False
 
             Assert.IsTrue(Contract.EqualNotNullB(1));
-            Assert.AreEqual(1048020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048020);
         }
 
         [TestMethod]
         public void NullTypeTest()
         {
             Contract.NullType(); // no error
-            Assert.AreEqual(986340, Engine.FeeConsumed.Value);
+            AssertGasConsumed(986340);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NativeContracts.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NativeContracts.cs
@@ -28,7 +28,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             // Minimum Response Fee
 
             Assert.AreEqual(new BigInteger(0_10000000u), Contract.OracleMinimumResponseFee());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             // getOracleNodes
 
             Assert.AreEqual(0, Contract.GetOracleNodes()!.Count);
-            Assert.AreEqual(2950200, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2950200);
         }
 
         [TestMethod]
@@ -46,19 +46,19 @@ namespace Neo.Compiler.CSharp.UnitTests
             // NeoSymbol
 
             Assert.AreEqual("NEO", Contract.NEOSymbol());
-            Assert.AreEqual(1967100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1967100);
 
             // NeoHash
 
             Assert.AreEqual(NativeContract.NEO.Hash, Contract.NEOHash());
-            Assert.AreEqual(984270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984270);
         }
 
         [TestMethod]
         public void Test_GAS()
         {
             Assert.AreEqual("GAS", Contract.GASSymbol());
-            Assert.AreEqual(1967100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1967100);
         }
 
         [TestMethod]
@@ -66,11 +66,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var genesisBlock = NativeContract.Ledger.GetBlock(Engine.Storage.Snapshot, 0);
             Assert.AreEqual(NativeContract.Ledger.Hash, Contract.LedgerHash());
-            Assert.AreEqual(984270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984270);
             Assert.AreEqual(0, Contract.LedgerCurrentIndex());
-            Assert.AreEqual(2950140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2950140);
             Assert.AreEqual(genesisBlock.Hash, Contract.LedgerCurrentHash());
-            Assert.AreEqual(2950140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2950140);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Params.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Params.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Params()
         {
             Assert.AreEqual(15, Contract.Test());
-            Assert.AreEqual(1259970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1259970);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Partial.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Partial.cs
@@ -10,9 +10,9 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Partial()
         {
             Assert.AreEqual(1, Contract.Test1());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
             Assert.AreEqual(2, Contract.Test2());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Pattern.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Pattern.cs
@@ -12,13 +12,13 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Between_Test()
         {
             Assert.AreEqual(true, Contract.Between(50));
-            Assert.AreEqual(1083030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1083030);
             Assert.AreEqual(false, Contract.Between(1));
-            Assert.AreEqual(1082790, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1082790);
             Assert.AreEqual(false, Contract.Between(100));
-            Assert.AreEqual(1083030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1083030);
             Assert.AreEqual(false, Contract.Between(200));
-            Assert.AreEqual(1083030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1083030);
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Polymorphism.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Polymorphism.cs
@@ -10,13 +10,13 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test()
         {
             Assert.AreEqual(14, Contract.Sum(5, 9));
-            Assert.AreEqual(1514550, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1514550);
             Assert.AreEqual(40, Contract.Mul(5, 8));
-            Assert.AreEqual(1531890, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1531890);
             Assert.AreEqual("test", Contract.Test());
-            Assert.AreEqual(1487760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1487760);
             Assert.AreEqual("base.test", Contract.Test2());
-            Assert.AreEqual(1812540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1812540);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Property_Method.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Property_Method.cs
@@ -12,7 +12,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestPropertyMethod()
         {
             var arr = Contract.TestProperty()!;
-            Assert.AreEqual(2053500, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2053500);
 
             Assert.AreEqual(2, arr.Count);
             Assert.AreEqual((arr[0] as StackItem)!.GetString(), "NEO3");
@@ -23,7 +23,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void TestPropertyMethod2()
         {
             Contract.TestProperty2();
-            Assert.AreEqual(1557360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1557360);
             // No errors
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Record.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Record.cs
@@ -13,7 +13,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var name = "klsas";
             var age = 24;
             var result = Contract.Test_CreateRecord(name, age)!;
-            Assert.AreEqual(2048820, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048820);
             var arr = result as Struct;
             Assert.AreEqual(2, arr!.Count);
             Assert.AreEqual(name, arr[0].GetString());
@@ -26,7 +26,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var name = "klsas";
             var age = 24;
             var result = Contract.Test_CreateRecord2(name, age)!;
-            Assert.AreEqual(2048970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2048970);
             var arr = result as Struct;
             Assert.AreEqual(2, arr!.Count);
             Assert.AreEqual(name, arr[0].GetString());
@@ -39,7 +39,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var name = "klsas";
             var age = 24;
             var result = Contract.Test_UpdateRecord(name, age)! as Struct;
-            Assert.AreEqual(2435700, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2435700);
             Assert.AreEqual(2, result!.Count);
             Assert.AreEqual(name, result[0].GetString());
             Assert.AreEqual(age, result[1].GetInteger());
@@ -51,7 +51,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var name = "klsas";
             var age = 2;
             var result = Contract.Test_UpdateRecord2(name, age)!;
-            Assert.AreEqual(3006450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3006450);
             var arr = result as Struct;
             Assert.AreEqual(2, arr!.Count);
             Assert.AreEqual("0" + name, arr[0].GetString());
@@ -64,7 +64,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var name = "klsas";
             var age = 24;
             var result = Contract.Test_DeconstructRecord(name, age)!;
-            Assert.AreEqual(2110620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2110620);
             Assert.AreEqual(name, result);
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Recursion.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Recursion.cs
@@ -28,7 +28,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             int src = 100, aux = 200, dst = 300;
             var result = Contract.HanoiTower(1, src, aux, dst)!;
-            Assert.AreEqual(2788440, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2788440);
             Assert.AreEqual(result.Count, 1);
             List<(BigInteger rodId, BigInteger src, BigInteger dst)> expectedResult = [(1, src, dst)];
             for (int i = 0; i < expectedResult.Count; ++i)
@@ -62,15 +62,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_MutualRecursion()
         {
             Assert.IsTrue(Contract.Odd(7));
-            Assert.AreEqual(1181940, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1181940);
             Assert.IsFalse(Contract.Even(9));
-            Assert.AreEqual(1220160, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1220160);
             Assert.IsTrue(Contract.Odd(-11));
-            Assert.AreEqual(1259040, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1259040);
             Assert.IsTrue(Contract.Even(-10));
-            Assert.AreEqual(1239870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1239870);
             Assert.IsFalse(Contract.Even(-9));
-            Assert.AreEqual(1220700, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1220700);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Returns.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Returns.cs
@@ -12,14 +12,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_OneReturn()
         {
             Assert.AreEqual(new BigInteger(-4), Contract.Subtract(5, 9));
-            Assert.AreEqual(1047660, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047660);
         }
 
         [TestMethod]
         public void Test_DoubleReturnA()
         {
             var array = Contract.Div(9, 5)!;
-            Assert.AreEqual(1539840, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1539840);
 
             Assert.AreEqual(2, array.Count);
             Assert.AreEqual(BigInteger.One, array[0]);
@@ -30,14 +30,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_VoidReturn()
         {
             Assert.AreEqual(new BigInteger(14), Contract.Sum(9, 5));
-            Assert.AreEqual(1047660, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047660);
         }
 
         [TestMethod]
         public void Test_DoubleReturnB()
         {
             Assert.AreEqual(new BigInteger(-3), Contract.Mix(9, 5));
-            Assert.AreEqual(1637040, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1637040);
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Shift.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Shift.cs
@@ -12,7 +12,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Shift()
         {
             var list = Contract.TestShift()?.Cast<BigInteger>().ToArray();
-            Assert.AreEqual(1048710, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048710);
             CollectionAssert.AreEqual(new BigInteger[] { 16, 4 }, list);
         }
 
@@ -20,7 +20,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Shift_BigInteger()
         {
             var list = Contract.TestShiftBigInt()?.Cast<BigInteger>().ToArray();
-            Assert.AreEqual(1049310, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049310);
             CollectionAssert.AreEqual(new BigInteger[] { 8, 16, 4, 2 }, list);
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticByteArray.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticByteArray.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var wantResult = new byte[] { 0x89, 0x77, 0x20, 0xd8, 0xcd, 0x76, 0xf4, 0xf0, 0x0a, 0xbf, 0xa3, 0x7c, 0x0e, 0xdd, 0x88, 0x9c, 0x20, 0x8f, 0xde, 0x9b };
             CollectionAssert.AreEqual(wantResult, Contract.TestStaticByteArray());
-            Assert.AreEqual(1230630, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1230630);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticClass.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticClass.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_StaticClass()
         {
             Assert.AreEqual(2, Contract.TestStaticClass());
-            Assert.AreEqual(1055910, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1055910);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticConstruct.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticConstruct.cs
@@ -10,7 +10,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_StaticConsturct()
         {
             var var1 = Contract.TestStatic();
-            Assert.AreEqual(987390, Engine.FeeConsumed.Value);
+            AssertGasConsumed(987390);
             // static byte[] callscript = ExecutionEngine.EntryScriptHash;
             // ...
             // return callscript

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticVar.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticVar.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_InitialValue()
         {
             Assert.AreEqual("hello world", Contract.Testinitalvalue());
-            Assert.AreEqual(2956140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2956140);
         }
 
         [TestMethod]
@@ -19,42 +19,42 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             //test (1+5)*7 == 42
             Assert.AreEqual(new BigInteger(42), Contract.TestMain());
-            Assert.AreEqual(2988480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2988480);
         }
 
         [TestMethod]
         public void Test_testBigIntegerParse()
         {
             Assert.AreEqual(new BigInteger(123), Contract.TestBigIntegerParse());
-            Assert.AreEqual(2956440, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2956440);
         }
 
         [TestMethod]
         public void Test_testBigIntegerParse2()
         {
             Assert.AreEqual(new BigInteger(123), Contract.TestBigIntegerParse2("123"));
-            Assert.AreEqual(4004280, Engine.FeeConsumed.Value);
+            AssertGasConsumed(4004280);
         }
 
         [TestMethod]
         public void Test_GetUInt160()
         {
             Assert.AreEqual("0x71a87191aef3fcf5e4441d791ded67ebab1aee7e", Contract.TestGetUInt160()?.ToString());
-            Assert.AreEqual(2956140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2956140);
         }
 
         [TestMethod]
         public void Test_GetECPoint()
         {
             Assert.AreEqual("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", Contract.TestGetECPoint()?.ToString());
-            Assert.AreEqual(2956140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2956140);
         }
 
         [TestMethod]
         public void Test_GetString()
         {
             Assert.AreEqual("hello world", Contract.TestGetString());
-            Assert.AreEqual(2956140, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2956140);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticVarInit.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_StaticVarInit.cs
@@ -10,11 +10,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_StaticVarInit()
         {
             var var1 = Contract.StaticInit();
-            Assert.AreEqual(1000470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1000470);
             Assert.AreEqual(var1, Contract.Hash);
 
             var var2 = Contract.DirectGet();
-            Assert.AreEqual(985530, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985530);
             Assert.AreEqual(var1, var2);
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_String.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_String.cs
@@ -19,7 +19,7 @@ namespace Neo.Compiler.CSharp.UnitTests
 
             Contract.OnRuntimeLog += method;
             Contract.TestSubstring();
-            Assert.AreEqual(3075900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3075900);
             Contract.OnRuntimeLog -= method;
 
             Assert.AreEqual(2, log.Count);
@@ -38,7 +38,7 @@ namespace Neo.Compiler.CSharp.UnitTests
 
             Contract.OnRuntimeLog += method;
             Contract.TestMain();
-            Assert.AreEqual(7625310, Engine.FeeConsumed.Value);
+            AssertGasConsumed(7625310);
             Contract.OnRuntimeLog -= method;
 
             Assert.AreEqual(1, log.Count);
@@ -56,7 +56,7 @@ namespace Neo.Compiler.CSharp.UnitTests
 
             Contract.OnRuntimeLog += method;
             Contract.TestEqual();
-            Assert.AreEqual(1970970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1970970);
             Contract.OnRuntimeLog -= method;
 
             Assert.AreEqual(1, log.Count);
@@ -67,53 +67,53 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_TestEmpty()
         {
             Assert.AreEqual("", Contract.TestEmpty());
-            Assert.AreEqual(984270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984270);
         }
 
         [TestMethod]
         public void Test_TestIsNullOrEmpty()
         {
             Assert.IsTrue(Contract.TestIsNullOrEmpty(""));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
 
             Assert.IsTrue(Contract.TestIsNullOrEmpty(null));
-            Assert.AreEqual(1047300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047300);
 
             Assert.IsFalse(Contract.TestIsNullOrEmpty("hello world"));
-            Assert.AreEqual(1047870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047870);
         }
 
         [TestMethod]
         public void Test_TestEndWith()
         {
             Assert.IsTrue(Contract.TestEndWith("hello world"));
-            Assert.AreEqual(1357650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1357650);
 
             Assert.IsFalse(Contract.TestEndWith("hel"));
-            Assert.AreEqual(1049250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049250);
 
             Assert.IsFalse(Contract.TestEndWith("hello"));
-            Assert.AreEqual(1049250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049250);
         }
 
         [TestMethod]
         public void Test_TestContains()
         {
             Assert.IsTrue(Contract.TestContains("hello world"));
-            Assert.AreEqual(2032740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032740);
 
             Assert.IsFalse(Contract.TestContains("hello"));
-            Assert.AreEqual(2032740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032740);
         }
 
         [TestMethod]
         public void Test_TestIndexOf()
         {
             Assert.AreEqual(6, Contract.TestIndexOf("hello world"));
-            Assert.AreEqual(2032470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032470);
 
             Assert.AreEqual(-1, Contract.TestIndexOf("hello"));
-            Assert.AreEqual(2032470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032470);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Switch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Switch.cs
@@ -28,32 +28,32 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_SwitchLongLong()
         {
             Assert.AreEqual(2, ((VM.Types.Integer)Contract.SwitchLongLong("a")!).GetInteger());
-            Assert.AreEqual(1049490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049490);
             Assert.AreEqual(0, ((VM.Types.Integer)Contract.SwitchLongLong("b")!).GetInteger());
-            Assert.AreEqual(1052130, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1052130);
             Assert.AreEqual(2, ((VM.Types.Integer)Contract.SwitchLongLong("c")!).GetInteger());
-            Assert.AreEqual(1050960, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050960);
             Assert.AreEqual(-1, ((VM.Types.Integer)Contract.SwitchLongLong("d")!).GetInteger());
-            Assert.AreEqual(1053600, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1053600);
             Assert.AreEqual(1, ((VM.Types.Integer)Contract.SwitchLongLong("e")!).GetInteger());
-            Assert.AreEqual(1054950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1054950);
             Assert.AreEqual(3, ((VM.Types.Integer)Contract.SwitchLongLong("f")!).GetInteger());
-            Assert.AreEqual(1056240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1056240);
             Assert.AreEqual(3, ((VM.Types.Integer)Contract.SwitchLongLong("g")!).GetInteger());
-            Assert.AreEqual(1057560, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1057560);
         }
 
         [TestMethod]
         public void Test_SwitchInteger()
         {
             Assert.AreEqual(2, ((VM.Types.Integer)Contract.SwitchInteger(1)!).GetInteger());
-            Assert.AreEqual(1048620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048620);
             Assert.AreEqual(3, ((VM.Types.Integer)Contract.SwitchInteger(2)!).GetInteger());
-            Assert.AreEqual(1049730, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049730);
             Assert.AreEqual(6, ((VM.Types.Integer)Contract.SwitchInteger(3)!).GetInteger());
-            Assert.AreEqual(1050840, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050840);
             Assert.AreEqual(0, ((VM.Types.Integer)Contract.SwitchInteger(0)!).GetInteger());
-            Assert.AreEqual(1050840, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050840);
         }
 
         [TestMethod]
@@ -70,9 +70,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             // Test default
 
             Assert.AreEqual(99, ((VM.Types.Integer)Contract.Switch6(6.ToString())!).GetInteger());
-            Assert.AreEqual(1055310, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1055310);
             Assert.AreEqual(99, ((VM.Types.Integer)Contract.Switch6Inline(6.ToString())!).GetInteger());
-            Assert.AreEqual(1055400, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1055400);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Throw.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Throw.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Throw()
         {
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestMain([]));
-            Assert.AreEqual(1063530, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1063530);
             Assert.IsTrue(exception.Message.Contains("Please supply at least one argument."));
         }
 
@@ -19,7 +19,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_NotThrow()
         {
             Contract.TestMain(["test"]);
-            Assert.AreEqual(1111290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1111290);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TryCatch.cs
@@ -12,191 +12,191 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Try01_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.Try01(false, false, false));
-            Assert.AreEqual(1049670, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049670);
             Assert.AreEqual(new BigInteger(3), Contract.Try01(false, false, true));
-            Assert.AreEqual(1050330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050330);
             Assert.AreEqual(new BigInteger(3), Contract.Try01(true, true, false));
-            Assert.AreEqual(1065660, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065660);
             Assert.AreEqual(new BigInteger(4), Contract.Try01(true, true, true));
-            Assert.AreEqual(1066320, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066320);
         }
 
         [TestMethod]
         public void Test_Try02_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.Try02(false, false, false));
-            Assert.AreEqual(1067130, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1067130);
             Assert.AreEqual(new BigInteger(3), Contract.Try02(false, false, true));
-            Assert.AreEqual(1067790, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1067790);
             Assert.AreEqual(new BigInteger(3), Contract.Try02(true, true, false));
-            Assert.AreEqual(1083120, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1083120);
             Assert.AreEqual(new BigInteger(4), Contract.Try02(true, true, true));
-            Assert.AreEqual(1083780, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1083780);
         }
 
         [TestMethod]
         public void Test_Try03_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.Try03(false, false, false));
-            Assert.AreEqual(1049670, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049670);
             Assert.AreEqual(new BigInteger(3), Contract.Try03(false, false, true));
-            Assert.AreEqual(1050330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050330);
             Assert.AreEqual(new BigInteger(3), Contract.Try03(true, true, false));
-            Assert.AreEqual(1081020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081020);
             Assert.AreEqual(new BigInteger(4), Contract.Try03(true, true, true));
-            Assert.AreEqual(1081680, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081680);
         }
 
         [TestMethod]
         public void Test_TryNest_AllPaths()
         {
             Assert.AreEqual(new BigInteger(3), Contract.TryNest(false, false, false, false));
-            Assert.AreEqual(1050600, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050600);
             Assert.AreEqual(new BigInteger(4), Contract.TryNest(true, false, false, false));
-            Assert.AreEqual(1081950, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081950);
             Assert.AreEqual(new BigInteger(3), Contract.TryNest(false, true, false, false));
-            Assert.AreEqual(1050600, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050600);
             Assert.AreEqual(new BigInteger(3), Contract.TryNest(false, false, true, true));
-            Assert.AreEqual(1081620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081620);
             Assert.AreEqual(new BigInteger(4), Contract.TryNest(true, true, true, true));
-            Assert.AreEqual(1143810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1143810);
         }
 
         [TestMethod]
         public void Test_ThrowInCatch_AllPaths()
         {
             Assert.AreEqual(new BigInteger(4), Contract.ThrowInCatch(false, false, true));
-            Assert.AreEqual(1050090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050090);
             Assert.AreEqual(new BigInteger(4), Contract.ThrowInCatch(true, false, true));
-            Assert.AreEqual(1066080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066080);
             Assert.ThrowsException<TestException>(() => Contract.ThrowInCatch(true, true, true));
-            Assert.AreEqual(1081290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081290);
         }
 
         [TestMethod]
         public void Test_TryFinally_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryFinally(false, false));
-            Assert.AreEqual(1049640, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049640);
             Assert.AreEqual(new BigInteger(3), Contract.TryFinally(false, true));
-            Assert.AreEqual(1050300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050300);
             Assert.ThrowsException<TestException>(() => Contract.TryFinally(true, true));
-            Assert.AreEqual(1065720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065720);
         }
 
         [TestMethod]
         public void Test_TryFinallyAndRethrow_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryFinallyAndRethrow(false, false));
-            Assert.AreEqual(1049640, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049640);
             Assert.AreEqual(new BigInteger(3), Contract.TryFinallyAndRethrow(false, true));
-            Assert.AreEqual(1050300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050300);
             Assert.ThrowsException<TestException>(() => Contract.TryFinallyAndRethrow(true, true));
-            Assert.AreEqual(1081080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081080);
         }
 
         [TestMethod]
         public void Test_TryCatch_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryCatch(false, false));
-            Assert.AreEqual(1049400, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049400);
             Assert.AreEqual(new BigInteger(3), Contract.TryCatch(true, true));
-            Assert.AreEqual(1081200, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1081200);
         }
 
         [TestMethod]
         public void Test_TryWithTwoFinally_AllPaths()
         {
             Assert.AreEqual(new BigInteger(1), Contract.TryWithTwoFinally(false, false, false, false, false, false));
-            Assert.AreEqual(1050810, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050810);
             Assert.AreEqual(new BigInteger(4), Contract.TryWithTwoFinally(false, false, false, false, true, false));
-            Assert.AreEqual(1051620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1051620);
             Assert.AreEqual(new BigInteger(6), Contract.TryWithTwoFinally(false, false, false, false, false, true));
-            Assert.AreEqual(1051620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1051620);
             Assert.AreEqual(new BigInteger(3), Contract.TryWithTwoFinally(true, false, true, false, false, false));
-            Assert.AreEqual(1067400, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1067400);
             Assert.AreEqual(new BigInteger(10), Contract.TryWithTwoFinally(false, true, false, true, false, true));
-            Assert.AreEqual(1068210, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1068210);
             Assert.AreEqual(new BigInteger(15), Contract.TryWithTwoFinally(true, true, true, true, true, true));
-            Assert.AreEqual(1085610, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1085610);
         }
 
         [TestMethod]
         public void Test_TryECPointCast_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryecpointCast(false, false, false));
-            Assert.AreEqual(1050240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050240);
             Assert.AreEqual(new BigInteger(3), Contract.TryecpointCast(false, false, true));
-            Assert.AreEqual(1050900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050900);
             Assert.AreEqual(new BigInteger(3), Contract.TryecpointCast(true, true, false));
-            Assert.AreEqual(1065990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065990);
             Assert.AreEqual(new BigInteger(4), Contract.TryecpointCast(true, true, true));
-            Assert.AreEqual(1066650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066650);
         }
 
         [TestMethod]
         public void Test_TryValidByteString2Ecpoint_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryvalidByteString2Ecpoint(false, false));
-            Assert.AreEqual(1050090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050090);
             Assert.AreEqual(new BigInteger(3), Contract.TryvalidByteString2Ecpoint(false, true));
-            Assert.AreEqual(1050750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050750);
             Assert.AreEqual(new BigInteger(2), Contract.TryvalidByteString2Ecpoint(true, false));
-            Assert.AreEqual(1050090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050090);
             Assert.AreEqual(new BigInteger(3), Contract.TryvalidByteString2Ecpoint(true, true));
-            Assert.AreEqual(1050750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050750);
         }
 
         [TestMethod]
         public void Test_TryInvalidByteArray2UInt160_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryinvalidByteArray2UInt160(false, false, false));
-            Assert.AreEqual(1050240, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050240);
             Assert.AreEqual(new BigInteger(3), Contract.TryinvalidByteArray2UInt160(false, false, true));
-            Assert.AreEqual(1050900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050900);
             Assert.AreEqual(new BigInteger(3), Contract.TryinvalidByteArray2UInt160(true, true, false));
-            Assert.AreEqual(1065990, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065990);
             Assert.AreEqual(new BigInteger(4), Contract.TryinvalidByteArray2UInt160(true, true, true));
-            Assert.AreEqual(1066650, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066650);
         }
 
         [TestMethod]
         public void Test_TryValidByteArray2UInt160_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryvalidByteArray2UInt160(false, false));
-            Assert.AreEqual(1050090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050090);
             Assert.AreEqual(new BigInteger(3), Contract.TryvalidByteArray2UInt160(false, true));
-            Assert.AreEqual(1050750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050750);
             Assert.AreEqual(new BigInteger(2), Contract.TryvalidByteArray2UInt160(true, false));
-            Assert.AreEqual(1050090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050090);
             Assert.AreEqual(new BigInteger(3), Contract.TryvalidByteArray2UInt160(true, true));
-            Assert.AreEqual(1050750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050750);
         }
 
         [TestMethod]
         public void Test_TryInvalidByteArray2UInt256_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryinvalidByteArray2UInt256(false, false, false));
-            Assert.AreEqual(1049790, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049790);
             Assert.AreEqual(new BigInteger(3), Contract.TryinvalidByteArray2UInt256(false, false, true));
-            Assert.AreEqual(1050450, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050450);
             Assert.AreEqual(new BigInteger(3), Contract.TryinvalidByteArray2UInt256(true, true, false));
-            Assert.AreEqual(1065930, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1065930);
             Assert.AreEqual(new BigInteger(4), Contract.TryinvalidByteArray2UInt256(true, true, true));
-            Assert.AreEqual(1066590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1066590);
         }
 
         [TestMethod]
         public void Test_TryValidByteArray2UInt256_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryvalidByteArray2UInt256(false, false));
-            Assert.AreEqual(1049640, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049640);
             Assert.AreEqual(new BigInteger(3), Contract.TryvalidByteArray2UInt256(false, true));
-            Assert.AreEqual(1050300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050300);
             Assert.AreEqual(new BigInteger(2), Contract.TryvalidByteArray2UInt256(true, false));
-            Assert.AreEqual(1049640, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049640);
             Assert.AreEqual(new BigInteger(3), Contract.TryvalidByteArray2UInt256(true, true));
-            Assert.AreEqual(1050300, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050300);
         }
 
         [TestMethod]
@@ -204,19 +204,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TryNULL2Ecpoint_1(false, false, false);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1797060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1797060);
             Assert.AreEqual(new BigInteger(2), result[0]);
             Assert.IsNotNull(result[1]);
 
             result = Contract.TryNULL2Ecpoint_1(true, false, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1798590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1798590);
             Assert.AreEqual(new BigInteger(4), result[0]);
             Assert.IsNull(result[1]);
 
             result = Contract.TryNULL2Ecpoint_1(false, true, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1797720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1797720);
             Assert.AreEqual(new BigInteger(3), result[0]);
             Assert.IsNotNull(result[1]);
         }
@@ -226,19 +226,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TryNULL2Uint160_1(false, false, false);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1797060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1797060);
             Assert.AreEqual(new BigInteger(2), result[0]);
             Assert.IsNotNull(result[1]);
 
             result = Contract.TryNULL2Uint160_1(true, false, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1798590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1798590);
             Assert.AreEqual(new BigInteger(4), result[0]);
             Assert.IsNull(result[1]);
 
             result = Contract.TryNULL2Uint160_1(false, true, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1797720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1797720);
             Assert.AreEqual(new BigInteger(3), result[0]);
             Assert.IsNotNull(result[1]);
         }
@@ -248,19 +248,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TryNULL2Uint256_1(false, false, false);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1797060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1797060);
             Assert.AreEqual(new BigInteger(2), result[0]);
             Assert.IsNotNull(result[1]);
 
             result = Contract.TryNULL2Uint256_1(true, false, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1798590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1798590);
             Assert.AreEqual(new BigInteger(4), result[0]);
             Assert.IsNull(result[1]);
 
             result = Contract.TryNULL2Uint256_1(false, true, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1797720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1797720);
             Assert.AreEqual(new BigInteger(3), result[0]);
             Assert.IsNotNull(result[1]);
         }
@@ -270,19 +270,19 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TryNULL2Bytestring_1(false, false, false);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1543380, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1543380);
             Assert.AreEqual(new BigInteger(2), result[0]);
             Assert.IsNotNull(result[1]);
 
             result = Contract.TryNULL2Bytestring_1(true, false, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1544910, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1544910);
             Assert.AreEqual(new BigInteger(4), result[0]);
             Assert.IsNull(result[1]);
 
             result = Contract.TryNULL2Bytestring_1(false, true, true);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1544040, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1544040);
             Assert.AreEqual(new BigInteger(3), result[0]);
             Assert.IsNotNull(result[1]);
         }
@@ -291,11 +291,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_TryUncatchableException_AllPaths()
         {
             Assert.AreEqual(new BigInteger(2), Contract.TryUncatchableException(false, false, false));
-            Assert.AreEqual(1049670, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049670);
             Assert.AreEqual(new BigInteger(3), Contract.TryUncatchableException(false, false, true));
-            Assert.AreEqual(1050330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1050330);
             Assert.ThrowsException<TestException>(() => Contract.TryUncatchableException(true, true, true));
-            Assert.AreEqual(1049250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049250);
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Tuple.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Tuple.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Assign()
         {
             var tuple = Contract.T1()! as Struct;
-            Assert.AreEqual(4789620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(4789620);
             Assert.AreEqual(5, tuple!.Count);
             Assert.AreEqual(1, tuple[2].GetInteger());
             Assert.AreEqual(4, tuple[3].GetInteger());

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TypeConvert.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TypeConvert.cs
@@ -11,7 +11,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void UnitTest_TestTypeConvert()
         {
             var arr = (Array)Contract.TestType()!;
-            Assert.AreEqual(4207710, Engine.FeeConsumed.Value);
+            AssertGasConsumed(4207710);
 
             //test 0,1,2
             Assert.IsTrue(arr[0].Type == StackItemType.Integer);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types.cs
@@ -17,30 +17,30 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Null_Test()
         {
             Assert.IsNull(Contract.CheckNull());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Bool_Test()
         {
             Assert.IsTrue(Contract.CheckBoolTrue());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
             Assert.IsFalse(Contract.CheckBoolFalse());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void ByteStringConcat_Test()
         {
             Assert.AreEqual("1212", Contract.ConcatByteString([(byte)'1'], [(byte)'2']));
-            Assert.AreEqual(1969260, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1969260);
         }
 
         [TestMethod]
         public void ToAddress_Test()
         {
             Assert.AreEqual("NdtB8RXRmJ7Nhw1FPTm7E6HoDZGnDw37nf", Contract.ToAddress(UInt160.Parse("820944cfdc70976602d71b0091445eedbc661bc5"), 53));
-            Assert.AreEqual(4575000, Engine.FeeConsumed.Value);
+            AssertGasConsumed(4575000);
         }
 
         [TestMethod]
@@ -51,111 +51,111 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(new JArray(checkEnumArg.Parameters.Select(u => u.ToJson()).ToArray<JToken?>()).ToString(false), @"[{""name"":""arg"",""type"":""Integer""}]");
 
             Contract.CheckEnumArg(5);
-            Assert.AreEqual(1046970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1046970);
         }
 
         [TestMethod]
         public void CheckBoolString_Test()
         {
             Assert.AreEqual(true.ToString(), Contract.CheckBoolString(true));
-            Assert.AreEqual(1047330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047330);
             Assert.AreEqual(false.ToString(), Contract.CheckBoolString(false));
-            Assert.AreEqual(1047390, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047390);
         }
 
         [TestMethod]
         public void Sbyte_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckSbyte());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Byte_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckByte());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Short_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckShort());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Ushort_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckUshort());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Int_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckInt());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Uint_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckUint());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Long_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckLong());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Ulong_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckUlong());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void BigInteger_Test()
         {
             Assert.AreEqual(new BigInteger(5), Contract.CheckBigInteger());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void ByteArray_Test()
         {
             CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, Contract.CheckByteArray());
-            Assert.AreEqual(1230030, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1230030);
         }
 
         [TestMethod]
         public void Char_Test()
         {
             Assert.AreEqual(new BigInteger('n'), Contract.CheckChar());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void String_Test()
         {
             Assert.AreEqual("neo", Contract.CheckString());
-            Assert.AreEqual(984270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984270);
             Assert.AreEqual(new BigInteger('e'), Contract.CheckStringIndex("neo", 1));
-            Assert.AreEqual(1049250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049250);
             Assert.AreEqual(new BigInteger('o'), Contract.CheckStringIndex("neo", 2));
-            Assert.AreEqual(1049250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049250);
         }
 
         [TestMethod]
         public void ArrayObj_Test()
         {
             var item = Contract.CheckArrayObj()!;
-            Assert.AreEqual(1045740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1045740);
 
             Assert.AreEqual(1, item.Count);
             Assert.AreEqual("neo", (item[0] as ByteString)?.GetString());
@@ -165,14 +165,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Enum_Test()
         {
             Assert.AreEqual(new Integer(5), Contract.CheckEnum());
-            Assert.AreEqual(984060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984060);
         }
 
         [TestMethod]
         public void Class_Test()
         {
             var item = Contract.CheckClass();
-            Assert.AreEqual(1557060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1557060);
             Assert.IsInstanceOfType(item, typeof(Array));
             Assert.AreEqual(1, ((Array)item).Count);
             Assert.AreEqual("neo", (((Array)item)[0] as ByteString)?.GetString());
@@ -182,7 +182,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Struct_Test()
         {
             var item = Contract.CheckStruct();
-            Assert.AreEqual(1496010, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1496010);
             Assert.IsInstanceOfType(item, typeof(Struct));
             Assert.AreEqual(1, ((Struct)item).Count);
             Assert.AreEqual("neo", (((Struct)item)[0] as ByteString)?.GetString());
@@ -192,7 +192,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Tuple_Test()
         {
             var item = Contract.CheckTuple()!;
-            Assert.AreEqual(1476630, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1476630);
             Assert.AreEqual(2, item.Count);
             Assert.AreEqual("neo", (item[0] as ByteString)?.GetString());
             Assert.AreEqual("smart economy", (item[1] as ByteString)?.GetString());
@@ -202,7 +202,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Tuple2_Test()
         {
             var item = Contract.CheckTuple2()!;
-            Assert.AreEqual(1478670, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1478670);
             Assert.AreEqual(2, item.Count);
             Assert.AreEqual("neo", (item[0] as ByteString)?.GetString());
             Assert.AreEqual("smart economy", (item[1] as ByteString)?.GetString());
@@ -239,7 +239,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Lambda_Test()
         {
             var item = Contract.CheckLambda();
-            Assert.AreEqual(984150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984150);
             Assert.IsInstanceOfType(item, typeof(Pointer));
         }
 
@@ -247,7 +247,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Delegate_Test()
         {
             var item = Contract.CheckDelegate();
-            Assert.AreEqual(984150, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984150);
             Assert.IsInstanceOfType(item, typeof(Pointer));
         }
 
@@ -255,7 +255,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Nameof_Test()
         {
             Assert.AreEqual("checkNull", Contract.CheckNameof());
-            Assert.AreEqual(984270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984270);
         }
 
         [TestMethod]
@@ -269,7 +269,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             Contract.OnDummyEvent -= delEvent;
             Assert.AreEqual(1, notifications.Count);
             Assert.AreEqual("neo", notifications.Last());
-            Assert.AreEqual(2213850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2213850);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types_BigInteger.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types_BigInteger.cs
@@ -13,23 +13,23 @@ namespace Neo.Compiler.CSharp.UnitTests
             // Init
 
             Assert.AreEqual(BigInteger.Parse("100000000000000000000000000"), Contract.Attribute());
-            Assert.AreEqual(984750, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984750);
 
             // static vars
 
             Assert.AreEqual(BigInteger.Zero, Contract.Zero());
-            Assert.AreEqual(984720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984720);
             Assert.AreEqual(BigInteger.One, Contract.One());
-            Assert.AreEqual(984720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984720);
             Assert.AreEqual(BigInteger.MinusOne, Contract.MinusOne());
-            Assert.AreEqual(984720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984720);
 
             // Parse
 
             Assert.AreEqual(456, Contract.Parse("456"));
-            Assert.AreEqual(2032890, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2032890);
             Assert.AreEqual(65, Contract.ConvertFromChar());
-            Assert.AreEqual(984720, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984720);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types_ECPoint.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types_ECPoint.cs
@@ -14,22 +14,22 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void ECPoint_test()
         {
             Assert.IsFalse(Contract.IsValid(InvalidECPoint.InvalidLength));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
             Assert.IsFalse(Contract.IsValid(InvalidECPoint.InvalidType));
-            Assert.AreEqual(1048620, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048620);
             Assert.ThrowsException<TestException>(() => Contract.IsValid(InvalidECPoint.Null));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.IsTrue(Contract.IsValid(Cryptography.ECC.ECPoint.Parse("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", Cryptography.ECC.ECCurve.Secp256r1)));
-            Assert.AreEqual(1048830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048830);
 
             Engine.StringInterpreter = new HexStringInterpreter();
 
             Assert.AreEqual("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", Contract.Ecpoint2String());
-            Assert.AreEqual(984870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984870);
             Assert.AreEqual("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", Contract.EcpointReturn()?.ToString());
-            Assert.AreEqual(984870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(984870);
             Assert.AreEqual("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", (Contract.Ecpoint2ByteArray() as VM.Types.Buffer)!.GetSpan().ToHexString());
-            Assert.AreEqual(1230630, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1230630);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_UIntTypes.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_UIntTypes.cs
@@ -18,18 +18,18 @@ namespace Neo.Compiler.CSharp.UnitTests
             // True
 
             Assert.IsTrue(Contract.ValidateAddress(address));
-            Assert.AreEqual(1049340, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049340);
 
             // False
 
             Assert.IsFalse(Contract.ValidateAddress(InvalidUInt160.InvalidType));
-            Assert.AreEqual(1048770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048770);
             Assert.ThrowsException<TestException>(() => Contract.ValidateAddress(InvalidUInt160.Null));
-            Assert.AreEqual(1048110, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048110);
             Assert.IsFalse(Contract.ValidateAddress(InvalidUInt160.InvalidType));
-            Assert.AreEqual(1048770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048770);
             Assert.IsFalse(Contract.ValidateAddress(InvalidUInt160.InvalidLength));
-            Assert.AreEqual(1048980, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048980);
         }
 
         [TestMethod]
@@ -39,9 +39,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             var notOwner = "NYjzhdekseMYWvYpSoAeypqMiwMuEUDhKB".ToScriptHash(ProtocolSettings.Default.AddressVersion);
 
             Assert.IsTrue(Contract.CheckOwner(owner));
-            Assert.AreEqual(1049040, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049040);
             Assert.IsFalse(Contract.CheckOwner(notOwner));
-            Assert.AreEqual(1049040, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049040);
         }
 
         [TestMethod]
@@ -51,9 +51,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             var notZero = "NYjzhdekseMYWvYpSoAeypqMiwMuEUDhKB".ToScriptHash(ProtocolSettings.Default.AddressVersion);
 
             Assert.IsTrue(Contract.CheckZeroStatic(zero));
-            Assert.AreEqual(1049220, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049220);
             Assert.IsFalse(Contract.CheckZeroStatic(notZero));
-            Assert.AreEqual(1049220, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049220);
         }
 
         [TestMethod]
@@ -62,7 +62,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             var notZero = "NYjzhdekseMYWvYpSoAeypqMiwMuEUDhKB".ToScriptHash(ProtocolSettings.Default.AddressVersion);
 
             Assert.AreEqual(notZero, Contract.ConstructUInt160(notZero.ToArray()));
-            Assert.AreEqual(1294230, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1294230);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/AttributeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AttributeTest.cs
@@ -24,17 +24,17 @@ namespace Neo.SmartContract.Framework.UnitTests
             // return in the middle
 
             Contract.ReentrantTest(0);
-            Assert.AreEqual(7224270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(7224270);
 
             // Method end
 
             Contract.ReentrantTest(1);
-            Assert.AreEqual(7225320, Engine.FeeConsumed.Value);
+            AssertGasConsumed(7225320);
 
             // Reentrant test
 
             var ex = Assert.ThrowsException<TestException>(() => Contract.ReentrantTest(123));
-            Assert.AreEqual(7244250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(7244250);
             Assert.IsTrue(ex.Message.Contains("Already entered"));
         }
     }

--- a/tests/Neo.SmartContract.Framework.UnitTests/DebugAndTestBase.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/DebugAndTestBase.cs
@@ -1,3 +1,4 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.TestingStandards;
 
@@ -6,8 +7,17 @@ namespace Neo.SmartContract.Framework.UnitTests;
 public class DebugAndTestBase<T> : TestBase<T>
     where T : SmartContract.Testing.SmartContract, IContractInfo
 {
+
+    internal bool TestGasConsume { set; get; } = true;
+
     static DebugAndTestBase()
     {
         TestCleanup.TestInitialize(typeof(T));
+    }
+
+    protected void AssertGasConsumed(long gasConsumed)
+    {
+        if (TestGasConsume)
+            Assert.AreEqual(gasConsumed, Engine.FeeConsumed.Value);
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/HelperTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/HelperTest.cs
@@ -14,7 +14,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // 0a0b0c0d0E0F
             Assert.AreEqual("0a0b0c0d0e0f", Contract.TestHexToBytes()!.ToHexString());
-            Assert.AreEqual(985170, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985170);
         }
 
         [TestMethod]
@@ -23,34 +23,34 @@ namespace Neo.SmartContract.Framework.UnitTests
             // 0
 
             Assert.IsNull(Contract.TestToBigInteger(null));
-            Assert.AreEqual(1293870, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1293870);
             Assert.AreEqual(0, Contract.TestToBigInteger([]));
-            Assert.AreEqual(1294080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1294080);
 
             // Value
 
             Assert.AreEqual(123, Contract.TestToBigInteger([123]));
-            Assert.AreEqual(1294080, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1294080);
         }
 
         [TestMethod]
         public void TestModPow()
         {
             Assert.AreEqual(4, Contract.ModMultiply(4, 7, 6));
-            Assert.AreEqual(1049250, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049250);
             Assert.AreEqual(9, Contract.ModInverse(3, 26));
-            Assert.AreEqual(1127070, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1127070);
             Assert.AreEqual(344, Contract.ModPow(23895, 15, 14189));
-            Assert.AreEqual(1109730, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1109730);
         }
 
         [TestMethod]
         public void TestBigIntegerParseandCast()
         {
             Assert.AreEqual(2000000000000000, Contract.TestBigIntegerCast([0x00, 0x00, 0x8d, 0x49, 0xfd, 0x1a, 0x07]));
-            Assert.AreEqual(1540020, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1540020);
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestBigIntegerParseHexString("00008d49fd1a07"));
-            Assert.AreEqual(2033310, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2033310);
             Assert.IsInstanceOfType<TargetInvocationException>(exception.InnerException);
         }
 
@@ -59,11 +59,11 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // With extension
             Assert.AreEqual(5, Contract.AssertCall(true));
-            Assert.AreEqual(1049400, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049400);
             AssertNoLogs();
 
             var ex = Assert.ThrowsException<TestException>(() => Contract.AssertCall(false));
-            Assert.AreEqual(1049370, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049370);
             AssertNoLogs();
             Assert.IsTrue(ex.Message.Contains("UT-ERROR-123"));
 
@@ -71,7 +71,7 @@ namespace Neo.SmartContract.Framework.UnitTests
 
             Engine.CallFlags &= ~CallFlags.AllowNotify;
             ex = Assert.ThrowsException<TestException>(() => Contract.AssertCall(false));
-            Assert.AreEqual(1049370, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049370);
             Engine.CallFlags = CallFlags.All;
             AssertNoLogs();
             Assert.IsTrue(ex.Message.Contains("UT-ERROR-123"));
@@ -79,74 +79,74 @@ namespace Neo.SmartContract.Framework.UnitTests
             // Void With extension
 
             Contract.VoidAssertCall(true);
-            Assert.AreEqual(1049130, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049130);
             AssertNoLogs();
 
             ex = Assert.ThrowsException<TestException>(() => Contract.VoidAssertCall(false));
-            Assert.AreEqual(1049130, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1049130);
         }
 
         [TestMethod]
         public void Test_ByteToByteArray()
         {
             CollectionAssert.AreEqual(new byte[] { 0x01 }, Contract.TestByteToByteArray());
-            Assert.AreEqual(1048770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1048770);
         }
 
         [TestMethod]
         public void Test_Reverse()
         {
             CollectionAssert.AreEqual(new byte[] { 0x03, 0x02, 0x01 }, Contract.TestReverse());
-            Assert.AreEqual(1478970, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1478970);
         }
 
         [TestMethod]
         public void Test_SbyteToByteArray()
         {
             CollectionAssert.AreEqual(new byte[] { 255 }, Contract.TestSbyteToByteArray());
-            Assert.AreEqual(1233060, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1233060);
         }
 
         [TestMethod]
         public void Test_StringToByteArray()
         {
             CollectionAssert.AreEqual("hello world"u8.ToArray(), Contract.TestStringToByteArray());
-            Assert.AreEqual(1233270, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1233270);
         }
 
         [TestMethod]
         public void Test_Concat()
         {
             CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 }, Contract.TestConcat());
-            Assert.AreEqual(1540830, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1540830);
         }
 
         [TestMethod]
         public void Test_Range()
         {
             CollectionAssert.AreEqual(new byte[] { 0x02 }, Contract.TestRange());
-            Assert.AreEqual(1294770, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1294770);
         }
 
         [TestMethod]
         public void Test_Take()
         {
             CollectionAssert.AreEqual(new byte[] { 0x01, 0x02 }, Contract.TestTake());
-            Assert.AreEqual(1294740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1294740);
         }
 
         [TestMethod]
         public void Test_Last()
         {
             CollectionAssert.AreEqual(new byte[] { 0x02, 0x03 }, Contract.TestLast());
-            Assert.AreEqual(1294740, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1294740);
         }
 
         [TestMethod]
         public void Test_ToScriptHash()
         {
             CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xaa, 0xbb, 0xcc, 0xdd, 0xee }, Contract.TestToScriptHash());
-            Assert.AreEqual(985170, Engine.FeeConsumed.Value);
+            AssertGasConsumed(985170);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/ListTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ListTest.cs
@@ -12,7 +12,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestCount()
         {
             Assert.AreEqual(4, Contract.TestCount(4));
-            Assert.AreEqual(2036100, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2036100);
         }
 
         [TestMethod]
@@ -34,7 +34,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestRemoveAt()
         {
             var item = Contract.TestRemoveAt(5, 2);
-            Assert.AreEqual(3389940, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3389940);
             var json = ParseJson(item);
 
             Assert.IsTrue(json is JArray);
@@ -50,7 +50,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestClear()
         {
             var item = Contract.TestClear(4);
-            Assert.AreEqual(3142470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3142470);
             var json = ParseJson(item);
 
             Assert.IsTrue(json is JArray);
@@ -62,7 +62,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestArrayConvert()
         {
             var array = Contract.TestArrayConvert(4)!;
-            Assert.AreEqual(2035980, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2035980);
             Assert.AreEqual(4, array.Count);
             for (int i = 0; i < 4; i++)
             {

--- a/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/MapTest.cs
@@ -14,7 +14,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestCount()
         {
             Assert.AreEqual(4, Contract.TestCount(4));
-            Assert.AreEqual(2036820, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2036820);
         }
 
         [TestMethod]
@@ -23,7 +23,7 @@ namespace Neo.SmartContract.Framework.UnitTests
             var key = System.Text.Encoding.ASCII.GetBytes("a");
             // Except: {"a":"teststring2"}
             Assert.AreEqual("7b2261223a2274657374737472696e6732227d", (Contract.TestByteArray(key) as ByteString)!.GetSpan().ToHexString());
-            Assert.AreEqual(2645550, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2645550);
         }
 
         [TestMethod]
@@ -32,7 +32,7 @@ namespace Neo.SmartContract.Framework.UnitTests
             var key = System.Text.Encoding.ASCII.GetBytes("a");
             // Except: {}
             Assert.AreEqual("7b7d", (Contract.TestClear(key) as ByteString)!.GetSpan().ToHexString());
-            Assert.AreEqual(2646090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2646090);
         }
 
         [TestMethod]
@@ -40,7 +40,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Except: {"\u0001\u0001":"\u0022\u0022"}
             Assert.AreEqual("{\"\\u0001\\u0001\":\"\\u0022\\u0022\"}", Contract.TestByteArray2());
-            Assert.AreEqual(3936330, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3936330);
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Except: {"\u4E2D":"129840test10022939"}
             Assert.AreEqual("{\"\\u4E2D\":\"129840test10022939\"}", Contract.TestUnicode("中"));
-            Assert.AreEqual(2399790, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2399790);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Except: {"ab":"\u6587"}
             Assert.AreEqual("{\"ab\":\"\\u6587\"}", Contract.TestUnicodeValue("文"));
-            Assert.AreEqual(2399790, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2399790);
         }
 
         [TestMethod]
@@ -64,7 +64,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Except: {"\u4E2D":"\u6587"}
             Assert.AreEqual("{\"\\u4E2D\":\"\\u6587\"}", Contract.TestUnicodeKeyValue("中", "文"));
-            Assert.AreEqual(2399850, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2399850);
         }
 
         [TestMethod]
@@ -72,7 +72,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Int cannot be used as the key for serializing Map
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestInt(1));
-            Assert.AreEqual(2399580, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2399580);
             Assert.IsInstanceOfType<TargetInvocationException>(exception.InnerException);
         }
 
@@ -81,7 +81,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // Bool cannot be used as the key for serializing Map
             var exception = Assert.ThrowsException<TestException>(() => Contract.TestBool(true));
-            Assert.AreEqual(2399580, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2399580);
             Assert.IsInstanceOfType<TargetInvocationException>(exception.InnerException);
         }
 
@@ -89,7 +89,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestDeserialize()
         {
             var item = Contract.TestDeserialize("a");
-            Assert.AreEqual(3874500, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3874500);
 
             Assert.IsInstanceOfType(item, typeof(Map));
             var map = item as Map;
@@ -102,7 +102,7 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestUInt160KeyDeserialize()
         {
             var item = Contract.Testuint160Key();
-            Assert.AreEqual(3813360, Engine.FeeConsumed.Value);
+            AssertGasConsumed(3813360);
 
             Assert.IsInstanceOfType(item, typeof(Map));
             var map = item as Map;

--- a/tests/Neo.SmartContract.Framework.UnitTests/RegexTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/RegexTest.cs
@@ -10,46 +10,46 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestStartWith()
         {
             Assert.IsTrue(Contract.TestStartWith());
-            Assert.AreEqual(1987890, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1987890);
         }
 
         [TestMethod]
         public void TestIndexOf()
         {
             Assert.AreEqual(4, Contract.TestIndexOf());
-            Assert.AreEqual(1986900, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1986900);
         }
 
         [TestMethod]
         public void TestEndWith()
         {
             Assert.IsTrue(Contract.TestEndWith());
-            Assert.AreEqual(1988760, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1988760);
         }
 
         [TestMethod]
         public void TestContains()
         {
             Assert.IsTrue(Contract.TestContains());
-            Assert.AreEqual(1987890, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1987890);
         }
 
         [TestMethod]
         public void TestNumberOnly()
         {
             Assert.IsTrue(Contract.TestNumberOnly());
-            Assert.AreEqual(1036470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1036470);
         }
 
         [TestMethod]
         public void TestAlphabetOnly()
         {
             Assert.IsTrue(Contract.TestAlphabetOnly());
-            Assert.AreEqual(1204290, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1204290);
             Assert.IsTrue(Contract.TestLowerAlphabetOnly());
-            Assert.AreEqual(1111470, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1111470);
             Assert.IsTrue(Contract.TestUpperAlphabetOnly());
-            Assert.AreEqual(1095090, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1095090);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/StringTest.cs
@@ -11,22 +11,22 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             // ab => 3
             Assert.AreEqual(3, Contract.TestStringAdd("a", "b"));
-            Assert.AreEqual(1357590, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1357590);
 
             // hello => 4
             Assert.AreEqual(4, Contract.TestStringAdd("he", "llo"));
-            Assert.AreEqual(1356540, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1356540);
 
             // world => 5
             Assert.AreEqual(5, Contract.TestStringAdd("wo", "rld"));
-            Assert.AreEqual(1357800, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1357800);
         }
 
         [TestMethod]
         public void TestStringAddInt()
         {
             Assert.AreEqual("Neo3", Contract.TestStringAddInt("Neo", 3));
-            Assert.AreEqual(2460480, Engine.FeeConsumed.Value);
+            AssertGasConsumed(2460480);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/UIntTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/UIntTest.cs
@@ -10,15 +10,15 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestStringAdd()
         {
             Assert.IsTrue(Contract.IsZeroUInt256(UInt256.Zero));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
             Assert.IsTrue(Contract.IsZeroUInt160(UInt160.Zero));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
             Assert.IsFalse(Contract.IsZeroUInt256(UInt256.Parse("0xa400ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01")));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
             Assert.IsFalse(Contract.IsZeroUInt160(UInt160.Parse("01ff00ff00ff00ff00ff00ff00ff00ff00ff00a4")));
-            Assert.AreEqual(1047510, Engine.FeeConsumed.Value);
+            AssertGasConsumed(1047510);
             Assert.AreEqual("Nas9CRigvY94DyqA59HiBZNrgWHRsgrUgt", Contract.ToAddress(UInt160.Parse("01ff00ff00ff00ff00ff00ff00ff00ff00ff00a4")));
-            Assert.AreEqual(4592490, Engine.FeeConsumed.Value);
+            AssertGasConsumed(4592490);
         }
     }
 }


### PR DESCRIPTION
@Hecate2 has said that adding the gas consume to the test will make it hard to update optimizer, and hard to debug while working on the pr task that will often change the gas. 

thus having this pr that add a global switch to gas consume test. pr that is not intent to focus on gas can turn off the gas test during the development and even in the pr, then  i can help to update the gas in later pr. 