### PR TITLE
Add: RecoverSecp256K1 and VerifyWithEd25519 for Framework.Native

### DIFF
--- a/src/Neo.SmartContract.Framework/Native/CryptoLib.cs
+++ b/src/Neo.SmartContract.Framework/Native/CryptoLib.cs
@@ -26,14 +26,15 @@ namespace Neo.SmartContract.Framework.Native
         /// Recovers the public key from a secp256k1 signature in bytes format.
         /// Available from HF_Echidna.
         /// </summary>
-        /// <param name="messageHash">The hash of the message that was signed. It cannot be null.</param>
+        /// <param name="messageHash">The 32-byte hash of the message that was signed. It cannot be null.</param>
         /// <param name="signature">
-        /// The signature in raw bytes format if it's length is 64.
-        /// Otherwise, it's the 65-byte signature in format: r[32] + s[32] + v[1]. 64-bytes for eip-2098, where v must be 27 or 28.
+        /// The signature, either:
+        /// - 65 bytes: r[32] + s[32] + v[1], where v is in [0..3] or [27..30], or
+        /// - 64 bytes (EIP-2098 compact): r[32] + yParityAndS[32] (highest bit encodes parity).
         /// It cannot be null.
         /// </param>
         /// <returns>The recovered public key in compressed format, or null if recovery fails.</returns>
-        public static extern ByteString RecoverSecp256K1(ByteString messageHash, ByteString signature);
+        public static extern ByteString? RecoverSecp256K1(ByteString messageHash, ByteString signature);
 
         public static extern ByteString Sha256(ByteString value);
 

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Crypto.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Crypto.cs
@@ -53,6 +53,16 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
             return CryptoLib.VerifyWithECDsa((ByteString)message, pubkey, (ByteString)signature, NamedCurveHash.secp256k1Keccak256);
         }
 
