### PR TITLE
Update GitHub workflow to use modern release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,16 +209,6 @@ jobs:
       run: |
         STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.version }})
         echo "statusCode=$STATUS_CODE" >> $GITHUB_OUTPUT
-    - name: Create release
-      if: steps.check_tag.outputs.statusCode == '404'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: ${{ steps.get_version.outputs.version }}
-        prerelease: ${{ contains(steps.get_version.outputs.version, '-') }}
     - name: Setup .NET Core
       if: steps.check_tag.outputs.statusCode == '404'
       uses: actions/setup-dotnet@v4
@@ -272,62 +262,23 @@ jobs:
         # Display checksums for verification
         echo "Checksums:"
         cat checksums.txt
-    - name: Upload nccs binaries to release
-      if: steps.check_tag.outputs.statusCode == '404' && steps.create_release.outputs.upload_url != ''
-      uses: actions/github-script@v7
+    - name: Create release and upload binaries
+      if: steps.check_tag.outputs.statusCode == '404'
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        script: |
-          const fs = require('fs');
-          const path = require('path');
-          
-          const assets = [
-            { name: 'nccs-win-x64.zip', path: './nccs-win-x64.zip', contentType: 'application/zip' },
-            { name: 'nccs-linux-x64.tar.gz', path: './nccs-linux-x64.tar.gz', contentType: 'application/gzip' },
-            { name: 'nccs-osx-x64.tar.gz', path: './nccs-osx-x64.tar.gz', contentType: 'application/gzip' },
-            { name: 'nccs-osx-arm64.tar.gz', path: './nccs-osx-arm64.tar.gz', contentType: 'application/gzip' },
-            { name: 'checksums.txt', path: './checksums.txt', contentType: 'text/plain' }
-          ];
-          
-          let uploadedCount = 0;
-          const errors = [];
-          
-          for (const asset of assets) {
-            try {
-              if (!fs.existsSync(asset.path)) {
-                console.error(`File not found: ${asset.path}`);
-                errors.push(`File not found: ${asset.path}`);
-                continue;
-              }
-              
-              console.log(`Uploading ${asset.name}...`);
-              const data = fs.readFileSync(asset.path);
-              const uploadUrl = '${{ steps.create_release.outputs.upload_url }}'.replace('{?name,label}', `?name=${asset.name}`);
-              
-              const response = await github.request({
-                method: 'POST',
-                url: uploadUrl,
-                headers: {
-                  'content-type': asset.contentType,
-                  'content-length': data.length
-                },
-                data: data
-              });
-              
-              console.log(`Successfully uploaded ${asset.name}`);
-              uploadedCount++;
-            } catch (error) {
-              console.error(`Failed to upload ${asset.name}: ${error.message}`);
-              errors.push(`Failed to upload ${asset.name}: ${error.message}`);
-            }
-          }
-          
-          console.log(`Upload summary: ${uploadedCount}/${assets.length} files uploaded successfully`);
-          
-          if (errors.length > 0) {
-            console.error('Errors encountered:');
-            errors.forEach(err => console.error(`  - ${err}`));
-            throw new Error(`Failed to upload some assets. ${uploadedCount}/${assets.length} succeeded.`);
-          }
+        tag_name: ${{ steps.get_version.outputs.version }}
+        name: ${{ steps.get_version.outputs.version }}
+        prerelease: ${{ contains(steps.get_version.outputs.version, '-') }}
+        generate_release_notes: true
+        files: |
+          nccs-win-x64.zip
+          nccs-linux-x64.tar.gz
+          nccs-osx-x64.tar.gz
+          nccs-osx-arm64.tar.gz
+          checksums.txt
     - name: Run ordered release script
       if: steps.check_tag.outputs.statusCode == '404'
       run: |


### PR DESCRIPTION
## Summary
- Replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
- Consolidate release creation and asset upload into single step
- Add automatic release notes generation

## Changes
- Removed deprecated `actions/create-release@v1` action
- Replaced complex JavaScript-based asset upload with native file upload
- Added `generate_release_notes: true` for automatic changelog generation
- Simplified workflow by reducing code complexity while maintaining all functionality

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test release creation on master branch (when appropriate)
- [ ] Confirm all release assets are uploaded correctly
- [ ] Validate release notes are generated automatically