### PR TITLE
fix(compiler): fail fast on local function declarations

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Statement/Statement.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Statement/Statement.cs
@@ -151,9 +151,9 @@ namespace Neo.Compiler
                 case LocalDeclarationStatementSyntax syntax:
                     ConvertLocalDeclarationStatement(model, syntax);
                     break;
-                // Currently, local function statements are not supported in this context.
-                case LocalFunctionStatementSyntax:
-                    break;
+                // Local function statements are currently unsupported and must fail explicitly.
+                case LocalFunctionStatementSyntax syntax:
+                    throw CompilationException.UnsupportedSyntax(syntax, "Local functions are not supported. Move the function to a class-level method.");
                 // Converts a return statement, used to exit a method and optionally return a value.
                 // Example: return x + y;
                 case ReturnStatementSyntax syntax:

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_LocalFunctionSyntax.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_LocalFunctionSyntax.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_LocalFunctionSyntax.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+
+namespace Neo.Compiler.CSharp.UnitTests.Syntax;
+
+[TestClass]
+public class UnitTest_LocalFunctionSyntax
+{
+    [TestMethod]
+    public void LocalFunctionDeclaration_CompilationFails()
+    {
+        Helper.AssertClassCompilationFails(@"
+public static int LocalFunctionIgnoredToday()
+{
+    int Add(int a, int b)
+    {
+        return a + b;
+    }
+
+    return 1;
+}", "Local function declarations must be rejected explicitly.");
+    }
+}


### PR DESCRIPTION
## Summary
- reject `LocalFunctionStatementSyntax` explicitly in statement conversion
- add regression test ensuring local-function declarations fail compilation with an explicit compiler diagnostic

## Root cause
`ConvertStatement` silently ignored local function declarations (`break` branch), which let contracts compile while dropping local-function code unexpectedly.

## Validation
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_LocalFunctionSyntax.LocalFunctionDeclaration_CompilationFails" -v minimal`
