### PR TITLE
Document record lowering and expand coverage

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
@@ -149,6 +149,8 @@ namespace Neo.Compiler
                 if (!Symbol.DeclaringSyntaxReferences.IsEmpty)
                     SyntaxNode = Symbol.DeclaringSyntaxReferences[0].GetSyntax();
 
+                RegisterMethodParameters();
+
                 // Step 3: Process method based on its kind
                 // This handles special cases for constructors and static constructors
                 // Examples:

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Record.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Record.cs
@@ -29,6 +29,27 @@ namespace Neo.Compiler.CSharp.TestContracts
         }
     }
 
+    public record StudentWithExtras(string Name)
+    {
+        public int EnrollmentYear { get; init; } = 2025;
+        public string? Tag { get; set; }
+    }
+
+    public record Customer(string Name, int Tier)
+    {
+        public string Identifier => $"{Name}:{Tier}";
+    }
+
+    public record PremiumCustomer(string Name, int Tier, string Level) : Customer(Name, Tier)
+    {
+        public int Score { get; init; }
+    }
+
+    public record struct Position(int X, int Y)
+    {
+        public int Z { get; init; }
+    }
+
     public class Contract_Record : SmartContract.Framework.SmartContract
     {
         public static object Test_CreateRecord(string n, int a)
@@ -62,6 +83,56 @@ namespace Neo.Compiler.CSharp.TestContracts
             var p = new Student(n, a);
             var (name, age) = p;
             return name;
+        }
+
+        public static object Test_CreateRecordWithExtras(string name, string? tag)
+        {
+            var record = new StudentWithExtras(name) { Tag = tag };
+            return record;
+        }
+
+        public static object Test_WithRecordExtras(string name, string tag, int yearIncrement)
+        {
+            var record = new StudentWithExtras(name) { Tag = tag };
+            var updated = record with
+            {
+                Tag = tag + ":updated",
+                EnrollmentYear = record.EnrollmentYear + yearIncrement
+            };
+            return updated;
+        }
+
+        public static object Test_RecordStructWith(int x, int y, int z, int deltaY)
+        {
+            var position = new Position(x, y) { Z = z };
+            var updated = position with { Y = y + deltaY };
+            return updated;
+        }
+
+        public static object Test_DerivedRecordWith(string name, int tier, string level, int bonus)
+        {
+            var customer = new PremiumCustomer(name, tier, level);
+            var updated = customer with
+            {
+                Tier = tier + bonus,
+                Level = level + "-VIP",
+                Score = (tier + bonus) * 10
+            };
+            return updated;
+        }
+
+        public static bool Test_RecordEquality(string name, int age)
+        {
+            var a = new Student(name, age);
+            var b = new Student(name, age);
+            return a == b;
+        }
+
+        public static bool Test_RecordStructIsolation(int x, int y, int z)
+        {
+            var original = new Position(x, y) { Z = z };
+            var clone = original with { Y = y + 10 };
+            return original.Y == y && clone.Y == y + 10 && original.Z == clone.Z;
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Record.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Record.cs
@@ -11,12 +11,12 @@ public abstract class Contract_Record(Neo.SmartContract.Testing.SmartContractIni
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Record"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""test_CreateRecord"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":0,""safe"":false},{""name"":""test_CreateRecord2"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":28,""safe"":false},{""name"":""test_UpdateRecord"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":58,""safe"":false},{""name"":""test_UpdateRecord2"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":137,""safe"":false},{""name"":""test_DeconstructRecord"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""String"",""offset"":229,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.8.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Record"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""test_CreateRecord"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":0,""safe"":false},{""name"":""test_CreateRecord2"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":28,""safe"":false},{""name"":""test_UpdateRecord"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":58,""safe"":false},{""name"":""test_UpdateRecord2"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""Any"",""offset"":137,""safe"":false},{""name"":""test_DeconstructRecord"",""parameters"":[{""name"":""n"",""type"":""String""},{""name"":""a"",""type"":""Integer""}],""returntype"":""String"",""offset"":229,""safe"":false},{""name"":""test_CreateRecordWithExtras"",""parameters"":[{""name"":""name"",""type"":""String""},{""name"":""tag"",""type"":""String""}],""returntype"":""Any"",""offset"":255,""safe"":false},{""name"":""test_WithRecordExtras"",""parameters"":[{""name"":""name"",""type"":""String""},{""name"":""tag"",""type"":""String""},{""name"":""yearIncrement"",""type"":""Integer""}],""returntype"":""Any"",""offset"":285,""safe"":false},{""name"":""test_RecordStructWith"",""parameters"":[{""name"":""x"",""type"":""Integer""},{""name"":""y"",""type"":""Integer""},{""name"":""z"",""type"":""Integer""},{""name"":""deltaY"",""type"":""Integer""}],""returntype"":""Any"",""offset"":384,""safe"":false},{""name"":""test_DerivedRecordWith"",""parameters"":[{""name"":""name"",""type"":""String""},{""name"":""tier"",""type"":""Integer""},{""name"":""level"",""type"":""String""},{""name"":""bonus"",""type"":""Integer""}],""returntype"":""Any"",""offset"":482,""safe"":false},{""name"":""test_RecordEquality"",""parameters"":[{""name"":""name"",""type"":""String""},{""name"":""age"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":729,""safe"":false},{""name"":""test_RecordStructIsolation"",""parameters"":[{""name"":""x"",""type"":""Integer""},{""name"":""y"",""type"":""Integer""},{""name"":""z"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":764,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.8.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3/AFcBAhALEr95eBJNNAVwaEBXAAN4EHnQeBF60EBXAQIQCxK/eEs0CnlLEVHQcGhAVwACeUp4EFHQRUBXAgIQCxK/eXgSTTTLcGjBv3mcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0s0BXFoQFcAAngRedBAVwICEAsSv3l4Ek01fP///3Bowb95nEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9LNLMMATB4i9soSzQFcWlAVwACeBB50EBXAwIQCxK/eXgSTTUg////cGhKwUVxckVpQIie/tQ=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2gA1cBAhALEr95eBJNNAVwaEBXAAN4EHnQeBF60EBXAQIQCxK/eEs0CnlLEVHQcGhAVwACeUp4EFHQRUBXAgIQCxK/eXgSTTTLcGjBv3mcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0s0BXFoQFcAAngRedBAVwICEAsSv3l4Ek01fP///3Bowb95nEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9LNLMMATB4i9soSzQFcWlAVwACeBB50EBXAwIQCxK/eXgSTTUg////cGhKwUVxckVpQFcBAgsB6QcLE794SzQKeUsSUdBwaEBXAAJ4EHnQQFcCAwsB6QcLE794SzTseUsSUdBwaMG/eQwIOnVwZGF0ZWSL2yhLElHQaBHOep5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfSxFR0HFpQFcCBBAQEBO/eXgSTTRCeksSUdBwaMG/eXueSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0s0EXFpQFcAA3gQedB4EXrQQFcAAngRedBAVwIEEAsQCxS/enl4E001uAAAAHBowb95e55KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfSzWeAAAAegwELVZJUIvbKEs1lgAAAHl7nkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ8aoEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9LE1HQcWlAVwAEenl4NA94EHnQeBF60HgSe9BAVwADeBB50HgRetBAVwACeBF50EBXAAJ4EnnQQFcCAhALEr95eBJNNSz9//9wEAsSv3l4Ek01Hv3//3FoaZdAVwIDEBAQE795eBJNNcb+//96SxJR0HBowb95Gp5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfSzWS/v//cWg0SnmXJAUJIjdpNEB5Gp5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACflyQECUBoEs5pEs6XQFcAAXgRzkD+dez4").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -73,6 +73,32 @@ public abstract class Contract_Record(Neo.SmartContract.Testing.SmartContractIni
     /// Unsafe method
     /// </summary>
     /// <remarks>
+    /// Script: VwECCwHpBwsTv3hLNAp5SxJR0HBoQA==
+    /// INITSLOT 0102 [64 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSHINT16 E907 [1 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSH3 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// OVER [2 datoshi]
+    /// CALL 0A [512 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("test_CreateRecordWithExtras")]
+    public abstract object? Test_CreateRecordWithExtras(string? name, string? tag);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
     /// Script: VwMCEAsSv3l4Ek01IP///3BoSsFFcXJFaUA=
     /// INITSLOT 0302 [64 datoshi]
     /// PUSH0 [1 datoshi]
@@ -97,6 +123,269 @@ public abstract class Contract_Record(Neo.SmartContract.Testing.SmartContractIni
     /// </remarks>
     [DisplayName("test_DeconstructRecord")]
     public abstract string? Test_DeconstructRecord(string? n, BigInteger? a);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwIEEAsQCxS/enl4E001uAAAAHBowb95e55KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfSzWeAAAAegwELVZJUIvbKEs1lgAAAHl7nkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ8aoEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9LE1HQcWlA
+    /// INITSLOT 0204 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSH4 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH3 [1 datoshi]
+    /// PICK [2 datoshi]
+    /// CALL_L B8000000 [512 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// UNPACK [2048 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG3 [2 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// OVER [2 datoshi]
+    /// CALL_L 9E000000 [512 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// PUSHDATA1 2D564950 '-VIP' [8 datoshi]
+    /// CAT [2048 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// OVER [2 datoshi]
+    /// CALL_L 96000000 [512 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG3 [2 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// PUSH10 [1 datoshi]
+    /// MUL [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH3 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("test_DerivedRecordWith")]
+    public abstract object? Test_DerivedRecordWith(string? name, BigInteger? tier, string? level, BigInteger? bonus);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwICEAsSv3l4Ek01LP3//3AQCxK/eXgSTTUe/f//cWhpl0A=
+    /// INITSLOT 0202 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PICK [2 datoshi]
+    /// CALL_L 2CFDFFFF [512 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PICK [2 datoshi]
+    /// CALL_L 1EFDFFFF [512 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// EQUAL [32 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("test_RecordEquality")]
+    public abstract bool? Test_RecordEquality(string? name, BigInteger? age);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwIDEBAQE795eBJNNcb+//96SxJR0HBowb95Gp5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfSzWS/v//cWg0SnmXJAUJIjdpNEB5Gp5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACflyQECUBoEs5pEs6XQA==
+    /// INITSLOT 0203 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH3 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PICK [2 datoshi]
+    /// CALL_L C6FEFFFF [512 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// UNPACK [2048 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// PUSH10 [1 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// OVER [2 datoshi]
+    /// CALL_L 92FEFFFF [512 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// CALL 4A [512 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// EQUAL [32 datoshi]
+    /// JMPIF 05 [2 datoshi]
+    /// PUSHF [1 datoshi]
+    /// JMP 37 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// CALL 40 [512 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// PUSH10 [1 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// EQUAL [32 datoshi]
+    /// JMPIF 04 [2 datoshi]
+    /// PUSHF [1 datoshi]
+    /// RET [0 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// EQUAL [32 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("test_RecordStructIsolation")]
+    public abstract bool? Test_RecordStructIsolation(BigInteger? x, BigInteger? y, BigInteger? z);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwIEEBAQE795eBJNNEJ6SxJR0HBowb95e55KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfSzQRcWlA
+    /// INITSLOT 0204 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH3 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// PICK [2 datoshi]
+    /// CALL 42 [512 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// UNPACK [2048 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG3 [2 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// OVER [2 datoshi]
+    /// CALL 11 [512 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("test_RecordStructWith")]
+    public abstract object? Test_RecordStructWith(BigInteger? x, BigInteger? y, BigInteger? z, BigInteger? deltaY);
 
     /// <summary>
     /// Unsafe method
@@ -191,6 +480,67 @@ public abstract class Contract_Record(Neo.SmartContract.Testing.SmartContractIni
     /// </remarks>
     [DisplayName("test_UpdateRecord2")]
     public abstract object? Test_UpdateRecord2(string? n, BigInteger? a);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwIDCwHpBwsTv3hLNOx5SxJR0HBowb95DAg6dXBkYXRlZIvbKEsSUdBoEc56nkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9LEVHQcWlA
+    /// INITSLOT 0203 [64 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSHINT16 E907 [1 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// PUSH3 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// OVER [2 datoshi]
+    /// CALL EC [512 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// UNPACK [2048 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// PUSHDATA1 3A75706461746564 ':updated' [8 datoshi]
+    /// CAT [2048 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// OVER [2 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SETITEM [8192 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("test_WithRecordExtras")]
+    public abstract object? Test_WithRecordExtras(string? name, string? tag, BigInteger? yearIncrement);
 
     #endregion
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Record.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Record.cs
@@ -78,5 +78,78 @@ namespace Neo.Compiler.CSharp.UnitTests
             AssertGasConsumed(1679970);
             Assert.AreEqual(name, result);
         }
+
+        [TestMethod]
+        public void Test_CreateRecordWithExtras()
+        {
+            var name = "neo";
+            var tag = "tag";
+            var result = Contract.Test_CreateRecordWithExtras(name, tag)!;
+            AssertGasConsumed(1618380);
+            var arr = result as Struct;
+            Assert.IsNotNull(arr);
+            Assert.AreEqual(3, arr!.Count);
+            Assert.AreEqual(name, arr[0].GetString());
+            Assert.AreEqual(2025, arr[1].GetInteger());
+            Assert.AreEqual(tag, arr[2].GetString());
+        }
+
+        [TestMethod]
+        public void Test_WithRecordExtras()
+        {
+            var name = "client";
+            var tag = "tag";
+            var result = Contract.Test_WithRecordExtras(name, tag, 2)!;
+            AssertGasConsumed(2543340);
+            var arr = result as Struct;
+            Assert.IsNotNull(arr);
+            Assert.AreEqual(3, arr!.Count);
+            Assert.AreEqual(name, arr[0].GetString());
+            Assert.AreEqual(2027, arr[1].GetInteger());
+            Assert.AreEqual(tag + ":updated", arr[2].GetString());
+        }
+
+        [TestMethod]
+        public void Test_RecordStructWith()
+        {
+            var result = Contract.Test_RecordStructWith(1, 2, 3, 4)!;
+            AssertGasConsumed(2250930);
+            var arr = result as Struct;
+            Assert.IsNotNull(arr);
+            Assert.AreEqual(3, arr!.Count);
+            Assert.AreEqual(1, arr[0].GetInteger());
+            Assert.AreEqual(6, arr[1].GetInteger());
+            Assert.AreEqual(3, arr[2].GetInteger());
+        }
+
+        [TestMethod]
+        public void Test_DerivedRecordWith()
+        {
+            var result = Contract.Test_DerivedRecordWith("neo", 2, "silver", 1)!;
+            AssertGasConsumed(3578550);
+            var arr = result as Struct;
+            Assert.IsNotNull(arr);
+            Assert.AreEqual(4, arr!.Count);
+            Assert.AreEqual("neo", arr[0].GetString());
+            Assert.AreEqual(3, arr[1].GetInteger());
+            Assert.AreEqual("silver-VIP", arr[2].GetString());
+            Assert.AreEqual(30, arr[3].GetInteger());
+        }
+
+        [TestMethod]
+        public void Test_RecordEquality()
+        {
+            var result = Contract.Test_RecordEquality("neo", 5);
+            AssertGasConsumed(2190090);
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void Test_RecordStructIsolation()
+        {
+            var result = Contract.Test_RecordStructIsolation(1, 2, 3);
+            AssertGasConsumed(2297220);
+            Assert.IsTrue(result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- document how positional record fields are mapped in the compiler and why the OriginalDefinition fallback is required for record-generated symbols
- clarify the with-expression clone fallback and record base-constructor path directly in the compiler
- extend record contract tests (extras, struct copies, derived with) and regenerate the testing artifact to lock in coverage

## Testing
- dotnet test --no-build --filter UnitTest_Record