### PR TITLE
use ConcurrentDictionary for Parallel.ForEach

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
@@ -12,6 +12,7 @@ extern alias scfx;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Neo.VM;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -144,7 +145,7 @@ internal partial class MethodConvert
         return false;
     }
 
-    internal static Dictionary<IMethodSymbol, bool> _cacheNeedInstanceConstructor = new Dictionary<IMethodSymbol, bool>(SymbolEqualityComparer.Default);
+    internal static ConcurrentDictionary<IMethodSymbol, bool> _cacheNeedInstanceConstructor = new ConcurrentDictionary<IMethodSymbol, bool>(SymbolEqualityComparer.Default);
 
     /// <summary>
     /// non-static methods needs constructors to be executed


### PR DESCRIPTION
May fail in large contracts if not fixed.
```
System.InvalidOperationException
  HResult=0x80131509
  Message=Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
  Source=System.Private.CoreLib
  StackTrace:
   at System.ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported() in System\ThrowHelper.cs:line 450
```