### PR TITLE
Add automated nccs compiler build and release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,10 +241,22 @@ jobs:
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r osx-arm64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-osx-arm64
         
         # Rename executables to have consistent naming
-        mv ./nccs-win-x64/nccs.exe ./nccs-win-x64/nccs.exe || mv ./nccs-win-x64/Neo.Compiler.CSharp.exe ./nccs-win-x64/nccs.exe || true
-        mv ./nccs-linux-x64/nccs ./nccs-linux-x64/nccs || mv ./nccs-linux-x64/Neo.Compiler.CSharp ./nccs-linux-x64/nccs || true
-        mv ./nccs-osx-x64/nccs ./nccs-osx-x64/nccs || mv ./nccs-osx-x64/Neo.Compiler.CSharp ./nccs-osx-x64/nccs || true
-        mv ./nccs-osx-arm64/nccs ./nccs-osx-arm64/nccs || mv ./nccs-osx-arm64/Neo.Compiler.CSharp ./nccs-osx-arm64/nccs || true
+        # Windows: Neo.Compiler.CSharp.exe -> nccs.exe
+        if [ -f "./nccs-win-x64/Neo.Compiler.CSharp.exe" ]; then
+          mv ./nccs-win-x64/Neo.Compiler.CSharp.exe ./nccs-win-x64/nccs.exe
+        fi
+        # Linux: Neo.Compiler.CSharp -> nccs
+        if [ -f "./nccs-linux-x64/Neo.Compiler.CSharp" ]; then
+          mv ./nccs-linux-x64/Neo.Compiler.CSharp ./nccs-linux-x64/nccs
+        fi
+        # macOS x64: Neo.Compiler.CSharp -> nccs
+        if [ -f "./nccs-osx-x64/Neo.Compiler.CSharp" ]; then
+          mv ./nccs-osx-x64/Neo.Compiler.CSharp ./nccs-osx-x64/nccs
+        fi
+        # macOS ARM64: Neo.Compiler.CSharp -> nccs
+        if [ -f "./nccs-osx-arm64/Neo.Compiler.CSharp" ]; then
+          mv ./nccs-osx-arm64/Neo.Compiler.CSharp ./nccs-osx-arm64/nccs
+        fi
         
         # Create zip archives
         echo "Creating archives..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: 9.0.300
@@ -164,10 +165,13 @@ jobs:
       id: get_version
       run: |
         sudo apt install xmlstarlet
