### PR TITLE
Fix SupportedStandards analyzer warning in test

### DIFF
--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandards.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandards.cs
@@ -9,13 +9,14 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.SmartContract.Framework;
 using Neo.SmartContract.Framework.Attributes;
 using Neo.SmartContract.Framework.Services;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
-    // Both NEP-10 and NEP-5 are obsolete, but this is just a test contract
-    [SupportedStandards("NEP-10", "NEP-5")]
+    // Using enumeration-based standards avoids analyzer warnings.
+    [SupportedStandards(NepStandard.Nep9, NepStandard.Nep17)]
     public class Contract_SupportedStandards : SmartContract
     {
         public static bool TestStandard()


### PR DESCRIPTION
## Summary
- switch the test contract to use the enum-based overload of [SupportedStandards]
- adds explicit NepStandard import to match analyzer expectations

## Testing
- dotnet build
- dotnet format