### PR TITLE
Make Neo.SmartContract.Testing only for building and compiling

### DIFF
--- a/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
+++ b/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
@@ -38,7 +38,10 @@
     <ProjectReference Include="..\Neo.SmartContract.Framework\Neo.SmartContract.Framework.csproj">
       <Aliases>scfx</Aliases>
     </ProjectReference>
-    <ProjectReference Include="..\Neo.SmartContract.Testing\Neo.SmartContract.Testing.csproj" />
+    <ProjectReference Include="..\Neo.SmartContract.Testing\Neo.SmartContract.Testing.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj
@@ -14,6 +14,7 @@
 		<ProjectReference Include="..\..\src\Neo.SmartContract.Framework\Neo.SmartContract.Framework.csproj">
 			<Aliases>scfx</Aliases>
 		</ProjectReference>
+    <ProjectReference Include="..\..\src\Neo.SmartContract.Testing\Neo.SmartContract.Testing.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Currently, compiler nuget is much larger than others (12MB+). It's esay to fullfil Nuget space. This PR can reduce 12.4% size of nuget. It doesn't enable `Neo.SmartContract.Testing` being packed into compiler nuget package.

## Optimization Results

| Metric | Before Optimization | After Optimization | Improvement |
|--------|---------------------|---------------------|-------------|
| **NuGet Package Size** | 12.45 MB | 10.91 MB | **-1.55 MB (-12.4%)** |
| **DLL File Count** | 55 files | 43 files | **-12 files** |
| **DLL Total Size (uncompressed)** | 22.18 MB | 19.51 MB | **-2.67 MB** |

## Removed Files

The following 12 test-related DLL files were excluded from the package:

| File Name | Size | Description |
|-----------|------|-------------|
| ReportGenerator.Core.dll | 1.3 MB | Test coverage report generator |
| Microsoft.VisualStudio.TestPlatform.TestFramework.dll | 0.36 MB | MSTest testing framework |
| Moq.dll | 0.3 MB | Test mocking framework |
| Castle.Core.dll | 0.37 MB | Dynamic proxy library (test dependency) |
| Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll | 0.03 MB | MSTest extensions |
| DotNetConfig.dll | 0.1 MB | Configuration file library |
| McMaster.NETCore.Plugins.dll | 0.03 MB | Plugin loader |
| Microsoft.DotNet.PlatformAbstractions.dll | 0.02 MB | Platform abstraction layer |
| Microsoft.Extensions.Configuration.CommandLine.dll | 0.03 MB | Command-line configuration extension |
| Microsoft.Extensions.DependencyModel.dll | 0.07 MB | Dependency model |
| ReportGenerator.DotnetCorePluginLoader.dll | 0.01 MB | Report generator plugin loader |
| System.Diagnostics.EventLog.dll | 0.05 MB | Event log (Windows-specific) |

