### PR TITLE
only enable static property to have stored attribute

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
@@ -132,10 +132,10 @@ internal partial class MethodConvert
                 // Ensure that no object was sent
                 Jump(OpCode.JMPIFNOT_L, endTarget);
             }
-            else if (NeedInstanceConstructor(Symbol))
+            else
             {
-                // Check class
-                Jump(OpCode.JMPIF_L, endTarget);
+                throw new CompilationException(property, DiagnosticId.SyntaxNotSupported,
+                    $"Store backed property must be static: {property.Name}");
             }
             Push(key);
             CallInteropMethod(ApplicationEngine.System_Storage_GetReadOnlyContext);
@@ -190,24 +190,22 @@ internal partial class MethodConvert
                 byte backingFieldIndex = _context.AddStaticField(backingField);
                 AccessSlot(OpCode.STSFLD, backingFieldIndex);
             }
-            else if (NeedInstanceConstructor(Symbol))
+            else
             {
-                AddInstruction(OpCode.DUP);
-                fields = fields.Where(p => !p.IsStatic).ToArray();
-                int backingFieldIndex = Array.FindIndex(fields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property));
-                AccessSlot(OpCode.LDARG, 0);
-                Push(backingFieldIndex);
-                AddInstruction(OpCode.ROT);
-                AddInstruction(OpCode.SETITEM);
+                throw new CompilationException(property, DiagnosticId.SyntaxNotSupported,
+                    $"Store backed property must be static: {property.Name}");
             }
             endTarget.Instruction = AddInstruction(OpCode.NOP);
         }
         else
         {
-            if (Symbol.IsStatic || !NeedInstanceConstructor(Symbol))
+            if (Symbol.IsStatic)
                 AccessSlot(OpCode.LDARG, 0);
             else
-                AccessSlot(OpCode.LDARG, 1);
+            {
+                throw new CompilationException(property, DiagnosticId.SyntaxNotSupported,
+                    $"Store backed property must be static: {property.Name}");
+            }
             switch (property.Type.Name)
             {
                 case "byte":

--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -26,3 +26,4 @@
 | NC4024  | Usage    | Error    | MultipleCatchBlockAnalyzer                 |
 | NC4025  | Method   | Error    | EnumMethodsUsageAnalyzer                   |
 | NC4026  | Usage    | Error    | SystemDiagnosticsUsageAnalyzer             |
+| NC4028  | Usage    | Error    | StoredPropertyAnalyzer                     |

--- a/src/Neo.SmartContract.Analyzer/Readme.md
+++ b/src/Neo.SmartContract.Analyzer/Readme.md
@@ -28,7 +28,7 @@ This repository contains a set of Roslyn analyzers and code fix providers for Ne
 - [StaticFieldInitializationAnalyzer.cs](NeoContractAnalyzer/StaticFieldInitializationAnalyzer.cs): This analyzer checks for proper initialization of static fields in smart contracts.
 - [MultipleCatchBlockAnalyzer.cs](NeoContractAnalyzer/MultipleCatchBlockAnalyzer.cs): This analyzer checks for multiple catch blocks in try statements.
 - [SystemDiagnosticsUsageAnalyzer.cs](NeoContractAnalyzer/SystemDiagnosticsUsageAnalyzer.cs): This analyzer detects and reports usage of System.Diagnostics namespace, which is not supported in Neo smart contracts.
-
+- [StoredPropertyAnalyzer.cs](NeoContractAnalyzer/StoredPropertyAnalyzer.cs): This analyzer checks for correct usage of StoredAttribute.
 ## How to Use
 
 To use these analyzers in your Neo smart contract project:

--- a/src/Neo.SmartContract.Analyzer/StoredPropertyAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StoredPropertyAnalyzer.cs
@@ -1,0 +1,124 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Neo.SmartContract.Analyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class StoredPropertyAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "NC4028";
+        private const string Category = "Usage";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            "Invalid StoredAttribute usage",
+            "{0}",
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "StoredAttribute can only be applied to static properties.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.Attribute);
+        }
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var attributeSyntax = (AttributeSyntax)context.Node;
+
+            // Check if it's a StoredAttribute
+            var attributeName = attributeSyntax.Name.ToString();
+            if (!attributeName.Contains("Stored"))
+                return;
+
+            // Get the parent property declaration
+            var propertyDecl = attributeSyntax.Parent?.Parent as PropertyDeclarationSyntax;
+            if (propertyDecl == null)
+            {
+                // Attribute is not on a property
+                var diagnostic = Diagnostic.Create(Rule, attributeSyntax.GetLocation(),
+                    "StoredAttribute can only be applied to properties.");
+                context.ReportDiagnostic(diagnostic);
+                return;
+            }
+
+            // Check if the property is static
+            if (!propertyDecl.Modifiers.Any(SyntaxKind.StaticKeyword))
+            {
+                var diagnostic = Diagnostic.Create(Rule, attributeSyntax.GetLocation(),
+                    "StoredAttribute can only be applied to static properties.");
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StoredPropertyCodeFixProvider)), Shared]
+    public class StoredPropertyCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(StoredPropertyAnalyzer.DiagnosticId);
+
+        public sealed override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var attribute = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<AttributeSyntax>().First();
+            var propertyDecl = attribute.Parent?.Parent as PropertyDeclarationSyntax;
+
+            if (propertyDecl == null)
+            {
+                // If attribute is not on a property, offer to remove it
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: "Remove StoredAttribute",
+                        createChangedDocument: c => RemoveAttributeAsync(context.Document, attribute, c),
+                        equivalenceKey: "RemoveStoredAttribute"),
+                    diagnostic);
+            }
+            else if (!propertyDecl.Modifiers.Any(SyntaxKind.StaticKeyword))
+            {
+                // If property is not static, offer to make it static
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: "Make property static",
+                        createChangedDocument: c => MakePropertyStaticAsync(context.Document, propertyDecl, c),
+                        equivalenceKey: "MakePropertyStatic"),
+                    diagnostic);
+            }
+        }
+
+        private async Task<Document> RemoveAttributeAsync(Document document, AttributeSyntax attribute, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = root.RemoveNode(attribute.Parent, SyntaxRemoveOptions.KeepNoTrivia);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Document> MakePropertyStaticAsync(Document document, PropertyDeclarationSyntax propertyDecl, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newProperty = propertyDecl.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+            var newRoot = root.ReplaceNode(propertyDecl, newProperty);
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Stored.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Stored.cs
@@ -8,15 +8,15 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
         // Test non-static
 
         [Stored]
-        public BigInteger WithoutConstructor { [Safe] get; protected set; }
+        public static BigInteger WithoutConstructor { [Safe] get; protected set; }
 
-        public void putWithoutConstructor(BigInteger value)
+        public static void putWithoutConstructor(BigInteger value)
         {
             WithoutConstructor = value;
         }
 
         [Safe]
-        public BigInteger getWithoutConstructor() => WithoutConstructor;
+        public static BigInteger getWithoutConstructor() => WithoutConstructor;
 
         // ---
 
@@ -53,9 +53,9 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 
 
         [Stored]
-        public BigInteger NonStaticPrivateGetterPublicSetter { [Safe] private get; set; }
+        public static BigInteger NonStaticPrivateGetterPublicSetter { [Safe] private get; set; }
 
         [Safe]
-        public BigInteger getNonStaticPrivateGetterPublicSetter() => NonStaticPrivateGetterPublicSetter;
+        public static BigInteger getNonStaticPrivateGetterPublicSetter() => NonStaticPrivateGetterPublicSetter;
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Stored.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Stored.cs
@@ -10,12 +10,12 @@ public abstract class Contract_Stored(Neo.SmartContract.Testing.SmartContractIni
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Stored"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""withoutConstructor"",""parameters"":[],""returntype"":""Integer"",""offset"":0,""safe"":true},{""name"":""putWithoutConstructor"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":72,""safe"":false},{""name"":""getWithoutConstructor"",""parameters"":[],""returntype"":""Integer"",""offset"":81,""safe"":true},{""name"":""withKey"",""parameters"":[],""returntype"":""Integer"",""offset"":84,""safe"":true},{""name"":""putWithKey"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":130,""safe"":false},{""name"":""getWithKey"",""parameters"":[],""returntype"":""Integer"",""offset"":139,""safe"":true},{""name"":""withString"",""parameters"":[],""returntype"":""Integer"",""offset"":142,""safe"":true},{""name"":""putWithString"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":198,""safe"":false},{""name"":""getWithString"",""parameters"":[],""returntype"":""Integer"",""offset"":207,""safe"":true},{""name"":""setPrivateGetterPublicSetter"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":260,""safe"":false},{""name"":""getPrivateGetterPublicSetter"",""parameters"":[],""returntype"":""Integer"",""offset"":304,""safe"":true},{""name"":""setNonStaticPrivateGetterPublicSetter"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":360,""safe"":false},{""name"":""getNonStaticPrivateGetterPublicSetter"",""parameters"":[],""returntype"":""Integer"",""offset"":411,""safe"":true},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":414,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Stored"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""withoutConstructor"",""parameters"":[],""returntype"":""Integer"",""offset"":0,""safe"":true},{""name"":""putWithoutConstructor"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":80,""safe"":false},{""name"":""getWithoutConstructor"",""parameters"":[],""returntype"":""Integer"",""offset"":89,""safe"":true},{""name"":""withKey"",""parameters"":[],""returntype"":""Integer"",""offset"":92,""safe"":true},{""name"":""putWithKey"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":138,""safe"":false},{""name"":""getWithKey"",""parameters"":[],""returntype"":""Integer"",""offset"":147,""safe"":true},{""name"":""withString"",""parameters"":[],""returntype"":""Integer"",""offset"":150,""safe"":true},{""name"":""putWithString"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":206,""safe"":false},{""name"":""getWithString"",""parameters"":[],""returntype"":""Integer"",""offset"":215,""safe"":true},{""name"":""setPrivateGetterPublicSetter"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":268,""safe"":false},{""name"":""getPrivateGetterPublicSetter"",""parameters"":[],""returntype"":""Integer"",""offset"":312,""safe"":true},{""name"":""setNonStaticPrivateGetterPublicSetter"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Void"",""offset"":374,""safe"":false},{""name"":""getNonStaticPrivateGetterPublicSetter"",""parameters"":[],""returntype"":""Integer"",""offset"":427,""safe"":true},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":430,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Neo.IO.Helper.AsSerializable<Neo.SmartContract.NefFile>(Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2hAQwSV2l0aG91dENvbnN0cnVjdG9yQfa0a+JBkl3oMUrYJgRFEEBXAAF4DBJXaXRob3V0Q29uc3RydWN0b3JBm/ZnzkHmPxiEQFcAAXhKNNhFQDSvQFjYJhcMAQFB9rRr4kGSXegxStgmBEUQSmBAVwABeGB4DAEBQZv2Z85B5j8YhEBXAAF4SjTnRUA0yUBZ2CYcDAZ0ZXN0TWVB9rRr4kGSXegxStgmBEUQSmFAVwABeGF4DAZ0ZXN0TWVBm/ZnzkHmPxiEQFcAAXhKNOJFQDS/QFrYJi8MGVByaXZhdGVHZXR0ZXJQdWJsaWNTZXR0ZXJB9rRr4kGSXegxStgmBEUQSmJAVwABeGJ4DBlQcml2YXRlR2V0dGVyUHVibGljU2V0dGVyQZv2Z85B5j8YhEA0okAMIk5vblN0YXRpY1ByaXZhdGVHZXR0ZXJQdWJsaWNTZXR0ZXJB9rRr4kGSXegxStgmBEUQQFcAAXgMIk5vblN0YXRpY1ByaXZhdGVHZXR0ZXJQdWJsaWNTZXR0ZXJBm/ZnzkHmPxiEQDSYQFYDQEp0AoE="));
+    public static Neo.SmartContract.NefFile Nef => Neo.IO.Helper.AsSerializable<Neo.SmartContract.NefFile>(Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2xAVjYJigMEldpdGhvdXRDb25zdHJ1Y3RvckH2tGviQZJd6DFK2CYERRBKYEBXAAF4YHgMEldpdGhvdXRDb25zdHJ1Y3RvckGb9mfOQeY/GIRAVwABeEo01kVANKdAWdgmFwwBAUH2tGviQZJd6DFK2CYERRBKYUBXAAF4YXgMAQFBm/ZnzkHmPxiEQFcAAXhKNOdFQDTJQFrYJhwMBnRlc3RNZUH2tGviQZJd6DFK2CYERRBKYkBXAAF4YngMBnRlc3RNZUGb9mfOQeY/GIRAVwABeEo04kVANL9AW9gmLwwZUHJpdmF0ZUdldHRlclB1YmxpY1NldHRlckH2tGviQZJd6DFK2CYERRBKY0BXAAF4Y3gMGVByaXZhdGVHZXR0ZXJQdWJsaWNTZXR0ZXJBm/ZnzkHmPxiEQDSiQFzYJjgMIk5vblN0YXRpY1ByaXZhdGVHZXR0ZXJQdWJsaWNTZXR0ZXJB9rRr4kGSXegxStgmBEUQSmRAVwABeGR4DCJOb25TdGF0aWNQcml2YXRlR2V0dGVyUHVibGljU2V0dGVyQZv2Z85B5j8YhEA0kEBWBUCpJ7GT"));
 
     #endregion
 
@@ -65,8 +65,8 @@ public abstract class Contract_Stored(Neo.SmartContract.Testing.SmartContractIni
     /// Safe method
     /// </summary>
     /// <remarks>
-    /// Script: NK9A
-    /// 00 : CALL AF [512 datoshi]
+    /// Script: NKdA
+    /// 00 : CALL A7 [512 datoshi]
     /// 02 : RET [0 datoshi]
     /// </remarks>
     [DisplayName("getWithoutConstructor")]
@@ -106,11 +106,11 @@ public abstract class Contract_Stored(Neo.SmartContract.Testing.SmartContractIni
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeEo02EVA
+    /// Script: VwABeEo01kVA
     /// 00 : INITSLOT 0001 [64 datoshi]
     /// 03 : LDARG0 [2 datoshi]
     /// 04 : DUP [2 datoshi]
-    /// 05 : CALL D8 [512 datoshi]
+    /// 05 : CALL D6 [512 datoshi]
     /// 07 : DROP [2 datoshi]
     /// 08 : RET [0 datoshi]
     /// </remarks>


### PR DESCRIPTION
This pr sets limitation on StoredAttribute, only allow static property to have it. This makes it easier to compile and avoid mistakes. 