### PR TITLE
Remove: several compiling warnings

### DIFF
--- a/examples/Example.SmartContract.ContractCall.UnitTests/Example.SmartContract.ContractCall.UnitTests.csproj
+++ b/examples/Example.SmartContract.ContractCall.UnitTests/Example.SmartContract.ContractCall.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.Event.UnitTests/Example.SmartContract.Event.UnitTests.csproj
+++ b/examples/Example.SmartContract.Event.UnitTests/Example.SmartContract.Event.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.Exception.UnitTests/Example.SmartContract.Exception.UnitTests.csproj
+++ b/examples/Example.SmartContract.Exception.UnitTests/Example.SmartContract.Exception.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.HelloWorld.UnitTests/Example.SmartContract.HelloWorld.UnitTests.csproj
+++ b/examples/Example.SmartContract.HelloWorld.UnitTests/Example.SmartContract.HelloWorld.UnitTests.csproj
@@ -18,7 +18,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
         <PackageReference Include="Neo.SmartContract.Testing" Version="3.8.1"/>

--- a/examples/Example.SmartContract.Inscription.UnitTests/Example.SmartContract.Inscription.UnitTests.csproj
+++ b/examples/Example.SmartContract.Inscription.UnitTests/Example.SmartContract.Inscription.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.Modifier.UnitTests/Example.SmartContract.Modifier.UnitTests.csproj
+++ b/examples/Example.SmartContract.Modifier.UnitTests/Example.SmartContract.Modifier.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.NEP17.UnitTests/Example.SmartContract.NEP17.UnitTests.csproj
+++ b/examples/Example.SmartContract.NEP17.UnitTests/Example.SmartContract.NEP17.UnitTests.csproj
@@ -18,7 +18,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
         <PackageReference Include="Neo.SmartContract.Testing" Version="3.8.1"/>

--- a/examples/Example.SmartContract.NFT.UnitTests/Example.SmartContract.NFT.UnitTests.csproj
+++ b/examples/Example.SmartContract.NFT.UnitTests/Example.SmartContract.NFT.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.Oracle.UnitTests/Example.SmartContract.Oracle.UnitTests.csproj
+++ b/examples/Example.SmartContract.Oracle.UnitTests/Example.SmartContract.Oracle.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.SampleRoyaltyNEP11Token.UnitTests/Example.SmartContract.SampleRoyaltyNEP11Token.UnitTests.csproj
+++ b/examples/Example.SmartContract.SampleRoyaltyNEP11Token.UnitTests/Example.SmartContract.SampleRoyaltyNEP11Token.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.Storage.UnitTests/Example.SmartContract.Storage.UnitTests.csproj
+++ b/examples/Example.SmartContract.Storage.UnitTests/Example.SmartContract.Storage.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/examples/Example.SmartContract.Transfer.UnitTests/Example.SmartContract.Transfer.UnitTests.csproj
+++ b/examples/Example.SmartContract.Transfer.UnitTests/Example.SmartContract.Transfer.UnitTests.csproj
@@ -18,7 +18,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
         <PackageReference Include="Neo.SmartContract.Testing" Version="3.8.1"/>

--- a/examples/Example.SmartContract.ZKP.UnitTests/Example.SmartContract.ZKP.UnitTests.csproj
+++ b/examples/Example.SmartContract.ZKP.UnitTests/Example.SmartContract.ZKP.UnitTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.8.0"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.8.0"/>
     </ItemGroup>

--- a/guidance/GETTING-STARTED-GUIDE.md
+++ b/guidance/GETTING-STARTED-GUIDE.md
@@ -354,7 +354,7 @@ Edit `HelloWorldContract.Tests.csproj`:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="Neo.SmartContract.Testing" Version="3.8.1" />

--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -1,30 +1,29 @@
 ### New Rules
 
