### PR TITLE
Use stable framework package in templates

### DIFF
--- a/src/Neo.Compiler.CSharp/TemplateManager.cs
+++ b/src/Neo.Compiler.CSharp/TemplateManager.cs
@@ -166,7 +166,7 @@ namespace Neo.Compiler
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Neo.SmartContract.Framework"" Version=""3.8.1-*"" />
+    <PackageReference Include=""Neo.SmartContract.Framework"" Version=""3.8.1"" />
   </ItemGroup>
 
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
@@ -186,7 +186,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             string csprojContent = File.ReadAllText(csprojFilePath);
             Assert.IsTrue(csprojContent.Contains("<TargetFramework>net9.0</TargetFramework>"));
             Assert.IsTrue(csprojContent.Contains("<PackageReference Include=\"Neo.SmartContract.Framework\""));
-            Assert.IsTrue(csprojContent.Contains("Version=\"3.8.1-*\""));
+            Assert.IsTrue(csprojContent.Contains("Version=\"3.8.1\""));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- switch generated template PackageReference to stable 3.8.1
- update template unit test expectation accordingly

## Testing
- not run (tests hung locally)