### PR TITLE
docs: improve security documentation based on reviewer feedback

### DIFF
--- a/docs/security/access-control-patterns.md
+++ b/docs/security/access-control-patterns.md
@@ -66,7 +66,9 @@ public class OwnerOnlyContract : SmartContract
     {
         OnlyOwner();
         Assert(newOwner != null && newOwner.IsValid, "Invalid new owner address");
+        Assert(newOwner != UInt160.Zero, "New owner cannot be zero address");
         Assert(newOwner != OWNER, "New owner must be different");
+        Assert(Runtime.CheckWitness(newOwner), "New owner must authorize the transfer");
         
         // Update owner in storage for future reference
         Storage.Put(Storage.CurrentContext, "owner", newOwner);

--- a/docs/security/safe-arithmetic.md
+++ b/docs/security/safe-arithmetic.md
@@ -23,6 +23,10 @@ This guide focuses on implementing safe arithmetic operations in Neo smart contr
 
 ### Neo N3 BigInteger Characteristics
 
+> **Important**: As noted by the Neo team, BigInteger in Neo VM has a maximum length of 256 bits (32 bytes). 
+> The VM will throw an exception if a value exceeds this limit, providing automatic overflow protection.
+> However, we still recommend implementing explicit bounds checking for business logic validation.
+
 ```csharp
 using Neo.SmartContract.Framework;
 using Neo.SmartContract.Framework.Services;
@@ -30,8 +34,9 @@ using Neo.SmartContract.Framework.Services;
 [DisplayName("ArithmeticSafetyDemo")]
 public class ArithmeticSafetyDemo : SmartContract
 {
-    // BigInteger in Neo can handle arbitrarily large numbers, but we still need bounds
-    // for practical and security reasons
+    // BigInteger in Neo VM has a maximum of 256 bits (32 bytes)
+    // The VM automatically prevents overflow beyond this limit
+    // We still define practical bounds for business logic validation
     
     /// <summary>
     /// Maximum safe value for token amounts (example: 21M tokens with 8 decimals)
@@ -49,11 +54,12 @@ public class ArithmeticSafetyDemo : SmartContract
     [Safe]
     public static void DemonstrateBigIntegerBehavior()
     {
-        // BigInteger can handle very large numbers
+        // BigInteger in Neo VM has automatic overflow protection at 256 bits
         BigInteger large1 = BigInteger.Parse("999999999999999999999999999999");
         BigInteger large2 = BigInteger.Parse("111111111111111111111111111111");
         
-        // This won't overflow, but we should still validate for business logic
+        // The VM will automatically throw if result exceeds 256 bits
+        // We still validate for business logic constraints
         BigInteger result = large1 + large2;
         
         // Always validate results against business logic constraints
@@ -70,7 +76,7 @@ public class ArithmeticSafetyDemo : SmartContract
 public class SafeAddition : SmartContract
 {
     /// <summary>
-    /// Safe addition with overflow protection
+    /// Safe addition with business logic validation
     /// </summary>
     public static BigInteger SafeAdd(BigInteger a, BigInteger b)
     {
@@ -78,8 +84,8 @@ public class SafeAddition : SmartContract
         Assert(a >= 0, "First operand must be non-negative");
         Assert(b >= 0, "Second operand must be non-negative");
         
-        // Check for overflow before operation
-        Assert(a <= MAX_SAFE_VALUE - b, "Addition would cause overflow");
+        // Check against business logic limits (VM handles 256-bit overflow automatically)
+        Assert(a <= MAX_SAFE_VALUE - b, "Addition would exceed business logic limits");
         
         BigInteger result = a + b;
         
@@ -246,7 +252,7 @@ public class SafeSubtraction : SmartContract
 public class SafeMultiplication : SmartContract
 {
     /// <summary>
-    /// Safe multiplication with overflow protection
+    /// Safe multiplication with business logic validation
     /// </summary>
     public static BigInteger SafeMultiply(BigInteger a, BigInteger b)
     {
@@ -257,8 +263,8 @@ public class SafeMultiplication : SmartContract
         if (a == 1) return b;
         if (b == 1) return a;
         
-        // Check for overflow before multiplication
-        Assert(a <= MAX_SAFE_VALUE / b, "Multiplication would cause overflow");
+        // Check against business logic limits (VM handles 256-bit overflow automatically)
+        Assert(a <= MAX_SAFE_VALUE / b, "Multiplication would exceed business logic limits");
         
         BigInteger result = a * b;
         


### PR DESCRIPTION
- Add witness check for new owner in TransferOwnership to prevent unauthorized transfers
- Add UInt160.Zero check to prevent transfers to zero address
- Update BigInteger documentation to clarify Neo VM's automatic 256-bit overflow protection
- Clarify that explicit bounds checking is for business logic validation, not overflow prevention

These improvements address security suggestions from PR #1345 review comments.