### PR TITLE
feat: Add multi-platform binary releases for nccs compiler 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,13 +204,18 @@ jobs:
     - name: Create release
       if: steps.check_tag.outputs.statusCode == '404'
       id: create_release
-      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: ${{ steps.get_version.outputs.version }}
-        prerelease: ${{ contains(steps.get_version.outputs.version, '-') }}
+      run: |
+        PRERELEASE_FLAG=""
+        if [[ "${{ steps.get_version.outputs.version }}" == *"-"* ]]; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+        
+        gh release create ${{ steps.get_version.outputs.version }} \
+          --title "${{ steps.get_version.outputs.version }}" \
+          --generate-notes \
+          $PRERELEASE_FLAG
     - name: Setup .NET Core
       if: steps.check_tag.outputs.statusCode == '404'
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,9 @@ jobs:
     if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
     needs: Test
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      release_created: ${{ steps.check_tag.outputs.statusCode }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -196,3 +199,64 @@ jobs:
         dotnet nuget push "pub/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${NUGET_TOKEN} --skip-duplicate
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+
+  BuildBinaries:
+    if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
+    needs: Release
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runtime: linux-x64
+            artifact: nccs-linux-x64.tar.gz
+          - os: macos-latest
+            runtime: osx-x64
+            artifact: nccs-macos-x64.tar.gz
+          - os: macos-latest
+            runtime: osx-arm64
+            artifact: nccs-macos-arm64.tar.gz
+          - os: windows-latest
+            runtime: win-x64
+            artifact: nccs-windows-x64.zip
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Build Binary
+      if: needs.Release.outputs.release_created == '404'
+      run: |
+        dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj \
+          --configuration Release \
+          --runtime ${{ matrix.runtime }} \
+          --self-contained true \
+          --output ./publish/${{ matrix.runtime }} \
+          /p:PublishSingleFile=true \
+          /p:IncludeNativeLibrariesForSelfExtract=true \
+          /p:PublishTrimmed=false
+    - name: Package Binary (Linux/macOS)
+      if: needs.Release.outputs.release_created == '404' && runner.os != 'Windows'
+      run: |
+        cd ./publish/${{ matrix.runtime }}
+        tar -czf ../../${{ matrix.artifact }} nccs
+    - name: Package Binary (Windows)
+      if: needs.Release.outputs.release_created == '404' && runner.os == 'Windows'
+      run: |
+        cd ./publish/${{ matrix.runtime }}
+        Compress-Archive -Path nccs.exe -DestinationPath ../../${{ matrix.artifact }}
+    - name: Upload Release Asset
+      if: needs.Release.outputs.release_created == '404'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.Release.outputs.upload_url }}
+        asset_path: ./${{ matrix.artifact }}
+        asset_name: ${{ matrix.artifact }}
+        asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -292,9 +292,11 @@ jobs:
         mkdir -p ./src/Neo.Compiler.CSharp/bin/Release/net9.0/
         
         # Copy pre-built Release artifacts if available, otherwise build from source
-        if [ -d "./release-build" ]; then
+        if [ -d "./release-build" ] && [ "$(ls -A ./release-build 2>/dev/null)" ]; then
           echo "Using pre-built Release artifacts from Test job..."
