### PR TITLE
[`Fix`]: warning AD0001 on `dotnet build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,9 @@ paket-files/
 .idea/
 *.sln.iml
 /src/Neo.Compiler.MSIL/Properties/launchSettings.json
+
+# VSCode
+.vscode/
+
+# MacOS
+**/.DS_Store

--- a/src/Neo.SmartContract.Analyzer/Neo.SmartContract.Analyzer.csproj
+++ b/src/Neo.SmartContract.Analyzer/Neo.SmartContract.Analyzer.csproj
@@ -21,9 +21,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">


### PR DESCRIPTION
There are so many compiler warnings, such as:
> CSC : warning AD0001: Analyzer 'Neo.SmartContract.Analyzer.CollectionTypesUsageAnalyzer' threw an exception of type 'System.IO.FileNotFoundException' with message 'Could not load file or assembly 'xunit.assert, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c'. The system cannot find the file specified.

And I found that after upgrading some dependencies, some warnings disappeared.