### PR TITLE
Fix: remove many compiler warnings

### DIFF
--- a/src/Neo.Compiler.CSharp/ContractInterfaceGenerator.cs
+++ b/src/Neo.Compiler.CSharp/ContractInterfaceGenerator.cs
@@ -75,7 +75,7 @@ namespace Neo.Compiler
                         sourceCode.WriteLine($"        [Safe]");
                     }
 
-                    if (property.setter != null)
+                    if (property.setter is not null)
                     {
                         sourceCode.WriteLine($"        {returnType} {propertyName} {{ get; set; }}");
                     }
@@ -157,7 +157,7 @@ namespace Neo.Compiler
                 string propertyName = getter.Name.Substring(4);
                 var setter = methods.FirstOrDefault(m => m.Name == $"set_{propertyName}");
 
-                if (setter != null)
+                if (setter is not null)
                     remainingMethods.Remove(setter);
 
                 properties.Add((getter, setter));

--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
@@ -34,10 +34,10 @@ internal static partial class ContractManifestExtensions
         var transferMethod1 = manifest.Abi.GetMethod("transfer", 3);
         var transferMethod2 = manifest.Abi.GetMethod("transfer", 5);
 
-        var symbolValid = symbolMethod != null && symbolMethod.Safe &&
+        var symbolValid = symbolMethod is not null && symbolMethod.Safe &&
                             symbolMethod.ReturnType == ContractParameterType.String;
 
