### PR TITLE
analyze write in nested try

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/TryCatchFinallyCoverage.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/TryCatchFinallyCoverage.cs
@@ -14,17 +14,15 @@ using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.VM;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Net;
-using System.Threading.Tasks.Dataflow;
 using static Neo.Optimizer.JumpTarget;
 using static Neo.Optimizer.OpCodeTypes;
 
 namespace Neo.Optimizer
 {
+    [DebuggerDisplay($"{nameof(TryCatchFinallySingleCoverage)} {nameof(tryAddr)}={{{nameof(tryAddr)}}}")]
     public class TryCatchFinallySingleCoverage
     {
         public readonly ContractInBasicBlocks contractInBasicBlocks;
@@ -39,11 +37,14 @@ namespace Neo.Optimizer
         public HashSet<BasicBlock> finallyBlocks { get; protected set; }
         // where to go after the try-catch-finally is finished
         public HashSet<BasicBlock> endingBlocks { get; protected set; }
+        // other try blocks DIRECTLY included in this try block
+        // if there is a nested try in the catch block in this try, the internal try is not included here
+        public HashSet<TryCatchFinallySingleCoverage> nestedTrys { get; protected set; }
         public TryCatchFinallySingleCoverage(ContractInBasicBlocks contractInBasicBlocks,
             int tryAddr, int catchAddr, int finallyAddr,
             BasicBlock tryBlock, BasicBlock? catchBlock, BasicBlock? finallyBlock,
             HashSet<BasicBlock> tryBlocks, HashSet<BasicBlock> catchBlocks, HashSet<BasicBlock> finallyBlocks,
-            HashSet<BasicBlock> endingBlocks)
+            HashSet<BasicBlock> endingBlocks, HashSet<TryCatchFinallySingleCoverage> nestedTrys)
         {
             this.contractInBasicBlocks = contractInBasicBlocks;
             this.tryAddr = tryAddr;
@@ -56,13 +57,14 @@ namespace Neo.Optimizer
             this.catchBlocks = catchBlocks;
             this.finallyBlocks = finallyBlocks;
             this.endingBlocks = endingBlocks;
+            this.nestedTrys = nestedTrys;
         }
 
         public TryCatchFinallySingleCoverage(ContractInBasicBlocks contractInBasicBlocks,
             int tryAddr, int catchAddr, int finallyAddr,
             BasicBlock tryBlock, BasicBlock? catchBlock, BasicBlock? finallyBlock) :
             this(contractInBasicBlocks, tryAddr, catchAddr, finallyAddr, tryBlock, catchBlock, finallyBlock,
-                [], [], [], [])
+                [], [], [], [], [])
         { }
     }
 
@@ -147,6 +149,8 @@ namespace Neo.Optimizer
                 {
                     if (instruction.OpCode == OpCode.TRY || instruction.OpCode == OpCode.TRY_L)
                     {
+                        if (tryType == TryType.TRY)
+                            allTry[tryBlock].nestedTrys.Add(allTry[currentBlock.nextBlock!]);
                         tryStack.Push((currentBlock.nextBlock!, null, TryType.TRY, true));
                         CoverSingleTry(currentBlock.nextBlock!, tryStack);
                     }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/WriteInTryAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/WriteInTryAnalyzer.cs
@@ -92,6 +92,11 @@ namespace Neo.Compiler.SecurityAnalyzer
             {
                 if (c.catchBlock == null || c.catchBlock.branchType == BranchType.THROW || c.catchBlock.branchType == BranchType.ABORT)
                     continue;
+                // The following is a defensive judge
+                // If finally block surely throws or aborts, the try is safe even if try writes storage
+                // However, if finally block surely throws or aborts, the catch block BranchType above should surely throw or abort
+                // The `continue` above should be executed, and the following continue is never utilized
+                // If the following continue is actually executed, there may be some problem in BranchType analysis
                 if (c.finallyBlock != null && (c.finallyBlock.branchType == BranchType.THROW || c.finallyBlock.branchType == BranchType.ABORT))
                     continue;
                 IEnumerable<BasicBlock> containingBasicBlocksWritingStorage = c.tryBlocks

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_WriteInTry.cs
@@ -82,7 +82,12 @@ namespace Neo.Compiler.CSharp.TestContracts
                 catch { }
                 finally { throw new Exception(); }
             }
-            catch { }
+            catch
+            {
+                try { Write(); }
+                catch { }
+                finally { throw new Exception(); }
+            }
             finally { ExecutionEngine.Abort(); }
         }
 

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_WriteInTry.cs
@@ -45,7 +45,7 @@ namespace Neo.Compiler.CSharp.TestContracts
         }
         public static void TryWriteWithVulnerability()
         {
-            try { Delete(); } catch { }
+            try { Delete(); } catch { }  // unsafe
         }
 
         public static void RecursiveTry(int i)
