### PR TITLE
fix(compiler): add int support for type patterns

### DIFF
--- a/docs/csharp-syntax/UnsupportedFeatures.md
+++ b/docs/csharp-syntax/UnsupportedFeatures.md
@@ -29,7 +29,6 @@ The versioned syntax checklists flag every feature the Neo compiler currently re
   - Exception filters (`exception_filter`)
 
 - **C# 7 Syntax Checklist**  
-  - Pattern matching with `is` (`pattern_matching_is`)
   - Local functions (`local_function`)
   - Ref returns (`ref_return`)
   - `ref` argument targeting array element (`ref_argument_array_element`)

--- a/docs/csharp-syntax/csharp-7.md
+++ b/docs/csharp-syntax/csharp-7.md
@@ -16,9 +16,9 @@ int sum = a + b;
 
 ### pattern_matching_is - Pattern matching with `is`
 
-Status: unsupported
+Status: supported
 Scope: method
-Notes: Type patterns in `is` expressions are rejected by the compiler. Roslyn would lower pattern matching into type checks, but Neo currently rejects this syntax.
+Notes: Type patterns in `is` expressions compile when the matched type maps to supported Neo stack item types (for example: `bool`, `int`, `string`, `byte[]`, `ByteString`, and `BigInteger`).
 ```csharp
 object value = 5;
 if (value is int number)

--- a/src/Neo.Compiler.CSharp/Helper.cs
+++ b/src/Neo.Compiler.CSharp/Helper.cs
@@ -135,6 +135,7 @@ namespace Neo.Compiler
             return type.ToString() switch
             {
                 "bool" => StackItemType.Boolean,
+                "int" => StackItemType.Integer,
                 "byte[]" => StackItemType.Buffer,
                 "string" => StackItemType.ByteString,
                 "Neo.SmartContract.Framework.ByteString" => StackItemType.ByteString,

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_PatternTypeSupport.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_PatternTypeSupport.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_PatternTypeSupport.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+
+namespace Neo.Compiler.CSharp.UnitTests.Syntax;
+
+[TestClass]
+public class UnitTest_PatternTypeSupport
+{
+    [TestMethod]
+    public void TypePattern_Int_Compiles()
+    {
+        Helper.AssertClassCompilationSucceeds(@"
+public static bool MatchInt(object value)
+{
+    return value is int;
+}", "Type pattern with int should compile.");
+    }
+}


### PR DESCRIPTION
## Summary
- add missing `int` mapping in `Helper.GetPatternType` so `is int` type patterns compile
- add `UnitTest_PatternTypeSupport.TypePattern_Int_Compiles` regression test

## Root cause
`GetPatternType` used string-based type matching and omitted the `"int"` case, even though the error message listed it as supported.

## Validation
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_PatternTypeSupport.TypePattern_Int_Compiles" -v minimal`
