### PR TITLE
Remove repository restriction from release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         file: ${{ github.workspace }}/coverage/lcov.info
 
   PublishPackage:
-    if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
+    if: github.ref == 'refs/heads/master'
     needs: Test
     runs-on: ubuntu-latest
     steps:
@@ -190,7 +190,7 @@ jobs:
             --no-service-endpoint;
 
   Release:
-    if: github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')
+    if: github.ref == 'refs/heads/master'
     needs: Test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Remove `startsWith(github.repository, 'neo-project/')` check from PublishPackage and Release jobs
- Enable testing and releases from forked repositories

## Changes
- Modified condition in PublishPackage job: `github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')` → `github.ref == 'refs/heads/master'`
- Modified condition in Release job: `github.ref == 'refs/heads/master' && startsWith(github.repository, 'neo-project/')` → `github.ref == 'refs/heads/master'`

## Rationale
The repository restriction prevents forks from testing the complete workflow, making development and debugging more difficult. This change allows developers to:
- Test the full release workflow on their forks
- Verify package publishing logic without restrictions
- Debug release processes in their own repositories

## Test plan
- [ ] Verify workflow runs successfully on master branch pushes
- [ ] Test that forked repositories can now execute release workflows
- [ ] Confirm no unintended side effects in package publishing