### PR TITLE
[`Fix`] warning AD0001: Analyzer `Neo.SmartContract.Analyzer.CollectionTypesUsageAnalyzer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,9 @@ paket-files/
 .idea/
 *.sln.iml
 /src/Neo.Compiler.MSIL/Properties/launchSettings.json
+
+# VSCode
+.vscode/
+
+# MacOS
+**/.DS_Store

--- a/tests/Neo.Compiler.CSharp.TestContracts/Neo.Compiler.CSharp.TestContracts.csproj
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Neo.Compiler.CSharp.TestContracts.csproj
@@ -4,6 +4,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<DisableImplicitAspNetCoreAnalyzers>true</DisableImplicitAspNetCoreAnalyzers>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<DisableImplicitAspNetCoreAnalyzers>true</DisableImplicitAspNetCoreAnalyzers>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION

There are so many compiler warnings
> 679 Warning(s)
    0 Error(s)

Such as:
> CSC : warning AD0001: Analyzer 'Neo.SmartContract.Analyzer.CollectionTypesUsageAnalyzer' threw an exception of type 'System.IO.FileNotFoundException' with message 'Could not load file or assembly 'xunit.assert, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c'. The system cannot find the file specified.

Similar issue from here [DisableImplicitAspNetCoreAnalyzers](https://github.com/dotnet/aspnetcore/issues/14723)
