### PR TITLE
Revert change from #1214

### DIFF
--- a/src/Neo.SmartContract.Framework/TokenContract.cs
+++ b/src/Neo.SmartContract.Framework/TokenContract.cs
@@ -43,7 +43,7 @@ namespace Neo.SmartContract.Framework
             balance += increment;
             if (balance < 0)
                 return false;
-            if (Helper.NumEqual(balance, 0))
+            if (balance.IsZero)
                 balanceMap.Delete(owner);
             else
                 balanceMap.Put(owner, balance);


### PR DESCRIPTION
We already optimize this call as `NumEqual`, it's cleaner

```diff
 private static void RegisterBigIntegerHandlers()
 {
     // Existing BigInteger handlers
     RegisterHandler(() => BigInteger.One, HandleBigIntegerOne);
     RegisterHandler(() => BigInteger.MinusOne, HandleBigIntegerMinusOne);
     RegisterHandler(() => BigInteger.Zero, HandleBigIntegerZero);
+    RegisterHandler((BigInteger b) => b.IsZero, HandleBigIntegerIsZero);
     RegisterHandler((BigInteger b) => b.IsOne, HandleBigIntegerIsOne);
     RegisterHandler((BigInteger b) => b.IsEven, HandleBigIntegerIsEven);
     RegisterHandler((BigInteger b) => b.Sign, HandleBigIntegerSign);
```

```csharp
   private static void HandleBigIntegerIsZero(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
   {
       if (instanceExpression is not null)
           methodConvert.ConvertExpression(model, instanceExpression);
       methodConvert.Push(0);
       methodConvert.AddInstruction(OpCode.NUMEQUAL);
   }
```