### PR TITLE
Fix: no contract method `GetExecPicoFeeFactor` in N4

### DIFF
--- a/examples/Example.SmartContract.FaunFeatures.UnitTests/FaunFeaturesTests.cs
+++ b/examples/Example.SmartContract.FaunFeatures.UnitTests/FaunFeaturesTests.cs
@@ -28,10 +28,7 @@ namespace Example.SmartContract.FaunFeatures.UnitTests
         public void TestExecFeeFactors()
         {
             var execFeeFactor = Contract.ExecFeeFactor ?? BigInteger.Zero;
-            var execPicoFeeFactor = Contract.ExecPicoFeeFactor ?? BigInteger.Zero;
-
             Assert.IsTrue(execFeeFactor > 0);
-            Assert.IsTrue(execPicoFeeFactor > BigInteger.Zero);
         }
     }
 }

--- a/examples/Example.SmartContract.FaunFeatures/FaunFeatures.cs
+++ b/examples/Example.SmartContract.FaunFeatures/FaunFeatures.cs
@@ -43,12 +43,6 @@ public class SampleFaunFeatures : SmartContract
     }
 
     [Safe]
-    public static BigInteger ExecPicoFeeFactor()
-    {
-        return Policy.GetExecPicoFeeFactor();
-    }
-
-    [Safe]
     public static bool IsCommitteeSigned()
     {
         return Treasury.Verify();

--- a/examples/Example.SmartContract.FaunFeatures/README.md
+++ b/examples/Example.SmartContract.FaunFeatures/README.md
@@ -1,17 +1,15 @@
 # Neo N3 HF_Faun Features Example
 
 ## Overview
-This example demonstrates Neo v3.9 (HF_Faun) native additions, including hex encoding helpers, pico-fee factor access, and treasury signature checks.
+This example demonstrates Neo v3.9 (HF_Faun) native additions, including hex encoding helpers, and treasury signature checks.
 
 ## Key Features
 - `StdLib.HexEncode` and `StdLib.HexDecode` for hex conversions
-- `Policy.GetExecPicoFeeFactor` for picoGAS execution pricing
 - `Treasury.Verify` for committee signature verification
 
 ## Usage
 The `SampleFaunFeatures` contract exposes simple read-only methods that can be called by clients to:
 - Encode and decode hex strings
-- Retrieve execution fee factors
 - Check if the current transaction is committee-signed
 
 ## Notes

--- a/src/Neo.SmartContract.Framework/Native/Policy.cs
+++ b/src/Neo.SmartContract.Framework/Native/Policy.cs
@@ -37,16 +37,6 @@ namespace Neo.SmartContract.Framework.Native
         public static extern uint GetExecFeeFactor();
 
         /// <summary>
-        /// Get the execution fee factor in picoGAS, 1 picoGAS = 1e-12 GAS.
-        /// Available since HF_Faun.
-        /// CallFlags requirement: CallFlags.ReadStates.
-        /// </summary>
-        public static BigInteger GetExecPicoFeeFactor()
-        {
-            return (BigInteger)GetExecFeeFactor() * 10000;
-        }
-
-        /// <summary>
         /// Get the storage price for per storage byte in the unit of datoshi, 1 datoshi = 1e-8 GAS.
         /// CallFlags requirement: CallFlags.ReadStates.
         /// </summary>

--- a/src/Neo.SmartContract.Framework/Native/Policy.cs
+++ b/src/Neo.SmartContract.Framework/Native/Policy.cs
@@ -30,7 +30,7 @@ namespace Neo.SmartContract.Framework.Native
         public static extern long GetFeePerByte();
 
         /// <summary>
-        /// Get the execution fee factor.
+        /// Get the execution fee factor in the unit of datoshi, 1 datoshi = 1e-8 GAS.
         /// The system fee is the base-fee multiplied by the execution fee factor.
         /// CallFlags requirement: CallFlags.ReadStates.
         /// </summary>
@@ -41,7 +41,10 @@ namespace Neo.SmartContract.Framework.Native
         /// Available since HF_Faun.
         /// CallFlags requirement: CallFlags.ReadStates.
         /// </summary>
-        public static extern BigInteger GetExecPicoFeeFactor();
+        public static BigInteger GetExecPicoFeeFactor()
+        {
+            return (BigInteger)GetExecFeeFactor() * 10000;
+        }
 
         /// <summary>
         /// Get the storage price for per storage byte in the unit of datoshi, 1 datoshi = 1e-8 GAS.

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_PartialCrossFile.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_PartialCrossFile.cs
@@ -5,13 +5,15 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;
 
+#pragma warning disable CS0067
+
 namespace Neo.SmartContract.Testing;
 
 public abstract class Contract_PartialCrossFile(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), IContractInfo
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_PartialCrossFile"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""getBaseValue"",""parameters"":[],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testCrossFileCall"",""parameters"":[],""returntype"":""Integer"",""offset"":3,""safe"":false},{""name"":""getMultiplier"",""parameters"":[],""returntype"":""Integer"",""offset"":55,""safe"":false},{""name"":""testCrossFileCallReverse"",""parameters"":[],""returntype"":""Integer"",""offset"":57,""safe"":false},{""name"":""expressionBodyTest"",""parameters"":[],""returntype"":""Integer"",""offset"":108,""safe"":false},{""name"":""complexCrossFileExpression"",""parameters"":[],""returntype"":""Integer"",""offset"":111,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.8.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_PartialCrossFile"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""getBaseValue"",""parameters"":[],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testCrossFileCall"",""parameters"":[],""returntype"":""Integer"",""offset"":3,""safe"":false},{""name"":""getMultiplier"",""parameters"":[],""returntype"":""Integer"",""offset"":55,""safe"":false},{""name"":""testCrossFileCallReverse"",""parameters"":[],""returntype"":""Integer"",""offset"":57,""safe"":false},{""name"":""expressionBodyTest"",""parameters"":[],""returntype"":""Integer"",""offset"":108,""safe"":false},{""name"":""complexCrossFileExpression"",""parameters"":[],""returntype"":""Integer"",""offset"":111,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"


### PR DESCRIPTION
The `PolicyContract` doesn't have contract method `GetExecPicoFeeFactor` in N4.

So adding an implementation rather than definition.