### PR TITLE
Fix some compiler warnings in `MethodConvert`

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
@@ -20,7 +20,6 @@ namespace Neo.Compiler;
 
 internal partial class MethodConvert
 {
-
     private static IModuleSymbol GetSymbolMetadataModule(ISymbol symbol, string symbolInfo)
     {
         var metadata = symbol.Locations.FirstOrDefault()?.MetadataModule;
@@ -613,8 +612,7 @@ internal partial class MethodConvert
         var enumMembers = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>()
             .Where(field => field is { HasConstantValue: true, IsImplicitlyDeclared: false }).ToArray();
 
-        var argument = arguments[1] as ArgumentSyntax;
-        if (argument is null) // unexpected case
+        if (arguments[1] is not ArgumentSyntax argument) // unexpected case
             throw new CompilationException(arguments[1], DiagnosticId.InvalidArgument, "Invalid second argument");
 
         var valueType = model.GetTypeInfo(argument.Expression).Type;

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
@@ -14,13 +14,21 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Neo.SmartContract.Native;
 using Neo.VM;
 
 namespace Neo.Compiler;
 
 internal partial class MethodConvert
 {
+
+    private static IModuleSymbol GetSymbolMetadataModule(ISymbol symbol, string symbolInfo)
+    {
+        var metadata = symbol.Locations.FirstOrDefault()?.MetadataModule;
+        if (metadata is null)
+            throw new CompilationException(symbol, DiagnosticId.InvalidArgument, $"Unexpected symbol location metadata module for {symbolInfo}");
+        return metadata;
+    }
+
     private static void HandleEnumParse(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
@@ -33,7 +41,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -45,7 +53,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.Parse requires at least two arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.Parse"), DiagnosticId.InvalidArgument, "Enum.Parse requires at least two arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -100,7 +108,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -112,7 +120,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.Parse requires at least two arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.Parse"), DiagnosticId.InvalidArgument, "Enum.Parse requires at least two arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -178,7 +186,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 2 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -190,7 +198,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.TryParse requires at least three arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.TryParse"), DiagnosticId.InvalidArgument, "Enum.TryParse requires at least three arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -269,7 +277,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -281,7 +289,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.IsDefined requires at least two arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.IsDefined"), DiagnosticId.InvalidArgument, "Enum.IsDefined requires at least two arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -327,7 +335,7 @@ internal partial class MethodConvert
 
         if (enumType is not INamedTypeSymbol enumTypeSymbol)
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidType, "Unable to determine enum type");
+            throw new CompilationException(symbol.Locations.FirstOrDefault()!.MetadataModule!, DiagnosticId.InvalidType, "Unable to determine enum type");
         }
 
         var enumMembers = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>()
@@ -367,7 +375,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -379,7 +387,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.GetName requires at least two arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.GetName"), DiagnosticId.InvalidArgument, "Enum.GetName requires at least two arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -427,7 +435,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -439,7 +447,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.TryParse requires at least three arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.TryParse"), DiagnosticId.InvalidArgument, "Enum.TryParse requires at least three arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -494,7 +502,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -506,7 +514,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.GetNames requires one argument");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.GetNames"), DiagnosticId.InvalidArgument, "Enum.GetNames requires one argument");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -538,7 +546,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -550,7 +558,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.GetValues requires one argument");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.GetValues"), DiagnosticId.InvalidArgument, "Enum.GetValues requires one argument");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -582,7 +590,7 @@ internal partial class MethodConvert
         ITypeSymbol? enumTypeSymbol = null;
         if (arguments is { Count: > 0 })
         {
-            if ((arguments[0] as ArgumentSyntax).Expression is TypeOfExpressionSyntax typeOfExpression)
+            if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
                 var typeInfo = model.GetTypeInfo(typeOfExpression.Type);
                 enumTypeSymbol = typeInfo.Type;
@@ -594,7 +602,7 @@ internal partial class MethodConvert
         }
         else
         {
-            throw new CompilationException(symbol.Locations.FirstOrDefault().MetadataModule, DiagnosticId.InvalidArgument, "Enum.IsDefined requires at least two arguments");
+            throw new CompilationException(GetSymbolMetadataModule(symbol, "Enum.IsDefined"), DiagnosticId.InvalidArgument, "Enum.IsDefined requires at least two arguments");
         }
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
@@ -605,7 +613,11 @@ internal partial class MethodConvert
         var enumMembers = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>()
             .Where(field => field is { HasConstantValue: true, IsImplicitlyDeclared: false }).ToArray();
 
-        var valueType = model.GetTypeInfo((arguments[1] as ArgumentSyntax)?.Expression).Type;
+        var argument = arguments[1] as ArgumentSyntax;
+        if (argument is null) // unexpected case
+            throw new CompilationException(arguments[1], DiagnosticId.InvalidArgument, "Invalid second argument");
+
+        var valueType = model.GetTypeInfo(argument.Expression).Type;
 
         // We need to compare the input value against the enum values
         var endLabel = new JumpTarget();

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
@@ -1,6 +1,14 @@
+// Copyright (C) 2015-2024 The Neo Project.
+//
+// The Neo.Compiler.CSharp is free software distributed under the MIT
+// software license, see the accompanying file LICENSE in the main directory
+// of the project or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Numerics;
 
 namespace Neo.Compiler;
@@ -600,7 +608,9 @@ internal partial class MethodConvert
     private static void RegisterObjectHandlers()
     {
         // Existing object handlers
+#pragma warning disable CS8602
         RegisterHandler((object? x, object? y) => x.Equals(y), HandleObjectEquals);
+#pragma warning restore CS8602
     }
 
     private static void RegisterCharHandlers()
@@ -663,6 +673,7 @@ internal partial class MethodConvert
         #endregion GetValueOrDefault
 
         // Nullable Value methods
+#pragma warning disable CS8629
         #region Value
         RegisterHandler((byte? x) => x.Value, HandleNullableByteValue);
         RegisterHandler((sbyte? x) => x.Value, HandleNullableSByteValue);
@@ -676,6 +687,7 @@ internal partial class MethodConvert
         RegisterHandler((long? x) => x.Value, HandleNullableLongValue);
         RegisterHandler((bool? x) => x.Value, HandleNullableBoolValue);
         #endregion Value
+#pragma warning restore CS8629
 
         // Nullable ToString() methods
         #region ToString()
@@ -755,8 +767,12 @@ internal partial class MethodConvert
     {
         RegisterHandler((Type enumType, string value) => Enum.Parse(enumType, value), HandleEnumParse);
         RegisterHandler((Type enumType, string value, bool ignoreCase) => Enum.Parse(enumType, value, ignoreCase), HandleEnumParseIgnoreCase);
+
+#pragma warning disable CS8600
         RegisterHandler((Type enumType, string value, object result) => Enum.TryParse(enumType, value, out result), HandleEnumTryParse);
         RegisterHandler((Type enumType, string value, bool ignoreCase, object result) => Enum.TryParse(enumType, value, ignoreCase, out result), HandleEnumTryParseIgnoreCase);
+#pragma warning restore CS8600
+
         RegisterHandler((Type enumType) => Enum.GetNames(enumType), HandleEnumGetNames);
         RegisterHandler((Type enumType) => Enum.GetValues(enumType), HandleEnumGetValues);
         RegisterHandler((Type enumType, object value) => Enum.IsDefined(enumType, value), HandleEnumIsDefined);


### PR DESCRIPTION

Explicitly handle several `null` problems to reduce compiler warnings.
And remove several unnecessary compiler warnings by disabling these.