### PR TITLE
fix: resolve P0 critical infrastructure and analyzer issues

### DIFF
--- a/.devcontainer/devcontainer.dockerfile
+++ b/.devcontainer/devcontainer.dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:9.0-jammy
+FROM mcr.microsoft.com/devcontainers/dotnet:10.0-jammy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Neo Smart Contract Compiler (nccs)
 
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /source
 
 # Copy solution and project files
@@ -26,7 +26,7 @@ RUN dotnet publish src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj \
     -o /app
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0
 WORKDIR /workspace
 
 # Install additional tools

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Variables
 DOTNET = dotnet
 NCCS_PROJECT = src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
-NCCS_BINARY = src/Neo.Compiler.CSharp/bin/Release/net9.0/nccs
+NCCS_BINARY = src/Neo.Compiler.CSharp/bin/Release/net10.0/nccs
 PUBLISH_ARGS ?=
 
 ifeq ($(NO_RESTORE),true)
@@ -41,7 +41,7 @@ else ifeq ($(UNAME_S),Darwin)
 else ifeq ($(OS),Windows_NT)
     PLATFORM = win
     RID = win-x64
-    NCCS_BINARY = src/Neo.Compiler.CSharp/bin/Release/net9.0/nccs.exe
+    NCCS_BINARY = src/Neo.Compiler.CSharp/bin/Release/net10.0/nccs.exe
 endif
 
 # Default target

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                 VM.Instruction instruction1 = instructions[i + 1].instruction;
                 VM.Instruction instruction2 = instructions[i + 2].instruction;
                 if (instruction.OpCode == OpCode.PUSHDATA1 && instruction.Operand.ToArray().SequenceEqual(update)
-                 && instruction1.OpCode == OpCode.PUSHDATA1 && instruction1.Operand.ToArray() == NativeContract.ContractManagement.Hash
+                 && instruction1.OpCode == OpCode.PUSHDATA1 && new UInt160(instruction1.Operand.ToArray()) == NativeContract.ContractManagement.Hash
                  && instruction2.OpCode == OpCode.SYSCALL && instruction2.TokenU32 == ApplicationEngine.System_Contract_Call.Hash)
                     return true;
             }


### PR DESCRIPTION
## Summary

Fixes 4 P0 critical issues that block Docker builds, DevContainer usage, Makefile compilation, and a dead code path in the security analyzer. Devpack Review report is here https://github.com/neo-project/neo-devpack-dotnet/issues/1514

## Changes

### P0-1: Dockerfile .NET version mismatch
- **File**: `Dockerfile:4,29`
- Updated SDK base image from `dotnet/sdk:9.0` → `10.0`
- Updated runtime base image from `dotnet/runtime-deps:9.0` → `10.0`
- Projects target .NET 10.0; the 9.0 images fail to build

### P0-2: DevContainer .NET version mismatch
- **File**: `.devcontainer/devcontainer.dockerfile:1`
- Updated from `devcontainers/dotnet:9.0-jammy` → `10.0-jammy`

### P0-3: Makefile binary path mismatch
- **File**: `Makefile:7,44`
- Updated `NCCS_BINARY` paths from `net9.0` → `net10.0` (both Linux and Windows)

### P0-4: UpdateAnalyzer SYSCALL detection dead code
- **File**: `src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs:53`
- The SYSCALL-based contract update detection path was dead code because `byte[]` reference equality (`==`) was used to compare an operand against `NativeContract.ContractManagement.Hash` (a `UInt160`)
- Fixed by constructing a `UInt160` from the operand bytes and using the overloaded `==` operator for proper value equality

## Verification

- Full solution builds with 0 errors, 0 warnings
- All 1329 tests pass (Compiler: 956, Framework: 216, Analyzer: 98, Template: 27, Testing: 32)