### PR TITLE
cover ConvertNonConstantByteArray

### DIFF
--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_ByteArrayAssignment.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_ByteArrayAssignment.cs
@@ -36,7 +36,7 @@ namespace Neo.Compiler.CSharp.TestContracts
 
         public static byte[] testAssignmentDynamic(byte x)
         {
-            byte[] result = new byte[] { 0x01, x };
+            byte[] result = [0x01, x];
             return result;
         }
     }


### PR DESCRIPTION
Simply cover more compiler codes in tests. I was going to cover more, but we have to solve https://github.com/neo-project/neo-devpack-dotnet/issues/1274 first.