### PR TITLE
Disable/Fix some tests warnings

### DIFF
--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Array.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Array.cs
@@ -8,7 +8,7 @@ namespace Neo.Compiler.CSharp.TestContracts
 {
     internal struct State
     {
-        public byte[] from = default;
+        public byte[]? from = default;
         public byte[] to = null!;
         public BigInteger amount = default;
         public State()
@@ -159,7 +159,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             var a = Ledger.GetBlock(0);
             var array = new[] { a };
             var firstItem = array?[0];
-            Runtime.Log(firstItem?.Timestamp.ToString());
+            Runtime.Log(firstItem?.Timestamp.ToString()!);
         }
 
         // This is new language feature introduced in C# 12

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Default.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Default.cs
@@ -64,6 +64,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             return a;
         }
 
+#pragma warning disable CS8600,CS8603
         public static string TestStringDefault()
         {
             string a = default;
@@ -75,6 +76,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             object a = default;
             return a;
         }
+#pragma warning restore CS8600,CS8603
 
         public static BigInteger TestBigIntegerDefault()
         {
@@ -93,11 +95,13 @@ namespace Neo.Compiler.CSharp.TestContracts
             public int Value;
         }
 
+#pragma warning disable CS8600,CS8603
         public static TestClass TestClassDefault()
         {
             TestClass a = default;
             return a;
         }
+#pragma warning restore CS8600,CS8603
 
         public class TestClass
         {

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Enum.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Enum.cs
@@ -23,6 +23,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             return System.Enum.Parse(typeof(TestEnum), value, ignoreCase);
         }
 
+#pragma warning disable CS8600
         public static bool TestEnumTryParse(string value)
         {
             return System.Enum.TryParse(typeof(TestEnum), value, out object result);
@@ -32,6 +33,7 @@ namespace Neo.Compiler.CSharp.TestContracts
         {
             return System.Enum.TryParse(typeof(TestEnum), value, ignoreCase, out object result);
         }
+#pragma warning restore CS8600
 
         public static string[] TestEnumGetNames()
         {
@@ -53,6 +55,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             return System.Enum.IsDefined(typeof(TestEnum), name);
         }
 
+#pragma warning disable CS8603
         public static string TestEnumGetName(TestEnum value)
         {
             return System.Enum.GetName(value);
@@ -62,5 +65,6 @@ namespace Neo.Compiler.CSharp.TestContracts
         {
             return System.Enum.GetName(typeof(TestEnum), value);
         }
+#pragma warning restore CS8603
     }
 }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Foreach.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Foreach.cs
@@ -190,7 +190,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             var tokens = new StorageMap(Storage.CurrentContext, 3).Find(FindOptions.KeysOnly | FindOptions.RemovePrefix);
             foreach (var item in tokens)
             {
-                Runtime.Log(item.ToString());
+                Runtime.Log(item.ToString()!);
             }
         }
 

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_PropertyMethod.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_PropertyMethod.cs
@@ -51,6 +51,7 @@ public class Contract_PropertyMethod : SmartContract.Framework.SmartContract
         public int Age { get; }
         public string Address { get; init; }
 
+#pragma warning disable CS8618
         public Person(string name, int age)
         {
             Name = name;
@@ -60,5 +61,6 @@ public class Contract_PropertyMethod : SmartContract.Framework.SmartContract
         public Person()
         {
         }
+#pragma warning restore CS8618
     }
 }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_Reentrancy.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_Reentrancy.cs
@@ -5,6 +5,7 @@ using Neo.SmartContract.Framework.Services;
 
 namespace Neo.Compiler.CSharp.TestContracts
 {
+#pragma warning disable CS8625
     public class Contract_Reentrancy : SmartContract.Framework.SmartContract
     {
         public static void HasReentrancy()
@@ -50,5 +51,6 @@ namespace Neo.Compiler.CSharp.TestContracts
         {
             HasReentrancyFromSingleBasicBlock();
         }
+#pragma warning restore CS8625
     }
 }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_StaticByteArray.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_StaticByteArray.cs
@@ -6,9 +6,9 @@ namespace Neo.Compiler.CSharp.TestContracts
     public class Contract_StaticByteArray : SmartContract.Framework.SmartContract
     {
         [DisplayName("TestEvent")]
-#pragma warning disable CS0067 // Event is never used
+#pragma warning disable CS0067, CS0414 // Event is never used
         public static event Action<byte[]> OnEvent = default!;
-#pragma warning restore CS0067 // Event is never used
+#pragma warning restore CS0067, CS0414 // Event is never used
 
         static byte[] NeoToken = new byte[] { 0x89, 0x77, 0x20, 0xd8, 0xcd, 0x76, 0xf4, 0xf0, 0x0a, 0xbf, 0xa3, 0x7c, 0x0e, 0xdd, 0x88, 0x9c, 0x20, 0x8f, 0xde, 0x9b };
 

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Types.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Types.cs
@@ -98,9 +98,11 @@ namespace Neo.Compiler.CSharp.TestContracts
             return Contract.Call(scriptHash, method, flag, args);
         }
 