-        find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "concat('::set-output name=version::v',//i:VersionPrefix/text())" | xargs echo
+        VERSION=$(find src -name Directory.Build.props | xargs xmlstarlet sel -N i=http://schemas.microsoft.com/developer/msbuild/2003 -t -v "//i:VersionPrefix/text()")
+        echo "version=v${VERSION}" >> $GITHUB_OUTPUT
     - name: Check tag
       id: check_tag
-      run: curl -s -I ${{ format('https://github.com/{0}/releases/tag/{1}', github.repository, steps.get_version.outputs.version) }} | head -n 1 | cut -d$' ' -f2 | xargs printf "::set-output name=statusCode::%s" | xargs echo
+      run: |
+        STATUS_CODE=$(curl -s -I ${{ format('https://github.com/{0}/releases/tag/{1}', github.repository, steps.get_version.outputs.version) }} | head -n 1 | cut -d$' ' -f2)
+        echo "statusCode=${STATUS_CODE}" >> $GITHUB_OUTPUT
     - name: Create release
       if: steps.check_tag.outputs.statusCode == '404'
       id: create_release
@@ -183,6 +187,98 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Build nccs compiler for multiple platforms
+      if: steps.check_tag.outputs.statusCode == '404'
+      run: |
+        # Build for different platforms
+        echo "Building nccs for Windows x64..."
+        dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-win-x64
+        
+        echo "Building nccs for Linux x64..."
+        dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r linux-x64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-linux-x64
+        
+        echo "Building nccs for macOS x64..."
+        dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r osx-x64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-osx-x64
+        
+        echo "Building nccs for macOS ARM64..."
+        dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r osx-arm64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-osx-arm64
+        
+        # Rename executables to have consistent naming
+        mv ./nccs-win-x64/nccs.exe ./nccs-win-x64/nccs.exe || mv ./nccs-win-x64/Neo.Compiler.CSharp.exe ./nccs-win-x64/nccs.exe || true
+        mv ./nccs-linux-x64/nccs ./nccs-linux-x64/nccs || mv ./nccs-linux-x64/Neo.Compiler.CSharp ./nccs-linux-x64/nccs || true
+        mv ./nccs-osx-x64/nccs ./nccs-osx-x64/nccs || mv ./nccs-osx-x64/Neo.Compiler.CSharp ./nccs-osx-x64/nccs || true
+        mv ./nccs-osx-arm64/nccs ./nccs-osx-arm64/nccs || mv ./nccs-osx-arm64/Neo.Compiler.CSharp ./nccs-osx-arm64/nccs || true
+        
+        # Create zip archives
+        echo "Creating archives..."
+        cd nccs-win-x64 && zip -r ../nccs-win-x64.zip * && cd ..
+        cd nccs-linux-x64 && tar -czf ../nccs-linux-x64.tar.gz * && cd ..
+        cd nccs-osx-x64 && tar -czf ../nccs-osx-x64.tar.gz * && cd ..
+        cd nccs-osx-arm64 && tar -czf ../nccs-osx-arm64.tar.gz * && cd ..
+        
+        # Generate checksums
+        echo "Generating checksums..."
+        sha256sum nccs-win-x64.zip nccs-linux-x64.tar.gz nccs-osx-x64.tar.gz nccs-osx-arm64.tar.gz > checksums.txt
+        
+        # Display checksums for verification
+        echo "Checksums:"
+        cat checksums.txt
+    - name: Upload nccs binaries to release
+      if: steps.check_tag.outputs.statusCode == '404' && steps.create_release.outputs.upload_url != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          
+          const assets = [
+            { name: 'nccs-win-x64.zip', path: './nccs-win-x64.zip', contentType: 'application/zip' },
+            { name: 'nccs-linux-x64.tar.gz', path: './nccs-linux-x64.tar.gz', contentType: 'application/gzip' },
+            { name: 'nccs-osx-x64.tar.gz', path: './nccs-osx-x64.tar.gz', contentType: 'application/gzip' },
+            { name: 'nccs-osx-arm64.tar.gz', path: './nccs-osx-arm64.tar.gz', contentType: 'application/gzip' },
+            { name: 'checksums.txt', path: './checksums.txt', contentType: 'text/plain' }
+          ];
+          
+          let uploadedCount = 0;
+          const errors = [];
+          
+          for (const asset of assets) {
+            try {
+              if (!fs.existsSync(asset.path)) {
+                console.error(`File not found: ${asset.path}`);
+                errors.push(`File not found: ${asset.path}`);
+                continue;
+              }
+              
+              console.log(`Uploading ${asset.name}...`);
+              const data = fs.readFileSync(asset.path);
+              const uploadUrl = '${{ steps.create_release.outputs.upload_url }}'.replace('{?name,label}', `?name=${asset.name}`);
+              
+              const response = await github.request({
+                method: 'POST',
+                url: uploadUrl,
+                headers: {
+                  'content-type': asset.contentType,
+                  'content-length': data.length
+                },
+                data: data
+              });
+              
+              console.log(`Successfully uploaded ${asset.name}`);
+              uploadedCount++;
+            } catch (error) {
+              console.error(`Failed to upload ${asset.name}: ${error.message}`);
+              errors.push(`Failed to upload ${asset.name}: ${error.message}`);
+            }
+          }
+          
+          console.log(`Upload summary: ${uploadedCount}/${assets.length} files uploaded successfully`);
+          
+          if (errors.length > 0) {
+            console.error('Errors encountered:');
+            errors.forEach(err => console.error(`  - ${err}`));
+            throw new Error(`Failed to upload some assets. ${uploadedCount}/${assets.length} succeeded.`);
+          }
     - name: Publish to NuGet
       if: steps.check_tag.outputs.statusCode == '404'
       run: |


### PR DESCRIPTION
## Summary
- Automated build process for nccs compiler across multiple platforms
- Platform-specific binaries automatically uploaded to GitHub releases
- Enhanced workflow reliability with proper error handling

## Changes
- **Multi-platform builds**: Added support for Windows x64, Linux x64, macOS x64, and macOS ARM64
- **Release automation**: Binaries are automatically built and uploaded when creating a new release
- **Checksums**: SHA256 checksums generated and included with releases for verification
- **Manual testing**: Added workflow_dispatch trigger to allow manual workflow runs
- **Error handling**: Comprehensive error handling and logging for the upload process
- **Modern syntax**: Updated deprecated GitHub Actions syntax to current standards

## Test Plan
- [ ] Workflow syntax validates correctly
- [ ] Manual workflow dispatch runs successfully
- [ ] Release creation triggers binary builds
- [ ] All platform binaries upload correctly
- [ ] Checksums file is generated and uploaded
- [ ] Error handling works as expected for failed uploads

This PR ensures users can download pre-built nccs compiler binaries directly from GitHub releases without needing to build from source, improving the developer experience.