-        if (symbolMethod == null)
+        if (symbolMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: symbol, it is not found in the ABI"));
 
@@ -45,11 +45,11 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: symbol, it is not safe, you should add a 'Safe' attribute to the symbol method"));
 
-        if (symbolMethod != null && symbolMethod.ReturnType != ContractParameterType.String)
+        if (symbolMethod is not null && symbolMethod.ReturnType != ContractParameterType.String)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: symbol, it's return type is not a string"));
 
-        if (decimalsMethod == null)
+        if (decimalsMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: decimals, it is not found in the ABI"));
 
@@ -57,12 +57,12 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: decimals, it is not safe, you should add a 'Safe' attribute to the decimals method"));
 
-        if (decimalsMethod != null && decimalsMethod.ReturnType != ContractParameterType.Integer)
+        if (decimalsMethod is not null && decimalsMethod.ReturnType != ContractParameterType.Integer)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: decimals, it's return type is not an integer"));
 
 
-        if (totalSupplyMethod == null)
+        if (totalSupplyMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: totalSupply, it is not found in the ABI"));
 
@@ -70,54 +70,54 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: totalSupply, it is not safe, you should add a 'Safe' attribute to the totalSupply method"));
 
-        if (totalSupplyMethod != null && totalSupplyMethod.ReturnType != ContractParameterType.Integer)
+        if (totalSupplyMethod is not null && totalSupplyMethod.ReturnType != ContractParameterType.Integer)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: totalSupply, it's return type is not an integer"));
 
-        if (balanceOfMethod1 == null && balanceOfMethod2 == null)
+        if (balanceOfMethod1 is null && balanceOfMethod2 is null)
         {
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it is not found in the ABI"));
         }
 
-        if (balanceOfMethod1 != null)
+        if (balanceOfMethod1 is not null)
         {
             if (balanceOfMethod1 is { Safe: false })
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it is not safe, you should add a 'Safe' attribute to the balanceOf method"));
 
-            if (balanceOfMethod1 != null && balanceOfMethod1.ReturnType != ContractParameterType.Integer)
+            if (balanceOfMethod1 is not null && balanceOfMethod1.ReturnType != ContractParameterType.Integer)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's return type is not an integer"));
 
-            if (balanceOfMethod1 != null && balanceOfMethod1.Parameters.Length != 1)
+            if (balanceOfMethod1 is not null && balanceOfMethod1.Parameters.Length != 1)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's parameters length is not 1"));
 
-            if (balanceOfMethod1 != null && balanceOfMethod1.Parameters[0].Type != ContractParameterType.Hash160)
+            if (balanceOfMethod1 is not null && balanceOfMethod1.Parameters[0].Type != ContractParameterType.Hash160)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's parameters type is not a Hash160"));
         }
 
-        if (balanceOfMethod2 != null)
+        if (balanceOfMethod2 is not null)
         {
             if (balanceOfMethod2 is { Safe: false })
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it is not safe, you should add a 'Safe' attribute to the balanceOf method"));
 
-            if (balanceOfMethod2 != null && balanceOfMethod2.ReturnType != ContractParameterType.Integer)
+            if (balanceOfMethod2 is not null && balanceOfMethod2.ReturnType != ContractParameterType.Integer)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's return type is not an integer"));
 
-            if (balanceOfMethod2 != null && balanceOfMethod2.Parameters.Length != 2)
+            if (balanceOfMethod2 is not null && balanceOfMethod2.Parameters.Length != 2)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's parameters length is not 2"));
 
-            if (balanceOfMethod2 != null && balanceOfMethod2.Parameters[0].Type != ContractParameterType.Hash160)
+            if (balanceOfMethod2 is not null && balanceOfMethod2.Parameters[0].Type != ContractParameterType.Hash160)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's first parameters type is not a Hash160"));
 
-            if (balanceOfMethod2 != null && balanceOfMethod2.Parameters[1].Type != ContractParameterType.ByteArray)
+            if (balanceOfMethod2 is not null && balanceOfMethod2.Parameters[1].Type != ContractParameterType.ByteArray)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                     $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it's second parameters type is not a ByteArray"));
 
@@ -125,7 +125,7 @@ internal static partial class ContractManifestExtensions
         // errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
         // $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it is not found in the ABI"));
 
-        if (tokensOfMethod == null)
+        if (tokensOfMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it is not found in the ABI"));
 
@@ -133,19 +133,19 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it is not safe, you should add a 'Safe' attribute to the tokensOf method"));
 
-        if (tokensOfMethod != null && tokensOfMethod.ReturnType != ContractParameterType.InteropInterface)
+        if (tokensOfMethod is not null && tokensOfMethod.ReturnType != ContractParameterType.InteropInterface)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it's return type is not an InteropInterface"));
 
-        if (tokensOfMethod != null && tokensOfMethod.Parameters.Length != 1)
+        if (tokensOfMethod is not null && tokensOfMethod.Parameters.Length != 1)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it's parameters length is not 1"));
 
-        if (tokensOfMethod != null && tokensOfMethod.Parameters[0].Type != ContractParameterType.Hash160)
+        if (tokensOfMethod is not null && tokensOfMethod.Parameters[0].Type != ContractParameterType.Hash160)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it's parameters type is not a Hash160"));
 
-        if (ownerOfMethod == null)
+        if (ownerOfMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not found in the ABI"));
 
@@ -153,15 +153,15 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not safe, you should add a 'Safe' attribute to the ownerOf method"));
 
-        if (ownerOfMethod != null && ownerOfMethod.ReturnType != ContractParameterType.Hash160)
+        if (ownerOfMethod is not null && ownerOfMethod.ReturnType != ContractParameterType.Hash160)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's return type is not a Hash160"));
 
-        if (ownerOfMethod != null && ownerOfMethod.Parameters.Length != 1)
+        if (ownerOfMethod is not null && ownerOfMethod.Parameters.Length != 1)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters length is not 1"));
 
-        if (ownerOfMethod == null)
+        if (ownerOfMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not found in the ABI"));
 
@@ -169,85 +169,85 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not safe, you should add a 'Safe' attribute to the ownerOf method"));
 
-        if (ownerOfMethod != null && ownerOfMethod.ReturnType != ContractParameterType.Hash160)
+        if (ownerOfMethod is not null && ownerOfMethod.ReturnType != ContractParameterType.Hash160)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's return type is not an InteropInterface"));
 
-        if (ownerOfMethod != null && ownerOfMethod.Parameters.Length != 1)
+        if (ownerOfMethod is not null && ownerOfMethod.Parameters.Length != 1)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters length is not 1"));
 
-        if (ownerOfMethod != null && ownerOfMethod.Parameters[0].Type != ContractParameterType.ByteArray)
+        if (ownerOfMethod is not null && ownerOfMethod.Parameters[0].Type != ContractParameterType.ByteArray)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters type is not a ByteArray"));
 
 
-        if (transferMethod1 == null && transferMethod2 == null)
+        if (transferMethod1 is null && transferMethod2 is null)
         {
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it is not found in the ABI"));
         }
 
-        if (transferMethod1 != null)
+        if (transferMethod1 is not null)
         {
             if (transferMethod1 is { Safe: false } &&
            transferMethod1.ReturnType != ContractParameterType.Boolean)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it is not safe, you should add a 'Safe' attribute to the transfer method"));
 
-            if (transferMethod1 != null && transferMethod1.ReturnType != ContractParameterType.Boolean)
+            if (transferMethod1 is not null && transferMethod1.ReturnType != ContractParameterType.Boolean)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's return type is not a Boolean"));
 
-            if (transferMethod1 != null && transferMethod1.Parameters.Length != 3)
+            if (transferMethod1 is not null && transferMethod1.Parameters.Length != 3)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's parameters length is not 3"));
 
-            if (transferMethod1 != null && transferMethod1.Parameters[0].Type != ContractParameterType.Hash160)
+            if (transferMethod1 is not null && transferMethod1.Parameters[0].Type != ContractParameterType.Hash160)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's first parameters type is not a Hash160"));
 
-            if (transferMethod1 != null && transferMethod1.Parameters[1].Type != ContractParameterType.ByteArray)
+            if (transferMethod1 is not null && transferMethod1.Parameters[1].Type != ContractParameterType.ByteArray)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's second parameters type is not a ByteArray"));
 
-            if (transferMethod1 != null && transferMethod1.Parameters[2].Type != ContractParameterType.Any)
+            if (transferMethod1 is not null && transferMethod1.Parameters[2].Type != ContractParameterType.Any)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's third parameters type is not a Any"));
         }
 
-        if (transferMethod2 != null)
+        if (transferMethod2 is not null)
         {
             if (transferMethod2 is { Safe: false } &&
           transferMethod2.ReturnType != ContractParameterType.Boolean)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it is not safe, you should add a 'Safe' attribute to the transfer method"));
 
-            if (transferMethod2 != null && transferMethod2.ReturnType != ContractParameterType.Boolean)
+            if (transferMethod2 is not null && transferMethod2.ReturnType != ContractParameterType.Boolean)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's return type is not a Boolean"));
 
-            if (transferMethod2 != null && transferMethod2.Parameters.Length != 5)
+            if (transferMethod2 is not null && transferMethod2.Parameters.Length != 5)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's parameters length is not 5"));
 
-            if (transferMethod2 != null && transferMethod2.Parameters[0].Type != ContractParameterType.Hash160)
+            if (transferMethod2 is not null && transferMethod2.Parameters[0].Type != ContractParameterType.Hash160)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's first parameters type is not a Hash160"));
 
-            if (transferMethod2 != null && transferMethod2.Parameters[1].Type != ContractParameterType.Hash160)
+            if (transferMethod2 is not null && transferMethod2.Parameters[1].Type != ContractParameterType.Hash160)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's second parameters type is not a Hash160"));
 
-            if (transferMethod2 != null && transferMethod2.Parameters[2].Type != ContractParameterType.Integer)
+            if (transferMethod2 is not null && transferMethod2.Parameters[2].Type != ContractParameterType.Integer)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's third parameters type is not an Integer"));
 
-            if (transferMethod2 != null && transferMethod2.Parameters[3].Type != ContractParameterType.ByteArray)
+            if (transferMethod2 is not null && transferMethod2.Parameters[3].Type != ContractParameterType.ByteArray)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's fourth parameters type is not a ByteArray"));
 
-            if (transferMethod2 != null && transferMethod2.Parameters[4].Type != ContractParameterType.Any)
+            if (transferMethod2 is not null && transferMethod2.Parameters[4].Type != ContractParameterType.Any)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's fifth parameters type is not a Any"));
 
@@ -256,30 +256,28 @@ internal static partial class ContractManifestExtensions
         // $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it is not found in the ABI"));
 
         // Check Transfer event
-        var transferEvent = manifest.Abi.Events.FirstOrDefault(a =>
-            a.Name == "Transfer");
-
-        if (transferEvent == null)
+        var transferEvent = manifest.Abi.Events.FirstOrDefault(a => a.Name == "Transfer");
+        if (transferEvent is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete NEP standard {NepStandard.Nep11.ToStandard()} implementation: Transfer event is not found in the ABI"));
 
-        if (transferEvent != null && transferEvent.Parameters.Length != 4)
+        if (transferEvent is not null && transferEvent.Parameters.Length != 4)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's parameters length is not 4"));
 
-        if (transferEvent != null && transferEvent.Parameters[0].Type != ContractParameterType.Hash160)
+        if (transferEvent is not null && transferEvent.Parameters[0].Type != ContractParameterType.Hash160)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's first parameters type is not a Hash160"));
 
-        if (transferEvent != null && transferEvent.Parameters[1].Type != ContractParameterType.Hash160)
+        if (transferEvent is not null && transferEvent.Parameters[1].Type != ContractParameterType.Hash160)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's second parameters type is not a Hash160"));
 
-        if (transferEvent != null && transferEvent.Parameters[2].Type != ContractParameterType.Integer)
+        if (transferEvent is not null && transferEvent.Parameters[2].Type != ContractParameterType.Integer)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's third parameters type is not an Integer"));
 
-        if (transferEvent != null && transferEvent.Parameters[3].Type != ContractParameterType.ByteArray)
+        if (transferEvent is not null && transferEvent.Parameters[3].Type != ContractParameterType.ByteArray)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: transfer, it's fourth parameters type is not a ByteArray"));
 

--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.cs
@@ -24,7 +24,7 @@ namespace Neo.Compiler
             CheckNep29Compliant(this ContractManifest manifest)
         {
             var deployMethod = manifest.Abi.GetMethod("_deploy", 2);
-            var deployValid = deployMethod != null &&
+            var deployValid = deployMethod is not null &&
                               deployMethod.ReturnType == ContractParameterType.Void &&
                               deployMethod.Parameters.Length == 2 &&
                               deployMethod.Parameters[0].Type == ContractParameterType.Any &&
@@ -40,7 +40,7 @@ namespace Neo.Compiler
             CheckNep30Compliant(this ContractManifest manifest)
         {
             var verifyMethod = manifest.Abi.GetMethod("verify", -1);
-            var verifyValid = verifyMethod != null && verifyMethod.Safe &&
+            var verifyValid = verifyMethod is not null && verifyMethod.Safe &&
                                 verifyMethod.ReturnType == ContractParameterType.Boolean;
 
             System.Collections.Generic.List<CompilationException> errors = [];

--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep17.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep17.cs
@@ -31,7 +31,7 @@ internal static partial class ContractManifestExtensions
         var transferMethod = manifest.Abi.GetMethod("transfer", 4);
 
         // Check symbol method
-        if (symbolMethod == null)
+        if (symbolMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: symbol, it is not found in the ABI"));
 
@@ -39,12 +39,12 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: symbol, it is not safe, you should add a 'Safe' attribute to the symbol method"));
 
-        if (symbolMethod != null && symbolMethod.ReturnType != ContractParameterType.String)
+        if (symbolMethod is not null && symbolMethod.ReturnType != ContractParameterType.String)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: symbol, it's return type is not a String"));
 
         // Check decimals method
-        if (decimalsMethod == null)
+        if (decimalsMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: decimals, it is not found in the ABI"));
 
@@ -52,12 +52,12 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: decimals, it is not safe, you should add a 'Safe' attribute to the decimals method"));
 
-        if (decimalsMethod != null && decimalsMethod.ReturnType != ContractParameterType.Integer)
+        if (decimalsMethod is not null && decimalsMethod.ReturnType != ContractParameterType.Integer)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: decimals, it's return type is not an Integer"));
 
         // Check totalSupply method
-        if (totalSupplyMethod == null)
+        if (totalSupplyMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: totalSupply, it is not found in the ABI"));
 
@@ -65,12 +65,12 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: totalSupply, it is not safe, you should add a 'Safe' attribute to the totalSupply method"));
 
-        if (totalSupplyMethod != null && totalSupplyMethod.ReturnType != ContractParameterType.Integer)
+        if (totalSupplyMethod is not null && totalSupplyMethod.ReturnType != ContractParameterType.Integer)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: totalSupply, it's return type is not an Integer"));
 
         // Check balanceOf method
-        if (balanceOfMethod == null)
+        if (balanceOfMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: balanceOf, it is not found in the ABI"));
 
@@ -78,37 +78,37 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: balanceOf, it is not safe, you should add a 'Safe' attribute to the balanceOf method"));
 
-        if (balanceOfMethod != null && balanceOfMethod.ReturnType != ContractParameterType.Integer)
+        if (balanceOfMethod is not null && balanceOfMethod.ReturnType != ContractParameterType.Integer)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: balanceOf, it's return type is not an Integer"));
 
-        if (balanceOfMethod != null && balanceOfMethod.Parameters.Length != 1)
+        if (balanceOfMethod is not null && balanceOfMethod.Parameters.Length != 1)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: balanceOf, it's parameters length is not 1"));
 
-        if (balanceOfMethod != null && balanceOfMethod.Parameters[0].Type != ContractParameterType.Hash160)
+        if (balanceOfMethod is not null && balanceOfMethod.Parameters[0].Type != ContractParameterType.Hash160)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: balanceOf, it's parameter type is not a Hash160"));
 
         // Check transfer method
-        if (transferMethod == null)
+        if (transferMethod is null)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: transfer, it is not found in the ABI"));
 
         // Note: transfer method should NOT be safe as per NEP-17 standard
-        if (transferMethod != null && transferMethod.Safe)
+        if (transferMethod is not null && transferMethod.Safe)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: transfer, it should not be marked as Safe"));
 
-        if (transferMethod != null && transferMethod.ReturnType != ContractParameterType.Boolean)
+        if (transferMethod is not null && transferMethod.ReturnType != ContractParameterType.Boolean)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: transfer, it's return type is not a Boolean"));
 
-        if (transferMethod != null && transferMethod.Parameters.Length != 4)
+        if (transferMethod is not null && transferMethod.Parameters.Length != 4)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep17.ToStandard()} implementation: transfer, it's parameters length is not 4"));
 
-        if (transferMethod != null && transferMethod.Parameters.Length == 4)
+        if (transferMethod is not null && transferMethod.Parameters.Length == 4)
         {
             if (transferMethod.Parameters[0].Type != ContractParameterType.Hash160)
                 errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
@@ -128,12 +128,12 @@ internal static partial class ContractManifestExtensions
         }
 
         // Check Transfer event
-        var transferEvent = manifest.Abi.Events.FirstOrDefault(e =>
-            e.Name == "Transfer");
-
-        if (transferEvent == null)
+        var transferEvent = manifest.Abi.Events.FirstOrDefault(e => e.Name == "Transfer");
+        if (transferEvent is null)
+        {
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete NEP standard {NepStandard.Nep17.ToStandard()} implementation: Transfer event is not found in the ABI"));
+        }
         else
         {
             if (transferEvent.Parameters.Length != 3)

--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep24.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep24.cs
@@ -26,7 +26,7 @@ internal static partial class ContractManifestExtensions
         var royaltyInfoMethod = manifest.Abi.GetMethod("royaltyInfo", 3);
 
         // Check if method exists
-        if (royaltyInfoMethod == null)
+        if (royaltyInfoMethod is null)
         {
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
                 $"Incomplete or unsafe NEP standard {NepStandard.Nep24.ToStandard()} implementation: royaltyInfo, it is not found in the ABI"));

--- a/src/Neo.SmartContract.Framework/Services/Runtime.cs
+++ b/src/Neo.SmartContract.Framework/Services/Runtime.cs
@@ -81,7 +81,7 @@ namespace Neo.SmartContract.Framework.Services
         }
 
         /// <summary>
-        /// Gets the unixtimestamp in seconds of the current block.
+        /// Gets the unixtimestamp in milliseconds of the current block.
         /// </summary>
         public static extern ulong Time
         {

--- a/src/Neo.SmartContract.Testing/Extensions/ArtifactExtensions.cs
+++ b/src/Neo.SmartContract.Testing/Extensions/ArtifactExtensions.cs
@@ -289,7 +289,7 @@ namespace Neo.SmartContract.Testing.Extensions
                 properties.Add((getter, setter));
                 methodList.Remove(getter);
 
-                if (setter != null)
+                if (setter is not null)
                 {
                     methodList.Remove(setter);
                 }
@@ -431,7 +431,7 @@ namespace Neo.SmartContract.Testing.Extensions
             if (debugInfo != null && nefFile != null)
             {
                 var debugMethod = Disassembler.CSharp.Disassembler.GetMethod(method, debugInfo);
-                if (debugMethod != null)
+                if (debugMethod is not null)
                 {
                     var (start, end) = Disassembler.CSharp.Disassembler.GetMethodStartEndAddress(debugMethod);
                     var instructions = Disassembler.CSharp.Disassembler.ConvertMethodToInstructions(nefFile, start, end);
@@ -530,7 +530,7 @@ namespace Neo.SmartContract.Testing.Extensions
 
                 foreach (var entry in compilerArray)
                 {
-                    if (entry == null) continue;
+                    if (entry is null) continue;
                     if (first) first = false;
                     else builder.Append(',');
                     builder.Append($"{entry["file"]?.AsString()}:{entry["line"]}({entry["method"]?.AsString()})");

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -37,7 +37,7 @@ namespace Neo.SmartContract.Testing
 {
     public class TestEngine
     {
-        public delegate UInt160? OnGetScriptHash(UInt160 current, UInt160 expected);
+        public delegate UInt160? OnGetScriptHash(UInt160? current, UInt160? expected);
 
         internal readonly List<FeeWatcher> _feeWatchers = [];
         internal readonly Dictionary<UInt160, CoveredContract> Coverage = [];
@@ -301,7 +301,10 @@ namespace Neo.SmartContract.Testing
                 if (Storage.IsInitialized)
                 {
                     var currentHash = NativeContract.Ledger.CurrentHash(Storage.Snapshot);
-                    PersistingBlock = new PersistingBlock(this, NativeContract.Ledger.GetBlock(Storage.Snapshot, currentHash));
+                    var block = NativeContract.Ledger.GetBlock(Storage.Snapshot, currentHash);
+                    if (block is null) throw new InvalidOperationException($"Can't get the current block {currentHash}");
+
+                    PersistingBlock = new PersistingBlock(this, block);
                 }
                 else
                 {

--- a/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
@@ -45,7 +45,7 @@ namespace Neo.SmartContract.Testing
             {
                 Name = TestingSyscall.Name,
                 Handler = typeof(TestingApplicationEngine).GetMethod(nameof(InvokeTestingSyscall),
-                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic),
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!,
                 FixedPrice = 0,
                 RequiredCallFlags = CallFlags.None,
             };
@@ -66,7 +66,7 @@ namespace Neo.SmartContract.Testing
         /// <summary>
         /// Override CallingScriptHash
         /// </summary>
-        public override UInt160 CallingScriptHash
+        public override UInt160? CallingScriptHash
         {
             get
             {
@@ -78,7 +78,7 @@ namespace Neo.SmartContract.Testing
         /// <summary>
         /// Override EntryScriptHash
         /// </summary>
-        public override UInt160 EntryScriptHash
+        public override UInt160? EntryScriptHash
         {
             get
             {

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NativeContracts.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NativeContracts.cs
@@ -76,11 +76,15 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Ledger()
         {
             var genesisBlock = NativeContract.Ledger.GetBlock(Engine.Storage.Snapshot, 0);
+            Assert.IsNotNull(genesisBlock);
             Assert.AreEqual(NativeContract.Ledger.Hash, Contract.LedgerHash());
             AssertGasConsumed(984270);
             Assert.AreEqual(0, Contract.LedgerCurrentIndex());
             AssertGasConsumed(2950140);
-            Assert.AreEqual(genesisBlock.Hash, Contract.LedgerCurrentHash());
+
+            var currentHash = Contract.LedgerCurrentHash();
+            Assert.IsNotNull(currentHash);
+            Assert.AreEqual(genesisBlock.Hash, currentHash);
             AssertGasConsumed(2950140);
         }
     }


### PR DESCRIPTION
 This PR removes many compiler warnings

> Build succeeded with 152 warning(s) in 5.6s

Warnings like these:
```
neo-devpack-dotnet/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep17.cs(111,13): warning CS8604: Possible null reference argument for parameter 'left' in 'bool ContractMethodDescriptor.operator !=(ContractMethodDescriptor left, ContractMethodDescriptor right)'.
neo-devpack-dotnet/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep17.cs(111,31): warning CS8625: Cannot convert null literal to non-nullable reference type.
neo-devpack-dotnet/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep17.cs(134,13): warning CS8604: Possible null reference argument for parameter 'left' in 'bool ContractEventDescriptor.operator ==(ContractEventDescriptor left, ContractEventDescriptor right)'.
neo-devpack-dotnet/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep17.cs(134,30): warning CS8625: Cannot convert null literal to non-nullable reference type.
neo-devpack-dotnet/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep24.cs(29,13): warning CS8604: Possible null reference argument for parameter 'left' in 'bool ContractMethodDescriptor.operator ==(ContractMethodDescriptor left, ContractMethodDescriptor right)'.
neo-devpack-dotnet/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtensions.Nep24.cs(29,34): warning CS8625: Cannot convert null literal to non-nullable reference type.
```