+#pragma warning disable CS8625
         public static object Create(byte[] nef, string manifest)
         {
             return ContractManagement.Deploy((ByteString)nef, manifest, null);
         }
+#pragma warning restore CS8625
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<NoWarn>CS0067;CS8981</NoWarn> <!-- disable CS0067(event is never used) -->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Contract.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Contract.cs
@@ -12,10 +12,12 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return Contract.Call(scriptHash, method, flag, args);
         }
 
+#pragma warning disable CS8625
         public static object Create(byte[] nef, string manifest)
         {
             return ContractManagement.Deploy((ByteString)nef, manifest, null);
         }
+#pragma warning restore CS8625
 
         public static int GetCallFlags()
         {

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Create.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Create.cs
@@ -24,10 +24,12 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return iter.Value.Item2;
         }
 
+#pragma warning disable CS8625
         public static void Update(byte[] nef, string manifest)
         {
             ContractManagement.Update((ByteString)nef, manifest, null);
         }
+#pragma warning restore CS8625
 
         public static void Destroy()
         {

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Native.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Native.cs
@@ -12,11 +12,13 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return NEO.Decimals;
         }
 
+#pragma warning disable CS8625
         [DisplayName("NEO_Transfer")]
         public static bool NEO_Transfer(UInt160 from, UInt160 to, BigInteger amount)
         {
             return NEO.Transfer(from, to, amount, null);
         }
+#pragma warning restore CS8625
 
         [DisplayName("NEO_BalanceOf")]
         public static BigInteger NEO_BalanceOf(UInt160 account)

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Nullable.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Nullable.cs
@@ -21,6 +21,7 @@ namespace Neo.SmartContract.Framework.TestContracts
             return a == null && !a.HasValue;
         }
 
+#pragma warning disable CS8602
         public static bool H160NullableNotEqual(UInt160 a, UInt160? b)
         {
             return a != b && !a.Equals(b) && !b.Equals(a) && b != a;
@@ -35,6 +36,7 @@ namespace Neo.SmartContract.Framework.TestContracts
         {
             return a != b && !a.Equals(b) && !b.Equals(a) && b != a;
         }
+#pragma warning restore CS8602
 
         public static bool H256NullableEqual(UInt256 a, UInt256? b)
         {

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_StaticStorageMap.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_StaticStorageMap.cs
@@ -13,6 +13,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             Data.Put(message, 1);
         }
 
+#pragma warning disable CS8604
         public static BigInteger Get(string msg)
         {
             return (BigInteger)Data.Get(msg);
@@ -51,5 +52,6 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             var store = new StorageMap(Storage.CurrentContext, x);
             return (BigInteger)store.Get("test1");
         }
+#pragma warning restore CS8604
     }
 }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Storage.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Storage.cs
@@ -67,7 +67,6 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return (byte[])value;
         }
 
-
         #endregion
 
         #region ByteArray

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Storage.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Storage.cs
@@ -2,6 +2,8 @@ using Neo.SmartContract.Framework.Services;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
+
+#pragma warning disable CS8604
     public class Contract_Storage : SmartContract
     {
         // There is no main here, it can be auto generation.
@@ -64,6 +66,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             var value = storage.Get((ByteString)key);
             return (byte[])value;
         }
+
 
         #endregion
 
@@ -177,7 +180,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             var storage = new StorageMap(context, prefix);
             var val = new Value() { Val = value };
             storage.PutObject(key, val);
-            val = (Value)storage.GetObject(key);
+            val = (Value)storage.GetObject(key)!;
             return val.Val;
         }
 
@@ -218,4 +221,5 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 
         #endregion
     }
+#pragma warning restore CS8604
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<NoWarn>CS0067</NoWarn> <!-- disable CS0067(event is never used) -->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Neo.SmartContract.Template.UnitTests/Neo.SmartContract.Template.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Template.UnitTests/Neo.SmartContract.Template.UnitTests.csproj
@@ -6,6 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<NoWarn>CS0067</NoWarn> <!-- disable CS0067(event is never used) -->
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fix some  noisy  compiler warnings in /tests. 
Generally just disable these warnings one by one(try not to affect any warnings that may be added and not to affect existing test cases)