@@ -72,6 +72,35 @@ namespace Neo.Compiler.CSharp.TestContracts
                 Delete();
             }
             finally { }
+        }
+
+        public static void SafeTryWithCatchWithThrowInFinally()
+        {
+            try
+            {
+                try { Write(); }
+                catch { }
+                finally { throw new Exception(); }
+            }
+            catch { }
+            finally { ExecutionEngine.Abort(); }
+        }
+
+        public static void UnsafeNestedTryWrite()
+        {
+            try
+            {
+                try { Write(); }
+                finally { }
+                throw new Exception();
+#pragma warning disable CS0162 // Unreachable code detected
+                UnsafeNestedTryWrite();
+#pragma warning restore CS0162 // Unreachable code detected
+            }
+            // no catch above and is safe
+            // but will be catched below, so the try above is unsafe
+            // for containing write in a nested try
+            catch { }
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_WriteInTry.cs
@@ -91,16 +91,17 @@ namespace Neo.Compiler.CSharp.TestContracts
             finally { ExecutionEngine.Abort(); }
         }
 
-        public static void UnsafeNestedTryWrite()
+        public static void UnsafeNestedTryWrite(bool recursive)
         {
             try
             {
                 try { Write(); }
-                finally { }
+                finally
+                {
+                    if (recursive)
+                        UnsafeNestedTryWrite(false);
+                }
                 throw new Exception();
-#pragma warning disable CS0162 // Unreachable code detected
-                UnsafeNestedTryWrite();
-#pragma warning restore CS0162 // Unreachable code detected
             }
             // no catch above and is safe
             // but will be catched below, so the try above is unsafe

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_WriteInTry.cs
@@ -41,12 +41,12 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         {
             ContractInBasicBlocks contractInBasicBlocks = new(NefFile, Manifest);
             TryCatchFinallyCoverage tryCatchFinallyCoverage = new(contractInBasicBlocks);
-            Assert.AreEqual(tryCatchFinallyCoverage.allTry.Count, 9);
+            Assert.AreEqual(tryCatchFinallyCoverage.allTry.Count, 13);
 
             WriteInTryAnalzyer.WriteInTryVulnerability v =
                 WriteInTryAnalzyer.AnalyzeWriteInTry(NefFile, Manifest);
-            // because most try throws or aborts in catch, or has no catch
-            Assert.AreEqual(v.vulnerabilities.Count, 1);
+            // because most try throws or aborts in catch, or has no catch, or throws or aborts in finally
+            Assert.AreEqual(v.vulnerabilities.Count, 2);
             v.GetWarningInfo(print: false);
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_WriteInTry.cs
@@ -41,7 +41,7 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         {
             ContractInBasicBlocks contractInBasicBlocks = new(NefFile, Manifest);
             TryCatchFinallyCoverage tryCatchFinallyCoverage = new(contractInBasicBlocks);
-            Assert.AreEqual(tryCatchFinallyCoverage.allTry.Count, 13);
+            Assert.AreEqual(tryCatchFinallyCoverage.allTry.Count, 14);
 
             WriteInTryAnalzyer.WriteInTryVulnerability v =
                 WriteInTryAnalzyer.AnalyzeWriteInTry(NefFile, Manifest);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
@@ -11,12 +11,12 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_WriteInTry"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""baseTry"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""tryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":108,""safe"":false},{""name"":""tryWriteWithVulnerability"",""parameters"":[],""returntype"":""Void"",""offset"":173,""safe"":false},{""name"":""recursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":187,""safe"":false},{""name"":""mutualRecursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":307,""safe"":false},{""name"":""safeTryWithCatchWithThrowInFinally"",""parameters"":[],""returntype"":""Void"",""offset"":385,""safe"":false},{""name"":""unsafeNestedTryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":420,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_WriteInTry"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""baseTry"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""tryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":108,""safe"":false},{""name"":""tryWriteWithVulnerability"",""parameters"":[],""returntype"":""Void"",""offset"":173,""safe"":false},{""name"":""recursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":187,""safe"":false},{""name"":""mutualRecursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":307,""safe"":false},{""name"":""safeTryWithCatchWithThrowInFinally"",""parameters"":[],""returntype"":""Void"",""offset"":385,""safe"":false},{""name"":""unsafeNestedTryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":443,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3FAVcCADsHLzQ6PTdwOwAHNEk9ADsdAAwXdGhyb3cgaW4gbmVzdGVkIGZpbmFsbHk6cWk6OwoADAEANCU9BHA4P0AQDAEANANAVwACeXhBm/ZnzkHmPxiEQAwBADQDQFcAAXhBm/ZnzkEvWMXtQFcBADsdADTODBV0aHJvdyBpbiBUcnlXcml0ZSB0cnk6cDsAHzTHDBd0aHJvdyBpbiBUcnlXcml0ZSBjYXRjaDo/VwEAOwcANKQ9BXA9AkBXAAE7AEE1f////3gQtyY0eJ1KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfNMA9NXidSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzQEP0BXAAE7AEl4ELcmN3idSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzVN////NTr///813/7//z0DP0BXAQA7HB87Cg01tv7//z0AcD0ADAlleGNlcHRpb246cD0AOFcBADsaADsACjWT/v//PQM/DAlleGNlcHRpb246cD0CQKlDfao=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3cAVcCADsHLzQ6PTdwOwAHNEk9ADsdAAwXdGhyb3cgaW4gbmVzdGVkIGZpbmFsbHk6cWk6OwoADAEANCU9BHA4P0AQDAEANANAVwACeXhBm/ZnzkHmPxiEQAwBADQDQFcAAXhBm/ZnzkEvWMXtQFcBADsdADTODBV0aHJvdyBpbiBUcnlXcml0ZSB0cnk6cDsAHzTHDBd0aHJvdyBpbiBUcnlXcml0ZSBjYXRjaDo/VwEAOwcANKQ9BXA9AkBXAAE7AEE1f////3gQtyY0eJ1KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfNMA9NXidSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzQEP0BXAAE7AEl4ELcmN3idSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzVN////NTr///813/7//z0DP0BXAgA7HDY7Cg01tv7//z0AcD0ADAlleGNlcHRpb246cDsKDTWc/v//PQBxPQAMCWV4Y2VwdGlvbjo4VwEAOxoAOwAKNXz+//89Az8MCWV4Y2VwdGlvbjpwPQJAvYOoJA==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -147,9 +147,9 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAOxwfOwoNNbb+//89AHA9AAwJZXhjZXB0aW9uOnA9ADg=
-    /// INITSLOT 0100 [64 datoshi]
-    /// TRY 1C1F [4 datoshi]
+    /// Script: VwIAOxw2OwoNNbb+//89AHA9AAwJZXhjZXB0aW9uOnA7Cg01nP7//z0AcT0ADAlleGNlcHRpb246OA==
+    /// INITSLOT 0200 [64 datoshi]
+    /// TRY 1C36 [4 datoshi]
     /// TRY 0A0D [4 datoshi]
     /// CALL_L B6FEFFFF [512 datoshi]
     /// ENDTRY 00 [4 datoshi]
@@ -158,7 +158,13 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
     /// THROW [512 datoshi]
     /// STLOC0 [2 datoshi]
+    /// TRY 0A0D [4 datoshi]
+    /// CALL_L 9CFEFFFF [512 datoshi]
     /// ENDTRY 00 [4 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// ENDTRY 00 [4 datoshi]
+    /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
+    /// THROW [512 datoshi]
     /// ABORT [0 datoshi]
     /// </remarks>
     [DisplayName("safeTryWithCatchWithThrowInFinally")]
@@ -204,11 +210,11 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAOxoAOwAKNZP+//89Az8MCWV4Y2VwdGlvbjpwPQJA
+    /// Script: VwEAOxoAOwAKNXz+//89Az8MCWV4Y2VwdGlvbjpwPQJA
     /// INITSLOT 0100 [64 datoshi]
     /// TRY 1A00 [4 datoshi]
     /// TRY 000A [4 datoshi]
-    /// CALL_L 93FEFFFF [512 datoshi]
+    /// CALL_L 7CFEFFFF [512 datoshi]
     /// ENDTRY 03 [4 datoshi]
     /// ENDFINALLY [4 datoshi]
     /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
@@ -11,12 +11,12 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_WriteInTry"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""baseTry"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""tryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":108,""safe"":false},{""name"":""tryWriteWithVulnerability"",""parameters"":[],""returntype"":""Void"",""offset"":173,""safe"":false},{""name"":""recursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":187,""safe"":false},{""name"":""mutualRecursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":307,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_WriteInTry"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""baseTry"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""tryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":108,""safe"":false},{""name"":""tryWriteWithVulnerability"",""parameters"":[],""returntype"":""Void"",""offset"":173,""safe"":false},{""name"":""recursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":187,""safe"":false},{""name"":""mutualRecursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":307,""safe"":false},{""name"":""safeTryWithCatchWithThrowInFinally"",""parameters"":[],""returntype"":""Void"",""offset"":385,""safe"":false},{""name"":""unsafeNestedTryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":420,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2BAVcCADsHLzQ6PTdwOwAHNEk9ADsdAAwXdGhyb3cgaW4gbmVzdGVkIGZpbmFsbHk6cWk6OwoADAEANCU9BHA4P0AQDAEANANAVwACeXhBm/ZnzkHmPxiEQAwBADQDQFcAAXhBm/ZnzkEvWMXtQFcBADsdADTODBV0aHJvdyBpbiBUcnlXcml0ZSB0cnk6cDsAHzTHDBd0aHJvdyBpbiBUcnlXcml0ZSBjYXRjaDo/VwEAOwcANKQ9BXA9AkBXAAE7AEE1f////3gQtyY0eJ1KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfNMA9NXidSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzQEP0BXAAE7AEl4ELcmN3idSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzVN////NTr///813/7//z0DP0ADkynT").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3FAVcCADsHLzQ6PTdwOwAHNEk9ADsdAAwXdGhyb3cgaW4gbmVzdGVkIGZpbmFsbHk6cWk6OwoADAEANCU9BHA4P0AQDAEANANAVwACeXhBm/ZnzkHmPxiEQAwBADQDQFcAAXhBm/ZnzkEvWMXtQFcBADsdADTODBV0aHJvdyBpbiBUcnlXcml0ZSB0cnk6cDsAHzTHDBd0aHJvdyBpbiBUcnlXcml0ZSBjYXRjaDo/VwEAOwcANKQ9BXA9AkBXAAE7AEE1f////3gQtyY0eJ1KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfNMA9NXidSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzQEP0BXAAE7AEl4ELcmN3idSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzVN////NTr///813/7//z0DP0BXAQA7HB87Cg01tv7//z0AcD0ADAlleGNlcHRpb246cD0AOFcBADsaADsACjWT/v//PQM/DAlleGNlcHRpb246cD0CQKlDfao=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -147,6 +147,27 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// Unsafe method
     /// </summary>
     /// <remarks>
+    /// Script: VwEAOxwfOwoNNbb+//89AHA9AAwJZXhjZXB0aW9uOnA9ADg=
+    /// INITSLOT 0100 [64 datoshi]
+    /// TRY 1C1F [4 datoshi]
+    /// TRY 0A0D [4 datoshi]
+    /// CALL_L B6FEFFFF [512 datoshi]
+    /// ENDTRY 00 [4 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// ENDTRY 00 [4 datoshi]
+    /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
+    /// THROW [512 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// ENDTRY 00 [4 datoshi]
+    /// ABORT [0 datoshi]
+    /// </remarks>
+    [DisplayName("safeTryWithCatchWithThrowInFinally")]
+    public abstract void SafeTryWithCatchWithThrowInFinally();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
     /// Script: VwEAOx0ANM4MFXRocm93IGluIFRyeVdyaXRlIHRyeTpwOwAfNMcMF3Rocm93IGluIFRyeVdyaXRlIGNhdGNoOj8=
     /// INITSLOT 0100 [64 datoshi]
     /// TRY 1D00 [4 datoshi]
@@ -178,6 +199,26 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// </remarks>
     [DisplayName("tryWriteWithVulnerability")]
     public abstract void TryWriteWithVulnerability();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEAOxoAOwAKNZP+//89Az8MCWV4Y2VwdGlvbjpwPQJA
+    /// INITSLOT 0100 [64 datoshi]
+    /// TRY 1A00 [4 datoshi]
+    /// TRY 000A [4 datoshi]
+    /// CALL_L 93FEFFFF [512 datoshi]
+    /// ENDTRY 03 [4 datoshi]
+    /// ENDFINALLY [4 datoshi]
+    /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
+    /// THROW [512 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// ENDTRY 02 [4 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("unsafeNestedTryWrite")]
+    public abstract void UnsafeNestedTryWrite();
 
     #endregion
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
@@ -11,12 +11,12 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_WriteInTry"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""baseTry"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""tryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":108,""safe"":false},{""name"":""tryWriteWithVulnerability"",""parameters"":[],""returntype"":""Void"",""offset"":173,""safe"":false},{""name"":""recursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":187,""safe"":false},{""name"":""mutualRecursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":307,""safe"":false},{""name"":""safeTryWithCatchWithThrowInFinally"",""parameters"":[],""returntype"":""Void"",""offset"":385,""safe"":false},{""name"":""unsafeNestedTryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":443,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_WriteInTry"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""baseTry"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""tryWrite"",""parameters"":[],""returntype"":""Void"",""offset"":108,""safe"":false},{""name"":""tryWriteWithVulnerability"",""parameters"":[],""returntype"":""Void"",""offset"":173,""safe"":false},{""name"":""recursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":187,""safe"":false},{""name"":""mutualRecursiveTry"",""parameters"":[{""name"":""i"",""type"":""Integer""}],""returntype"":""Void"",""offset"":307,""safe"":false},{""name"":""safeTryWithCatchWithThrowInFinally"",""parameters"":[],""returntype"":""Void"",""offset"":385,""safe"":false},{""name"":""unsafeNestedTryWrite"",""parameters"":[{""name"":""recursive"",""type"":""Boolean""}],""returntype"":""Void"",""offset"":443,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3cAVcCADsHLzQ6PTdwOwAHNEk9ADsdAAwXdGhyb3cgaW4gbmVzdGVkIGZpbmFsbHk6cWk6OwoADAEANCU9BHA4P0AQDAEANANAVwACeXhBm/ZnzkHmPxiEQAwBADQDQFcAAXhBm/ZnzkEvWMXtQFcBADsdADTODBV0aHJvdyBpbiBUcnlXcml0ZSB0cnk6cDsAHzTHDBd0aHJvdyBpbiBUcnlXcml0ZSBjYXRjaDo/VwEAOwcANKQ9BXA9AkBXAAE7AEE1f////3gQtyY0eJ1KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfNMA9NXidSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzQEP0BXAAE7AEl4ELcmN3idSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzVN////NTr///813/7//z0DP0BXAgA7HDY7Cg01tv7//z0AcD0ADAlleGNlcHRpb246cDsKDTWc/v//PQBxPQAMCWV4Y2VwdGlvbjo4VwEAOxoAOwAKNXz+//89Az8MCWV4Y2VwdGlvbjpwPQJAvYOoJA==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3iAVcCADsHLzQ6PTdwOwAHNEk9ADsdAAwXdGhyb3cgaW4gbmVzdGVkIGZpbmFsbHk6cWk6OwoADAEANCU9BHA4P0AQDAEANANAVwACeXhBm/ZnzkHmPxiEQAwBADQDQFcAAXhBm/ZnzkEvWMXtQFcBADsdADTODBV0aHJvdyBpbiBUcnlXcml0ZSB0cnk6cDsAHzTHDBd0aHJvdyBpbiBUcnlXcml0ZSBjYXRjaDo/VwEAOwcANKQ9BXA9AkBXAAE7AEE1f////3gQtyY0eJ1KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfNMA9NXidSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzQEP0BXAAE7AEl4ELcmN3idSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAnzVN////NTr///813/7//z0DP0BXAgA7HDY7Cg01tv7//z0AcD0ADAlleGNlcHRpb246cDsKDTWc/v//PQBxPQAMCWV4Y2VwdGlvbjo4VwEBOyAAOwAKNXz+//89CXgmBQk07D8MCWV4Y2VwdGlvbjpwPQJAGDAVNA==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -210,12 +210,16 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAOxoAOwAKNXz+//89Az8MCWV4Y2VwdGlvbjpwPQJA
-    /// INITSLOT 0100 [64 datoshi]
-    /// TRY 1A00 [4 datoshi]
+    /// Script: VwEBOyAAOwAKNXz+//89CXgmBQk07D8MCWV4Y2VwdGlvbjpwPQJA
+    /// INITSLOT 0101 [64 datoshi]
+    /// TRY 2000 [4 datoshi]
     /// TRY 000A [4 datoshi]
     /// CALL_L 7CFEFFFF [512 datoshi]
-    /// ENDTRY 03 [4 datoshi]
+    /// ENDTRY 09 [4 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// JMPIFNOT 05 [2 datoshi]
+    /// PUSHF [1 datoshi]
+    /// CALL EC [512 datoshi]
     /// ENDFINALLY [4 datoshi]
     /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
     /// THROW [512 datoshi]
@@ -224,7 +228,7 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("unsafeNestedTryWrite")]
-    public abstract void UnsafeNestedTryWrite();
+    public abstract void UnsafeNestedTryWrite(bool? recursive);
 
     #endregion
 }


### PR DESCRIPTION
```python
try:
  try:
    Write()
  finally:
    ...
except:
  ...
```
This is also considered unsafe, because the `Write()` in the internal try may throw and be caught by the external try. Thus it is ambiguous whether the internal `Write()` is reverted.