### PR TITLE
Fix GitHub Actions build issue by targeting only .NET 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,6 @@ jobs:
         dotnet add    ./src/Neo.SmartContract.Testing/Neo.SmartContract.Testing.csproj package 'Neo' --version ${{ env.VERSION_NEO }}-${{ env.VERSION_SUFFIX_NEO }}
     - name : Build (Neo.SmartContract.Testing)
       run: |
-        dotnet build ./src/Neo.SmartContract.Testing -f netstandard2.1
         dotnet build ./src/Neo.SmartContract.Testing -f net9.0
     - name : Pack (Neo.SmartContract.Testing)
       run: |


### PR DESCRIPTION
## Problem

The GitHub Actions workflow was failing with a package downgrade error:

```
error NU1605: Warning As Error: Detected package downgrade: Neo from 3.8.1 to 3.8.1-CI01961
```

## Root Cause

The workflow was attempting to build `Neo.SmartContract.Testing` for both `netstandard2.1` and `net9.0`, but the project file only targets `net9.0`. This created a dependency resolution conflict when the workflow replaced the Neo project reference with a CI package reference.

## Solution

- Removed the `netstandard2.1` target from the GitHub Actions build step
- Now only builds for `net9.0`, which matches the project's target framework
- Prevents the package downgrade warning that was being treated as an error

## Changes

- Modified `.github/workflows/main.yml` to only build `Neo.SmartContract.Testing` for `net9.0`
- Aligns with the user preference to target only .NET 9 framework

## Testing

- Verified the build works locally with `dotnet build ./src/Neo.SmartContract.Testing -f net9.0`
- No breaking changes to functionality

Fixes the CI build failure in the PublishPackage job.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author