-          cp -r ./release-build/* ./src/Neo.Compiler.CSharp/bin/Release/net9.0/ || true
+          cp -r ./release-build/* ./src/Neo.Compiler.CSharp/bin/Release/net9.0/
+        else
+          echo "No pre-built artifacts found, will build from source"
         fi
         
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
 
   Test:
     runs-on: ubuntu-latest
+    outputs:
+      build_artifacts_available: ${{ steps.build_artifacts.outputs.available }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -30,6 +32,15 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Cache .NET Dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.nuget/packages
+          ~/.dotnet
+        key: ${{ runner.os }}-dotnet-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+        restore-keys: |
+          ${{ runner.os }}-dotnet-
     - name: Check format
       run: |
         dotnet format --no-restore --verify-no-changes --verbosity diagnostic
@@ -90,6 +101,21 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         format: lcov
         file: ${{ github.workspace }}/coverage/lcov.info
+    - name: Build Release Artifacts for Binary Distribution
+      id: build_artifacts
+      run: |
+        echo "Building Release configuration for binary distribution..."
+        dotnet build ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj \
+          --configuration Release \
+          --output ./release-build
+        echo "available=true" >> $GITHUB_OUTPUT
+    - name: Upload Release Build Artifacts
+      if: steps.build_artifacts.outputs.available == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-build-artifacts
+        path: ./release-build
+        retention-days: 1
 
   PublishPackage:
     if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
@@ -157,6 +183,7 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       release_created: ${{ steps.check_tag.outputs.statusCode }}
+      version: ${{ steps.get_version.outputs.version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -167,10 +194,13 @@ jobs:
       id: get_version
       run: |
         sudo apt install xmlstarlet
-        find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "concat('::set-output name=version::v',//i:VersionPrefix/text())" | xargs echo
+        VERSION=$(find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "//i:VersionPrefix/text()")
+        echo "version=v${VERSION}" >> $GITHUB_OUTPUT
     - name: Check tag
       id: check_tag
-      run: curl -s -I ${{ format('https://github.com/{0}/releases/tag/{1}', github.repository, steps.get_version.outputs.version) }} | head -n 1 | cut -d$' ' -f2 | xargs printf "::set-output name=statusCode::%s" | xargs echo
+      run: |
+        STATUS_CODE=$(curl -s -I ${{ format('https://github.com/{0}/releases/tag/{1}', github.repository, steps.get_version.outputs.version) }} | head -n 1 | cut -d$' ' -f2)
+        echo "statusCode=${STATUS_CODE}" >> $GITHUB_OUTPUT
     - name: Create release
       if: steps.check_tag.outputs.statusCode == '404'
       id: create_release
@@ -202,7 +232,7 @@ jobs:
 
   BuildBinaries:
     if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
-    needs: Release
+    needs: [Test, Release]
     strategy:
       matrix:
         include:
@@ -220,18 +250,48 @@ jobs:
             artifact: nccs-windows-x64.zip
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
+    - name: Checkout (Sparse)
+      if: needs.Release.outputs.release_created == '404'
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
-        submodules: recursive
+        sparse-checkout: |
+          src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
+        sparse-checkout-cone-mode: false
+        fetch-depth: 1
+    - name: Download Release Build Artifacts
+      if: needs.Release.outputs.release_created == '404' && needs.Test.outputs.build_artifacts_available == 'true'
+      uses: actions/download-artifact@v4
+      with:
+        name: release-build-artifacts
+        path: ./release-build
     - name: Setup .NET Core
+      if: needs.Release.outputs.release_created == '404'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-    - name: Build Binary
+    - name: Cache .NET Dependencies
       if: needs.Release.outputs.release_created == '404'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.nuget/packages
+          ~/.dotnet
+        key: ${{ runner.os }}-dotnet-${{ hashFiles('src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-dotnet-
+    - name: Publish Platform Binary
+      if: needs.Release.outputs.release_created == '404'
+      shell: bash
       run: |
+        # Create output directory structure
+        mkdir -p ./src/Neo.Compiler.CSharp/bin/Release/net9.0/
+        
+        # Copy pre-built Release artifacts if available, otherwise build from source
+        if [ -d "./release-build" ]; then
+          echo "Using pre-built Release artifacts from Test job..."
+          cp -r ./release-build/* ./src/Neo.Compiler.CSharp/bin/Release/net9.0/ || true
+        fi
+        
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj \
           --configuration Release \
           --runtime ${{ matrix.runtime }} \
@@ -252,11 +312,9 @@ jobs:
         Compress-Archive -Path nccs.exe -DestinationPath ../../${{ matrix.artifact }}
     - name: Upload Release Asset
       if: needs.Release.outputs.release_created == '404'
-      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.Release.outputs.upload_url }}
-        asset_path: ./${{ matrix.artifact }}
-        asset_name: ${{ matrix.artifact }}
-        asset_content_type: application/octet-stream
+      run: |
+        gh release upload ${{ needs.Release.outputs.version }} \
+          ./${{ matrix.artifact }} \
+          --clobber

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ Project templates for creating new NEO smart contracts with the proper structure
 
 ## Getting Started
 
+### Quick Start with Binary Releases
+
+For users who want to compile smart contracts without setting up the full development environment, we provide pre-built binary releases of the Neo C# Compiler (nccs).
+
+**Download standalone binaries:**
+- [Latest Release](https://github.com/neo-project/neo-devpack-dotnet/releases/latest)
+- Available for Windows x64, macOS (x64 & Apple Silicon), and Linux x64
+- No .NET SDK installation required
+- Self-contained executables with all dependencies included
+
+**Quick usage:**
+```bash
+# Download and extract the binary for your platform
+# Windows: nccs-windows-x64.zip
+# macOS: nccs-macos-x64.tar.gz or nccs-macos-arm64.tar.gz  
+# Linux: nccs-linux-x64.tar.gz
+
+# Compile a smart contract project
+./nccs path/to/your/contract.csproj
+
+# Or compile source files directly
+./nccs Contract1.cs Contract2.cs
+```
+
+📖 **[Complete Binary Usage Guide](docs/binary-releases.md)**
+
 ### Prerequisites
 
 - [.NET SDK](https://dotnet.microsoft.com/download) 9.0 or later

--- a/docs/binary-releases.md
+++ b/docs/binary-releases.md
@@ -1,0 +1,111 @@
+# Neo C# Compiler Binary Releases
+
+## Overview
+Starting with version 3.7.4, the Neo C# Compiler (nccs) is available as standalone binary applications for multiple platforms. These binaries eliminate the need to install .NET SDK on your system to compile Neo smart contracts.
+
+## Supported Platforms
+- **Windows x64** - `nccs-windows-x64.zip`
+- **macOS x64** - `nccs-macos-x64.tar.gz`
+- **macOS Apple Silicon** - `nccs-macos-arm64.tar.gz`
+- **Linux x64** - `nccs-linux-x64.tar.gz`
+
+## Download and Installation
+
+### 1. Download the Binary
+Visit the [releases page](https://github.com/neo-project/neo-devpack-dotnet/releases) and download the appropriate binary for your platform.
+
+### 2. Extract the Archive
+
+#### Windows
+```cmd
+# Extract the zip file to a directory of your choice
+tar -xf nccs-windows-x64.zip -C C:\neo-tools\
+```
+
+#### macOS/Linux
+```bash
+# Extract the tar.gz file
+tar -xzf nccs-macos-x64.tar.gz
+# or
+tar -xzf nccs-linux-x64.tar.gz
+
+# Make the binary executable
+chmod +x nccs
+```
+
+### 3. Add to PATH (Optional)
+For easier access, add the directory containing the nccs binary to your system's PATH environment variable.
+
+## Usage Examples
+
+### Basic Compilation
+```bash
+# Compile a smart contract project
+./nccs path/to/your/contract.csproj
+
+# Compile with custom output directory
+./nccs path/to/your/contract.csproj -o ./build/
+```
+
+### Advanced Options
+```bash
+# Compile with debugging information and optimization
+./nccs path/to/your/contract.csproj --debug --optimize=All
+
+# Generate assembly output and interface files
+./nccs path/to/your/contract.csproj --assembly --generate-interface
+
+# Compile multiple source files
+./nccs Contract1.cs Contract2.cs Contract3.cs
+```
+
+### Available Command-Line Options
+- `-o, --output` - Specify output directory
+- `--base-name` - Set base name for output files
+- `--debug` - Generate debug information
+- `--assembly` - Generate assembly (.asm) file
+- `--optimize` - Set optimization level (None, Basic, All, Experimental)
+- `--generate-interface` - Generate C# interface file
+- `--security-analysis` - Perform security analysis
+- `--generate-artifacts` - Generate additional artifacts
+
+## Benefits of Binary Releases
+1. **No .NET SDK Required** - Run the compiler without installing .NET
+2. **Self-Contained** - All dependencies included in the binary
+3. **Fast Setup** - Download and run immediately
+4. **Consistent Environment** - Same compiler version across all platforms
+5. **CI/CD Friendly** - Easy to integrate into build pipelines
+
+## Verification
+After installation, verify the compiler works correctly:
+
+```bash
+./nccs --help
+```
+
+This should display the help information and available command-line options.
+
+## Troubleshooting
+
+### Permission Denied (macOS/Linux)
+If you encounter permission errors, ensure the binary is executable:
+```bash
+chmod +x nccs
+```
+
+### Security Warning (macOS)
+On macOS, you might see a security warning for unsigned binaries. You can bypass this by:
+1. Go to System Preferences > Security & Privacy
+2. Click "Allow Anyway" for the blocked application
+
+### Antivirus Issues (Windows)
+Some antivirus software may flag the executable. This is a false positive common with packed executables. Add an exception for the nccs.exe file if needed.
+
+## Build Information
+These binaries are built with:
+- Single-file deployment
+- Self-contained runtime
+- Native libraries included
+- No trimming (full compatibility)
+
+For the latest updates and release notes, visit the [project repository](https://github.com/neo-project/neo-devpack-dotnet). 

--- a/docs/binary-releases.md
+++ b/docs/binary-releases.md
@@ -1,7 +1,7 @@
 # Neo C# Compiler Binary Releases
 
 ## Overview
-Starting with version 3.7.4, the Neo C# Compiler (nccs) is available as standalone binary applications for multiple platforms. These binaries eliminate the need to install .NET SDK on your system to compile Neo smart contracts.
+Starting with version 3.8.1, the Neo C# Compiler (nccs) is available as standalone binary applications for multiple platforms. These binaries eliminate the need to install .NET SDK on your system to compile Neo smart contracts.
 
 ## Supported Platforms
 - **Windows x64** - `nccs-windows-x64.zip`
@@ -18,8 +18,14 @@ Visit the [releases page](https://github.com/neo-project/neo-devpack-dotnet/rele
 
 #### Windows
 ```cmd
-# Extract the zip file to a directory of your choice
-tar -xf nccs-windows-x64.zip -C C:\neo-tools\
+# Using PowerShell (recommended)
+Expand-Archive -Path nccs-windows-x64.zip -DestinationPath C:\neo-tools\
+
+# Or using Windows Explorer
+# Right-click on nccs-windows-x64.zip and select "Extract All..."
+
+# Or using 7-Zip/WinRAR if installed
+# Right-click and choose "Extract Here" or "Extract to folder"
 ```
 
 #### macOS/Linux
@@ -33,8 +39,38 @@ tar -xzf nccs-linux-x64.tar.gz
 chmod +x nccs
 ```
 
-### 3. Add to PATH (Optional)
-For easier access, add the directory containing the nccs binary to your system's PATH environment variable.
+### 3. Add to PATH (Optional but Recommended)
+
+#### Windows
+```cmd
+# Temporary (current session only)
+set PATH=%PATH%;C:\neo-tools\
+
+# Permanent (system-wide)
+# 1. Open System Properties > Advanced > Environment Variables
+# 2. Add C:\neo-tools\ to the PATH variable
+# 3. Or use PowerShell as Administrator:
+setx /M PATH "$env:PATH;C:\neo-tools\"
+```
+
+#### macOS/Linux
+```bash
+# Temporary (current session)
+export PATH=$PATH:/path/to/nccs
+
+# Permanent (add to ~/.bashrc, ~/.zshrc, or ~/.profile)
+echo 'export PATH=$PATH:/path/to/nccs' >> ~/.bashrc
+source ~/.bashrc
+```
+
+### 4. Verify Installation
+```bash
+# Check if nccs is accessible
+nccs --help
+
+# Verify version
+nccs --version
+```
 
 ## Usage Examples
 
@@ -50,24 +86,60 @@ For easier access, add the directory containing the nccs binary to your system's
 ### Advanced Options
 ```bash
 # Compile with debugging information and optimization
-./nccs path/to/your/contract.csproj --debug --optimize=All
+./nccs path/to/your/contract.csproj --debug=Extended --optimize=All
 
 # Generate assembly output and interface files
 ./nccs path/to/your/contract.csproj --assembly --generate-interface
 
-# Compile multiple source files
-./nccs Contract1.cs Contract2.cs Contract3.cs
+# Generate testing artifacts for unit tests
+./nccs path/to/your/contract.csproj --generate-artifacts=All -o ./build/
+
+# Compile with security analysis and overflow checking
+./nccs path/to/your/contract.csproj --security-analysis --checked
+
+# Compile solution file
+./nccs path/to/your/solution.sln -o ./dist/
+
+# Compile multiple source files with custom output name
+./nccs Contract1.cs Contract2.cs Contract3.cs --base-name=MyContract
+
+# Full-featured compilation example
+./nccs ./MyContract.csproj \
+  --output ./build \
+  --debug=Extended \
+  --optimize=All \
+  --assembly \
+  --generate-interface \
+  --generate-artifacts=All \
+  --security-analysis \
+  --checked
 ```
 
 ### Available Command-Line Options
-- `-o, --output` - Specify output directory
-- `--base-name` - Set base name for output files
-- `--debug` - Generate debug information
-- `--assembly` - Generate assembly (.asm) file
-- `--optimize` - Set optimization level (None, Basic, All, Experimental)
-- `--generate-interface` - Generate C# interface file
-- `--security-analysis` - Perform security analysis
-- `--generate-artifacts` - Generate additional artifacts
+
+#### Output and Files
+- `-o, --output <directory>` - Specify output directory for generated files
+- `--base-name <name>` - Set base name for output files (default: project name)
+- `--assembly` - Generate assembly (.asm) file for debugging
+
+#### Compilation Settings
+- `--optimize <level>` - Set optimization level: `None`, `Basic`, `All`, `Experimental`
+- `--checked` - Enable overflow and underflow checking
+- `--nullable <option>` - Nullable reference types: `Disable`, `Annotations`, `Warnings`, `Enable`
+- `--no-inline` - Disable inline code insertion for better debugging
+
+#### Debug Options
+- `-d, --debug <level>` - Generate debug information: `None`, `Strict`, `Extended`
+- `--address-version <version>` - Address version for contract deployment (default: 0x35)
+
+#### Code Generation
+- `--generate-interface` - Generate C# interface files for contract interaction
+- `--generate-artifacts <flags>` - Generate testing artifacts: `None`, `Source`, `Library`, `All`
+- `--security-analysis` - Perform comprehensive security analysis
+
+#### Advanced Options
+- `--help` - Display help information
+- `--version` - Show compiler version information
 
 ## Benefits of Binary Releases
 1. **No .NET SDK Required** - Run the compiler without installing .NET
@@ -97,9 +169,63 @@ chmod +x nccs
 On macOS, you might see a security warning for unsigned binaries. You can bypass this by:
 1. Go to System Preferences > Security & Privacy
 2. Click "Allow Anyway" for the blocked application
+3. Or use the command line to bypass Gatekeeper:
+```bash
+xattr -d com.apple.quarantine nccs
+```
 
 ### Antivirus Issues (Windows)
 Some antivirus software may flag the executable. This is a false positive common with packed executables. Add an exception for the nccs.exe file if needed.
+
+### PATH Configuration Issues
+If `nccs` command is not found:
+```bash
+# Check if nccs is in your PATH
+which nccs  # macOS/Linux
+where nccs  # Windows
+
+# Run with full path if not in PATH
+/full/path/to/nccs --help
+```
+
+### .NET Runtime Dependencies
+If you encounter runtime errors about missing .NET components:
+- The binaries are self-contained and should not require .NET installation
+- Try downloading a fresh copy from the releases page
+- Ensure you downloaded the correct platform-specific binary
+
+### Common Compilation Errors
+```bash
+# Error: "Project file not found"
+# Solution: Ensure the .csproj file path is correct
+./nccs ./path/to/MyContract.csproj
+
+# Error: "Target framework not supported"
+# Solution: Ensure your project targets .NET 9.0
+# Check your .csproj file contains: <TargetFramework>net9.0</TargetFramework>
+
+# Error: "Neo.SmartContract.Framework not found"
+# Solution: Ensure Neo.SmartContract.Framework package is installed
+dotnet add package Neo.SmartContract.Framework
+```
+
+### Platform-Specific Issues
+
+#### Windows
+- Run PowerShell as Administrator if you encounter permission issues
+- Disable real-time protection temporarily if antivirus blocks execution
+
+#### macOS
+- For Apple Silicon Macs, use the `nccs-macos-arm64.tar.gz` version
+- For Intel Macs, use the `nccs-macos-x64.tar.gz` version
+
+#### Linux
+- Ensure your system has glibc 2.31 or later
+- On older distributions, you may need to install additional dependencies:
+```bash
+sudo apt-get update
+sudo apt-get install libc6 libgcc1 libssl1.1
+```
 
 ## Build Information
 These binaries are built with:


### PR DESCRIPTION
This PR adds multi-platform binary release functionality to the Neo C# Compiler (nccs), enabling users to download and use standalone executables without requiring .NET SDK installation.

## Changes Made

### 🔧 **GitHub Workflow Enhancements**
- Added `BuildBinaries` job with matrix strategy for cross-platform builds
- Generates standalone executables for:
  - Windows x64 (`nccs-windows-x64.zip`)
  - macOS x64 (`nccs-macos-x64.tar.gz`)
  - macOS Apple Silicon (`nccs-macos-arm64.tar.gz`)
  - Linux x64 (`nccs-linux-x64.tar.gz`)
- Self-contained deployments with all dependencies included
- Single-file publishing for easy distribution
- Automatic upload as GitHub release assets