### PR TITLE
fix nextBlock of BasicBlock; reduce false positives in re-entrnacy analysis

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/BasicBlock.cs
@@ -84,7 +84,11 @@ namespace Neo.Optimizer
                 BasicBlock thisBlock = new(startAddr, block);
                 basicBlocksByStartInstruction.Add(block.First(), thisBlock);
                 if (prevBlock != null)
-                    prevBlock.nextBlock = thisBlock;
+                {
+                    OpCode prevLastOpCode = prevBlock.instructions.Last().OpCode;
+                    if (!OpCodeTypes.unconditionalJump.Contains(prevLastOpCode) && prevLastOpCode != OpCode.RET)
+                        prevBlock.nextBlock = thisBlock;
+                }
                 prevBlock = thisBlock;
             }
             // handle jumps between blocks

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
@@ -45,10 +45,9 @@ namespace Neo.Compiler.SecurityAnalyzer
                 foreach ((BasicBlock callBlock, HashSet<BasicBlock> writeBlocks) in vulnerabilityPairs)
                 {
                     string additional = $"[SEC] Potential Re-entrancy: Calling contracts at instruction address: " +
-                        $"{string.Join(", ", callOtherContractInstructions[callBlock])} before writing storage\n";
-                    //    $"before writing storage at:\n";
-                    //foreach (BasicBlock writeBlock in writeBlocks)
-                    //    additional += $"\t{string.Join(", ", writeStorageInstructions[writeBlock])}\n";
+                        $"{string.Join(", ", callOtherContractInstructions[callBlock])} before writing storage at\n";
+                    foreach (BasicBlock writeBlock in writeBlocks)
+                        additional += $"\t{string.Join(", ", writeStorageInstructions[writeBlock])}\n";
                     if (print)
                         Console.Write(additional);
                     result += additional;


### PR DESCRIPTION
This does not affect any compilation or optimization, but reduces false positives in reentrancy analysis. 
If a basic block ends with JMP or JMP_L or RET, it never reaches the following block by normal execution, and the nextBlock property should be remained `null`.