-| Rule ID | Category | Severity | Notes                                      |
-|---------|----------|----------|--------------------------------------------|
-| NC4002  | Type     | Error    | FloatUsageAnalyzer                         |
-| NC4003  | Type     | Error    | DecimalUsageAnalyzer                       |
-| NC4004  | Type     | Error    | DoubleUsageAnalyzer                        |
-| NC4005  | Method   | Error    | SystemMathUsageAnalyzer                    |
-| NC4006  | Method   | Error    | BigIntegerUsageAnalyzer                    |
-| NC4007  | Method   | Error    | StringMethodUsageAnalyzer                  |
-| NC4008  | Usage    | Error    | BigIntegerCreationAnalyzer                 |
-| NC4009  | Usage    | Info     | InitialValueAnalyzer                       |
-| NC4010  | Usage    | Warning  | RefKeywordUsageAnalyzer                    |
-| NC4011  | Usage    | Error    | LinqUsageAnalyzer                          |
-| NC4012  | Method   | Error    | CharMethodsUsageAnalyzer                   |
-| NC4013  | Type     | Error    | CollectionTypesUsageAnalyzer               |
-| NC4014  | Usage    | Warning  | VolatileKeywordUsageAnalyzer               |
-| NC4015  | Usage    | Error    | KeywordUsageAnalyzer                       |
-| NC4017  | Usage    | Error    | BanCastMethodAnalyzer                      |
-| NC4018  | Naming   | Error    | SmartContractMethodNamingAnalyzer          |
-| NC4019  | Usage    | Error    | NotifyEventNameAnalyzer                    |
-| NC4020  | Naming   | Warning  | SmartContractMethodNamingAnalyzerUnderline |
-| NC4021  | Usage    | Warning  | SupportedStandardsAnalyzer                 |
-| NC4022  | Usage    | Warning  | BigIntegerUsingUsageAnalyzer               |
-| NC4023  | Usage    | Error    | StaticFieldInitializationAnalyzer          |
-| NC4024  | Usage    | Error    | MultipleCatchBlockAnalyzer                 |
-| NC4025  | Method   | Error    | EnumMethodsUsageAnalyzer                   |
-| NC4026  | Usage    | Error    | SystemDiagnosticsUsageAnalyzer             |
-| NC4027  | Usage    | Warning  | CatchOnlySystemExceptionAnalyzer           |
-| NC4028  | Usage    | Error    | SystemThreadingUsageAnalyzer               |
+Rule ID | Category | Severity | Notes                                      
+--------|----------|----------|--------------------------------------------
+NC4002  | Type     | Error    | FloatUsageAnalyzer                         
+NC4003  | Type     | Error    | DecimalUsageAnalyzer                       
+NC4004  | Type     | Error    | DoubleUsageAnalyzer                        
+NC4005  | Method   | Error    | SystemMathUsageAnalyzer                    
+NC4006  | Method   | Error    | BigIntegerUsageAnalyzer                    
+NC4007  | Method   | Error    | StringMethodUsageAnalyzer                  
+NC4008  | Usage    | Error    | BigIntegerCreationAnalyzer                 
+NC4009  | Usage    | Info     | InitialValueAnalyzer                       
+NC4010  | Usage    | Warning  | RefKeywordUsageAnalyzer                    
+NC4011  | Usage    | Error    | LinqUsageAnalyzer                          
+NC4012  | Method   | Error    | CharMethodsUsageAnalyzer                   
+NC4013  | Type     | Error    | CollectionTypesUsageAnalyzer               
+NC4014  | Usage    | Warning  | VolatileKeywordUsageAnalyzer               
+NC4015  | Usage    | Error    | KeywordUsageAnalyzer                       
+NC4017  | Usage    | Error    | BanCastMethodAnalyzer                      
+NC4018  | Naming   | Error    | SmartContractMethodNamingAnalyzer          
+NC4019  | Usage    | Error    | NotifyEventNameAnalyzer                    
+NC4020  | Naming   | Warning  | SmartContractMethodNamingAnalyzerUnderline 
+NC4021  | Usage    | Warning  | SupportedStandardsAnalyzer                 
+NC4022  | Usage    | Warning  | BigIntegerUsingUsageAnalyzer               
+NC4023  | Usage    | Error    | StaticFieldInitializationAnalyzer          
+NC4024  | Usage    | Error    | MultipleCatchBlockAnalyzer                 
+NC4025  | Method   | Error    | EnumMethodsUsageAnalyzer                                
+NC4027  | Usage    | Warning  | CatchOnlySystemExceptionAnalyzer           
+NC4028  | Namespace| Error    | SystemThreadingUsageAnalyzer               

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj
@@ -10,7 +10,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Remove compiling warnings:

1:
> neo-devpack-dotnet/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj : warning NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: Microsoft.NET.Test.Sdk 17.14.1, Microsoft.NET.Test.Sdk 17.14.1


2.
> neo-devpack-dotnet/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md(3,1): warning RS2007: Analyzer release file 'AnalyzerReleases.Unshipped.md' has a missing or invalid release header '| Rule ID | Category | Severity | Notes                                      |' (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md)

3.
> neo-devpack-dotnet/src/Neo.SmartContract.Analyzer/SystemDiagnosticsUsageAnalyzer.cs(26,13): warning RS2001: Rule 'NC4028' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file. (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md)

4.
> CSC : warning RS2002: Rule 'NC4026' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md)