+        public static ByteString? RecoverSecp256K1(byte[] messageHash, byte[] signature)
+        {
+            return CryptoLib.RecoverSecp256K1((ByteString)messageHash, (ByteString)signature);
+        }
+
+        public static bool VerifyWithEd25519(byte[] message, byte[] pubkey, byte[] signature)
+        {
+            return CryptoLib.VerifyWithEd25519((ByteString)message, (ByteString)pubkey, (ByteString)signature);
+        }
+
         public static byte[] Bls12381Serialize(object data)
         {
             return CryptoLib.Bls12381Serialize(data);

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Crypto.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Crypto.cs
@@ -11,72 +11,16 @@ public abstract class Contract_Crypto(Neo.SmartContract.Testing.SmartContractIni
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Crypto"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""SHA256"",""parameters"":[{""name"":""value"",""type"":""ByteArray""}],""returntype"":""ByteArray"",""offset"":0,""safe"":false},{""name"":""RIPEMD160"",""parameters"":[{""name"":""value"",""type"":""ByteArray""}],""returntype"":""ByteArray"",""offset"":12,""safe"":false},{""name"":""murmur32"",""parameters"":[{""name"":""value"",""type"":""ByteArray""},{""name"":""seed"",""type"":""Integer""}],""returntype"":""ByteArray"",""offset"":24,""safe"":false},{""name"":""secp256r1VerifySignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":37,""safe"":false},{""name"":""secp256r1VerifyKeccakSignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":53,""safe"":false},{""name"":""secp256k1VerifySignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":69,""safe"":false},{""name"":""secp256k1VerifyKeccakSignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":85,""safe"":false},{""name"":""bls12381Serialize"",""parameters"":[{""name"":""data"",""type"":""Any""}],""returntype"":""ByteArray"",""offset"":101,""safe"":false},{""name"":""bls12381Deserialize"",""parameters"":[{""name"":""data"",""type"":""ByteArray""}],""returntype"":""Any"",""offset"":109,""safe"":false},{""name"":""bls12381Equal"",""parameters"":[{""name"":""x"",""type"":""Any""},{""name"":""y"",""type"":""Any""}],""returntype"":""Any"",""offset"":117,""safe"":false},{""name"":""bls12381Add"",""parameters"":[{""name"":""x"",""type"":""Any""},{""name"":""y"",""type"":""Any""}],""returntype"":""Any"",""offset"":126,""safe"":false},{""name"":""bls12381Mul"",""parameters"":[{""name"":""x"",""type"":""Any""},{""name"":""mul"",""type"":""ByteArray""},{""name"":""neg"",""type"":""Boolean""}],""returntype"":""Any"",""offset"":135,""safe"":false},{""name"":""bls12381Pairing"",""parameters"":[{""name"":""g1"",""type"":""Any""},{""name"":""g2"",""type"":""Any""}],""returntype"":""Any"",""offset"":145,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0x726cb6e0cd8628a1350a611384688911ab75f51b"",""methods"":[""bls12381Add"",""bls12381Deserialize"",""bls12381Equal"",""bls12381Mul"",""bls12381Pairing"",""bls12381Serialize"",""murmur32"",""ripemd160"",""sha256"",""verifyWithECDsa""]}],""trusts"":[],""extra"":{""Version"":""3.8.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Crypto"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""SHA256"",""parameters"":[{""name"":""value"",""type"":""ByteArray""}],""returntype"":""ByteArray"",""offset"":0,""safe"":false},{""name"":""RIPEMD160"",""parameters"":[{""name"":""value"",""type"":""ByteArray""}],""returntype"":""ByteArray"",""offset"":12,""safe"":false},{""name"":""murmur32"",""parameters"":[{""name"":""value"",""type"":""ByteArray""},{""name"":""seed"",""type"":""Integer""}],""returntype"":""ByteArray"",""offset"":24,""safe"":false},{""name"":""secp256r1VerifySignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":37,""safe"":false},{""name"":""secp256r1VerifyKeccakSignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":53,""safe"":false},{""name"":""secp256k1VerifySignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":69,""safe"":false},{""name"":""secp256k1VerifyKeccakSignatureWithMessage"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""PublicKey""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":85,""safe"":false},{""name"":""recoverSecp256K1"",""parameters"":[{""name"":""messageHash"",""type"":""ByteArray""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""ByteArray"",""offset"":101,""safe"":false},{""name"":""verifyWithEd25519"",""parameters"":[{""name"":""message"",""type"":""ByteArray""},{""name"":""pubkey"",""type"":""ByteArray""},{""name"":""signature"",""type"":""ByteArray""}],""returntype"":""Boolean"",""offset"":114,""safe"":false},{""name"":""bls12381Serialize"",""parameters"":[{""name"":""data"",""type"":""Any""}],""returntype"":""ByteArray"",""offset"":130,""safe"":false},{""name"":""bls12381Deserialize"",""parameters"":[{""name"":""data"",""type"":""ByteArray""}],""returntype"":""Any"",""offset"":138,""safe"":false},{""name"":""bls12381Equal"",""parameters"":[{""name"":""x"",""type"":""Any""},{""name"":""y"",""type"":""Any""}],""returntype"":""Any"",""offset"":146,""safe"":false},{""name"":""bls12381Add"",""parameters"":[{""name"":""x"",""type"":""Any""},{""name"":""y"",""type"":""Any""}],""returntype"":""Any"",""offset"":155,""safe"":false},{""name"":""bls12381Mul"",""parameters"":[{""name"":""x"",""type"":""Any""},{""name"":""mul"",""type"":""ByteArray""},{""name"":""neg"",""type"":""Boolean""}],""returntype"":""Any"",""offset"":164,""safe"":false},{""name"":""bls12381Pairing"",""parameters"":[{""name"":""g1"",""type"":""Any""},{""name"":""g2"",""type"":""Any""}],""returntype"":""Any"",""offset"":174,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0x726cb6e0cd8628a1350a611384688911ab75f51b"",""methods"":[""bls12381Add"",""bls12381Deserialize"",""bls12381Equal"",""bls12381Mul"",""bls12381Pairing"",""bls12381Serialize"",""murmur32"",""recoverSecp256K1"",""ripemd160"",""sha256"",""verifyWithECDsa"",""verifyWithEd25519""]}],""trusts"":[],""extra"":{""Version"":""3.8.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAob9XWrEYlohBNhCjWhKIbN4LZscgZzaGEyNTYBAAEPG/V1qxGJaIQTYQo1oSiGzeC2bHIJcmlwZW1kMTYwAQABDxv1dasRiWiEE2EKNaEohs3gtmxyCG11cm11cjMyAgABDxv1dasRiWiEE2EKNaEohs3gtmxyD3ZlcmlmeVdpdGhFQ0RzYQQAAQ8b9XWrEYlohBNhCjWhKIbN4LZschFibHMxMjM4MVNlcmlhbGl6ZQEAAQ8b9XWrEYlohBNhCjWhKIbN4LZschNibHMxMjM4MURlc2VyaWFsaXplAQABDxv1dasRiWiEE2EKNaEohs3gtmxyDWJsczEyMzgxRXF1YWwCAAEPG/V1qxGJaIQTYQo1oSiGzeC2bHILYmxzMTIzODFBZGQCAAEPG/V1qxGJaIQTYQo1oSiGzeC2bHILYmxzMTIzODFNdWwDAAEPG/V1qxGJaIQTYQo1oSiGzeC2bHIPYmxzMTIzODFQYWlyaW5nAgABDwAAmlcAAXjbKDcAANswQFcAAXjbKDcBANswQFcAAnl42yg3AgDbMEBXAAMAF3rbKHl42yg3AwBAVwADAHt62yh5eNsoNwMAQFcAAwAWetsoeXjbKDcDAEBXAAMAenrbKHl42yg3AwBAVwABeDcEAEBXAAF4NwUAQFcAAnl4NwYAQFcAAnl4NwcAQFcAA3p5eDcIAEBXAAJ5eDcJAEB8Stw+").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwb9XWrEYlohBNhCjWhKIbN4LZscgZzaGEyNTYBAAEPG/V1qxGJaIQTYQo1oSiGzeC2bHIJcmlwZW1kMTYwAQABDxv1dasRiWiEE2EKNaEohs3gtmxyCG11cm11cjMyAgABDxv1dasRiWiEE2EKNaEohs3gtmxyD3ZlcmlmeVdpdGhFQ0RzYQQAAQ8b9XWrEYlohBNhCjWhKIbN4LZschByZWNvdmVyU2VjcDI1NksxAgABDxv1dasRiWiEE2EKNaEohs3gtmxyEXZlcmlmeVdpdGhFZDI1NTE5AwABDxv1dasRiWiEE2EKNaEohs3gtmxyEWJsczEyMzgxU2VyaWFsaXplAQABDxv1dasRiWiEE2EKNaEohs3gtmxyE2JsczEyMzgxRGVzZXJpYWxpemUBAAEPG/V1qxGJaIQTYQo1oSiGzeC2bHINYmxzMTIzODFFcXVhbAIAAQ8b9XWrEYlohBNhCjWhKIbN4LZscgtibHMxMjM4MUFkZAIAAQ8b9XWrEYlohBNhCjWhKIbN4LZscgtibHMxMjM4MU11bAMAAQ8b9XWrEYlohBNhCjWhKIbN4LZscg9ibHMxMjM4MVBhaXJpbmcCAAEPAAC3VwABeNsoNwAA2zBAVwABeNsoNwEA2zBAVwACeXjbKDcCANswQFcAAwAXetsoeXjbKDcDAEBXAAMAe3rbKHl42yg3AwBAVwADABZ62yh5eNsoNwMAQFcAAwB6etsoeXjbKDcDAEBXAAJ52yh42yg3BABAVwADetsoedsoeNsoNwUAQFcAAXg3BgBAVwABeDcHAEBXAAJ5eDcIAEBXAAJ5eDcJAEBXAAN6eXg3CgBAVwACeXg3CwBAfEt+cQ==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
     #region Unsafe methods
-
-    /// <summary>
-    /// Unsafe method
-    /// </summary>
-    /// <remarks>
-    /// Script: VwACeXg3BwBA
-    /// INITSLOT 0002 [64 datoshi]
-    /// LDARG1 [2 datoshi]
-    /// LDARG0 [2 datoshi]
-    /// CALLT 0700 [32768 datoshi]
-    /// RET [0 datoshi]
-    /// </remarks>
-    [DisplayName("bls12381Add")]
-    public abstract object? Bls12381Add(object? x, object? y = null);
-
-    /// <summary>
-    /// Unsafe method
-    /// </summary>
-    /// <remarks>
-    /// Script: VwABeDcFAEA=
-    /// INITSLOT 0001 [64 datoshi]
-    /// LDARG0 [2 datoshi]
-    /// CALLT 0500 [32768 datoshi]
-    /// RET [0 datoshi]
-    /// </remarks>
-    [DisplayName("bls12381Deserialize")]
-    public abstract object? Bls12381Deserialize(byte[]? data);
-
-    /// <summary>
-    /// Unsafe method
-    /// </summary>
-    /// <remarks>
-    /// Script: VwACeXg3BgBA
-    /// INITSLOT 0002 [64 datoshi]
-    /// LDARG1 [2 datoshi]
-    /// LDARG0 [2 datoshi]
-    /// CALLT 0600 [32768 datoshi]
-    /// RET [0 datoshi]
-    /// </remarks>
-    [DisplayName("bls12381Equal")]
-    public abstract object? Bls12381Equal(object? x, object? y = null);
-
-    /// <summary>
-    /// Unsafe method
-    /// </summary>
-    /// <remarks>
-    /// Script: VwADenl4NwgAQA==
-    /// INITSLOT 0003 [64 datoshi]
-    /// LDARG2 [2 datoshi]
-    /// LDARG1 [2 datoshi]
-    /// LDARG0 [2 datoshi]
-    /// CALLT 0800 [32768 datoshi]
-    /// RET [0 datoshi]
-    /// </remarks>
-    [DisplayName("bls12381Mul")]
-    public abstract object? Bls12381Mul(object? x, byte[]? mul, bool? neg);
 
     /// <summary>
     /// Unsafe method
@@ -89,6 +33,62 @@ public abstract class Contract_Crypto(Neo.SmartContract.Testing.SmartContractIni
     /// CALLT 0900 [32768 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
+    [DisplayName("bls12381Add")]
+    public abstract object? Bls12381Add(object? x, object? y = null);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeDcHAEA=
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALLT 0700 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("bls12381Deserialize")]
+    public abstract object? Bls12381Deserialize(byte[]? data);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeXg3CABA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALLT 0800 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("bls12381Equal")]
+    public abstract object? Bls12381Equal(object? x, object? y = null);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwADenl4NwoAQA==
+    /// INITSLOT 0003 [64 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALLT 0A00 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("bls12381Mul")]
+    public abstract object? Bls12381Mul(object? x, byte[]? mul, bool? neg);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeXg3CwBA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALLT 0B00 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
     [DisplayName("bls12381Pairing")]
     public abstract object? Bls12381Pairing(object? g1, object? g2 = null);
 
@@ -96,10 +96,10 @@ public abstract class Contract_Crypto(Neo.SmartContract.Testing.SmartContractIni
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeDcEAEA=
+    /// Script: VwABeDcGAEA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
-    /// CALLT 0400 [32768 datoshi]
+    /// CALLT 0600 [32768 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("bls12381Serialize")]
@@ -120,6 +120,22 @@ public abstract class Contract_Crypto(Neo.SmartContract.Testing.SmartContractIni
     /// </remarks>
     [DisplayName("murmur32")]
     public abstract byte[]? Murmur32(byte[]? value, BigInteger? seed);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACedsoeNsoNwQAQA==
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// CALLT 0400 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("recoverSecp256K1")]
+    public abstract byte[]? RecoverSecp256K1(byte[]? messageHash, byte[]? signature);
 
     /// <summary>
     /// Unsafe method
@@ -220,6 +236,24 @@ public abstract class Contract_Crypto(Neo.SmartContract.Testing.SmartContractIni
     /// RET [0 datoshi]
     /// </remarks>
     public abstract byte[]? SHA256(byte[]? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwADetsoedsoeNsoNwUAQA==
+    /// INITSLOT 0003 [64 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// CALLT 0500 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("verifyWithEd25519")]
+    public abstract bool? VerifyWithEd25519(byte[]? message, byte[]? pubkey, byte[]? signature);
 
     #endregion
 }


### PR DESCRIPTION

Add `RecoverSecp256K1` and `VerifyWithEd25519` for `Framework.Native.CryptLib`.

These methods are available since HF_Echidna.