### PR TITLE
fix(framework): align NEP-11/NEP-26 runtime and manifest behavior

### DIFF
--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
@@ -161,22 +161,6 @@ internal static partial class ContractManifestExtensions
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters length is not 1"));
 
-        if (ownerOfMethod is null)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not found in the ABI"));
-
-        if (ownerOfMethod is { Safe: false })
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not safe, you should add a 'Safe' attribute to the ownerOf method"));
-
-        if (ownerOfMethod is not null && ownerOfMethod.ReturnType != ContractParameterType.Hash160)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's return type is not an InteropInterface"));
-
-        if (ownerOfMethod is not null && ownerOfMethod.Parameters.Length != 1)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters length is not 1"));
-
         if (ownerOfMethod is not null && ownerOfMethod.Parameters[0].Type != ContractParameterType.ByteArray)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
             $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters type is not a ByteArray"));

--- a/src/Neo.SmartContract.Framework/Interfaces/INEP26.cs
+++ b/src/Neo.SmartContract.Framework/Interfaces/INEP26.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using System.Numerics;
+using Neo.SmartContract.Framework.Services;
 
 namespace Neo.SmartContract.Framework.Interfaces;
 
@@ -33,5 +34,5 @@ public interface INEP26
     /// Both static and non-static methods of smart contract interface works,
     /// they differ on how you process static field.
     /// </remarks>
-    public void OnNEP11Payment(UInt160 from, BigInteger amount, string tokenId, object? data = null);
+    public void OnNEP11Payment(UInt160 from, BigInteger amount, ByteString tokenId, object? data = null);
 }

--- a/src/Neo.SmartContract.Framework/Nep11Token.cs
+++ b/src/Neo.SmartContract.Framework/Nep11Token.cs
@@ -48,8 +48,10 @@ namespace Neo.SmartContract.Framework
         [Safe]
         public virtual Map<string, object> Properties(ByteString tokenId)
         {
+            if (tokenId.Length > 64) throw new Exception("The argument \"tokenId\" should be 64 or less bytes long.");
             var tokenMap = new StorageMap(Prefix_Token);
-            TokenState token = (TokenState)StdLib.Deserialize(tokenMap[tokenId]!);
+            var tokenKey = tokenMap[tokenId] ?? throw new Exception("The token with given \"tokenId\" does not exist.");
+            TokenState token = (TokenState)StdLib.Deserialize(tokenKey);
             return new Map<string, object>()
             {
                 ["name"] = token.Name
@@ -77,7 +79,8 @@ namespace Neo.SmartContract.Framework
             if (!to.IsValid) throw new Exception("The argument \"to\" is invalid.");
 
             var tokenMap = new StorageMap(Prefix_Token);
-            TokenState token = (TokenState)StdLib.Deserialize(tokenMap[tokenId]!);
+            var tokenKey = tokenMap[tokenId] ?? throw new Exception("The token with given \"tokenId\" does not exist.");
+            TokenState token = (TokenState)StdLib.Deserialize(tokenKey);
             UInt160 from = token.Owner;
             if (!Runtime.CheckWitness(from)) return false;
             if (from != to)
@@ -140,7 +143,7 @@ namespace Neo.SmartContract.Framework
         {
             OnTransfer(from, to, 1, tokenId);
             if (to is not null && ContractManagement.GetContract(to) is not null)
-                Contract.Call(to, "onNEP11Payment", CallFlags.All, from, 1, tokenId, data);
+                Contract.Call(to, Method.OnNEP11Payment, CallFlags.All, from, 1, tokenId, data);
         }
     }
 }

--- a/src/Neo.SmartContract.Framework/Nep11Token.cs
+++ b/src/Neo.SmartContract.Framework/Nep11Token.cs
@@ -14,12 +14,14 @@ using Neo.SmartContract.Framework.Native;
 using Neo.SmartContract.Framework.Services;
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace Neo.SmartContract.Framework
 {
     [SupportedStandards(NepStandard.Nep11)]
     [ContractPermission(Permission.Any, Method.OnNEP11Payment)]
+    [ExcludeFromCodeCoverage]
     public abstract class Nep11Token<TokenState> : TokenContract
         where TokenState : Nep11TokenState
     {

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_NEP11.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_NEP11.cs
@@ -13,12 +13,12 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_NEP11"",""groups"":[],""features"":{},""supportedstandards"":[""NEP-11""],""abi"":{""methods"":[{""name"":""symbol"",""parameters"":[],""returntype"":""String"",""offset"":0,""safe"":true},{""name"":""decimals"",""parameters"":[],""returntype"":""Integer"",""offset"":7,""safe"":true},{""name"":""totalSupply"",""parameters"":[],""returntype"":""Integer"",""offset"":9,""safe"":true},{""name"":""balanceOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""Integer"",""offset"":29,""safe"":true},{""name"":""ownerOf"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Hash160"",""offset"":207,""safe"":true},{""name"":""properties"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Map"",""offset"":366,""safe"":true},{""name"":""tokens"",""parameters"":[],""returntype"":""InteropInterface"",""offset"":413,""safe"":true},{""name"":""tokensOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""InteropInterface"",""offset"":441,""safe"":true},{""name"":""transfer"",""parameters"":[{""name"":""to"",""type"":""Hash160""},{""name"":""tokenId"",""type"":""ByteArray""},{""name"":""data"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":523,""safe"":false}],""events"":[{""name"":""Transfer"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""to"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""ByteArray""}]}]},""permissions"":[{""contract"":""0x726cb6e0cd8628a1350a611384688911ab75f51b"",""methods"":[""sha256""]},{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""deserialize"",""serialize""]},{""contract"":""0xfffdc93764dbaddd97c48f252a53ea4643faa3fd"",""methods"":[""getContract""]},{""contract"":""*"",""methods"":[""onNEP11Payment""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_NEP11"",""groups"":[],""features"":{},""supportedstandards"":[""NEP-11""],""abi"":{""methods"":[{""name"":""symbol"",""parameters"":[],""returntype"":""String"",""offset"":0,""safe"":true},{""name"":""decimals"",""parameters"":[],""returntype"":""Integer"",""offset"":7,""safe"":true},{""name"":""totalSupply"",""parameters"":[],""returntype"":""Integer"",""offset"":9,""safe"":true},{""name"":""balanceOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""Integer"",""offset"":29,""safe"":true},{""name"":""ownerOf"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Hash160"",""offset"":207,""safe"":true},{""name"":""properties"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Map"",""offset"":366,""safe"":true},{""name"":""tokens"",""parameters"":[],""returntype"":""InteropInterface"",""offset"":534,""safe"":true},{""name"":""tokensOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""InteropInterface"",""offset"":562,""safe"":true},{""name"":""transfer"",""parameters"":[{""name"":""to"",""type"":""Hash160""},{""name"":""tokenId"",""type"":""ByteArray""},{""name"":""data"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":644,""safe"":false}],""events"":[{""name"":""Transfer"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""to"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""ByteArray""}]}]},""permissions"":[{""contract"":""0x726cb6e0cd8628a1350a611384688911ab75f51b"",""methods"":[""sha256""]},{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""deserialize"",""serialize""]},{""contract"":""0xfffdc93764dbaddd97c48f252a53ea4643faa3fd"",""methods"":[""getContract""]},{""contract"":""*"",""methods"":[""onNEP11Payment""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA7znO4OTpJcbCoGp54UQN2G/OrAtkZXNlcmlhbGl6ZQEAAQ/A7znO4OTpJcbCoGp54UQN2G/OrAlzZXJpYWxpemUBAAEP/aP6Q0bqUyolj8SX3a3bZDfJ/f8LZ2V0Q29udHJhY3QBAAEPAAD9JgMMBFRFU1RAEEAMAQBB9rRr4kGSXegxStgmBEUQQFcBAXhK2SgkBkUJIgbKABSzJCUMIFRoZSBhcmd1bWVudCAib3duZXIiIGlzIGludmFsaWQuOkGb9mfOERGIThBR0FASwHB4aMFFU4tQQZJd6DFK2CYFRRBA2yFAVwICQZv2Z84REYhOEFHQUBLAcHhowUVTi1BBkl3oMUrYJgZFECIE2yFxaXmecWkQtSYECUBpsSQQeGjBRVOLUEEvWMXtIg9peGjBRVOLUEHmPxiECEBXAwF4ygBAtyY8DDdUaGUgYXJndW1lbnQgInRva2VuSWQiIHNob3VsZCBiZSA2NCBvciBsZXNzIGJ5dGVzIGxvbmcuOhMRiE4QUdBBm/ZnzhLAcHhowUVTi1BBkl3oMUrYJjRFDC5UaGUgdG9rZW4gd2l0aCBnaXZlbiAidG9rZW5JZCIgZG9lcyBub3QgZXhpc3QuOnFpNwAAcmoQzkBXAgETEYhOEFHQQZv2Z84SwHB4aMFFU4tQQZJd6DE3AABxyEoMBG5hbWVpEc7QQFcBABMRiE4QUdBBm/ZnzhLAcBNowUVB3zC4mkBXAQF4StkoJAZFCSIGygAUsyQkDB9UaGUgYXJndW1lbnQgIm93bmVyIiBpcyBpbnZhbGlkOhQRiE4QUdBBm/ZnzhLAcBN4aMFFU4tQQd8wuJpAVwMDeErZKCQGRQkiBsoAFLMkIgwdVGhlIGFyZ3VtZW50ICJ0byIgaXMgaW52YWxpZC46ExGIThBR0EGb9mfOEsBweWjBRVOLUEGSXegxNwAAcWkQznJqQfgn7IwkBAlAaniYJiV4SmkQUdBFaTcBAEp5aMFFU4tQQeY/GIRFD3lqNA8ReXg0Cnp5eGo0RQhAVwIDeng12f3//0VBm/ZnzhQRiE4QUdBQEsBweHmL2yhxehC3JhAQaWjBRVOLUEHmPxiEQGlowUVTi1BBL1jF7UBXAQR6EXl4FMAMCFRyYW5zZmVyQZUBb2F5cGjYJgUJIgp5NwIAcGjYqiYge3oReBTAHwwOb25ORVAxMVBheW1lbnR5QWJ9W1JFQLtDdk0=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA7znO4OTpJcbCoGp54UQN2G/OrAtkZXNlcmlhbGl6ZQEAAQ/A7znO4OTpJcbCoGp54UQN2G/OrAlzZXJpYWxpemUBAAEP/aP6Q0bqUyolj8SX3a3bZDfJ/f8LZ2V0Q29udHJhY3QBAAEPAAD91wMMBFRFU1RAEEAMAQBB9rRr4kGSXegxStgmBEUQQFcBAXhK2SgkBkUJIgbKABSzJCUMIFRoZSBhcmd1bWVudCAib3duZXIiIGlzIGludmFsaWQuOkGb9mfOERGIThBR0FASwHB4aMFFU4tQQZJd6DFK2CYFRRBA2yFAVwICQZv2Z84REYhOEFHQUBLAcHhowUVTi1BBkl3oMUrYJgZFECIE2yFxaXmecWkQtSYECUBpsSQQeGjBRVOLUEEvWMXtIg9peGjBRVOLUEHmPxiECEBXAwF4ygBAtyY8DDdUaGUgYXJndW1lbnQgInRva2VuSWQiIHNob3VsZCBiZSA2NCBvciBsZXNzIGJ5dGVzIGxvbmcuOhMRiE4QUdBBm/ZnzhLAcHhowUVTi1BBkl3oMUrYJjRFDC5UaGUgdG9rZW4gd2l0aCBnaXZlbiAidG9rZW5JZCIgZG9lcyBub3QgZXhpc3QuOnFpNwAAcmoQzkBXAwF4ygBAtyY8DDdUaGUgYXJndW1lbnQgInRva2VuSWQiIHNob3VsZCBiZSA2NCBvciBsZXNzIGJ5dGVzIGxvbmcuOhMRiE4QUdBBm/ZnzhLAcHhowUVTi1BBkl3oMUrYJjRFDC5UaGUgdG9rZW4gd2l0aCBnaXZlbiAidG9rZW5JZCIgZG9lcyBub3QgZXhpc3QuOnFpNwAAcshKDARuYW1lahHO0EBXAQATEYhOEFHQQZv2Z84SwHATaMFFQd8wuJpAVwEBeErZKCQGRQkiBsoAFLMkJAwfVGhlIGFyZ3VtZW50ICJvd25lciIgaXMgaW52YWxpZDoUEYhOEFHQQZv2Z84SwHATeGjBRVOLUEHfMLiaQFcEA3hK2SgkBkUJIgbKABSzJCIMHVRoZSBhcmd1bWVudCAidG8iIGlzIGludmFsaWQuOhMRiE4QUdBBm/ZnzhLAcHlowUVTi1BBkl3oMUrYJjRFDC5UaGUgdG9rZW4gd2l0aCBnaXZlbiAidG9rZW5JZCIgZG9lcyBub3QgZXhpc3QuOnFpNwAAcmoQznNrQfgn7IwkBAlAa3iYJiV4SmoQUdBFajcBAEp5aMFFU4tQQeY/GIRFD3lrNA8ReXg0Cnp5eGs0RQhAVwIDeng1KP3//0VBm/ZnzhQRiE4QUdBQEsBweHmL2yhxehC3JhAQaWjBRVOLUEHmPxiEQGlowUVTi1BBL1jF7UBXAQR6EXl4FMAMCFRyYW5zZmVyQZUBb2F5cGjYJgUJIgp5NwIAcGjYqiYge3oReBTAHwwOb25ORVAxMVBheW1lbnR5QWJ9W1JFQO14HAo=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -162,8 +162,15 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
     /// Safe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIBExGIThBR0EGb9mfOEsBweGjBRVOLUEGSXegxNwAAcchKDARuYW1laRHO0EA=
-    /// INITSLOT 0201 [64 datoshi]
+    /// Script: VwMBeMoAQLcmPAw3VGhlIGFyZ3VtZW50ICJ0b2tlbklkIiBzaG91bGQgYmUgNjQgb3IgbGVzcyBieXRlcyBsb25nLjoTEYhOEFHQQZv2Z84SwHB4aMFFU4tQQZJd6DFK2CY0RQwuVGhlIHRva2VuIHdpdGggZ2l2ZW4gInRva2VuSWQiIGRvZXMgbm90IGV4aXN0LjpxaTcAAHLISgwEbmFtZWoRztBA
+    /// INITSLOT 0301 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// SIZE [4 datoshi]
+    /// PUSHINT8 40 [1 datoshi]
+    /// GT [8 datoshi]
+    /// JMPIFNOT 3C [2 datoshi]
+    /// PUSHDATA1 54686520617267756D656E742022746F6B656E4964222073686F756C64206265203634206F72206C657373206279746573206C6F6E672E [8 datoshi]
+    /// THROW [512 datoshi]
     /// PUSH3 [1 datoshi]
     /// PUSH1 [1 datoshi]
     /// NEWBUFFER [256 datoshi]
@@ -183,12 +190,20 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
     /// CAT [2048 datoshi]
     /// SWAP [2 datoshi]
     /// SYSCALL 925DE831 'System.Storage.Get' [32768 datoshi]
-    /// CALLT 0000 [32768 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIFNOT 34 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHDATA1 54686520746F6B656E207769746820676976656E2022746F6B656E49642220646F6573206E6F742065786973742E [8 datoshi]
+    /// THROW [512 datoshi]
     /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// CALLT 0000 [32768 datoshi]
+    /// STLOC2 [2 datoshi]
     /// NEWMAP [8 datoshi]
     /// DUP [2 datoshi]
     /// PUSHDATA1 6E616D65 'name' [8 datoshi]
-    /// LDLOC1 [2 datoshi]
+    /// LDLOC2 [2 datoshi]
     /// PUSH1 [1 datoshi]
     /// PICKITEM [64 datoshi]
     /// SETITEM [8192 datoshi]
@@ -249,8 +264,8 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwMDeErZKCQGRQkiBsoAFLMkIgwdVGhlIGFyZ3VtZW50ICJ0byIgaXMgaW52YWxpZC46ExGIThBR0EGb9mfOEsBweWjBRVOLUEGSXegxNwAAcWkQznJqQfgn7IwkBAlAaniYJiV4SmkQUdBFaTcBAEp5aMFFU4tQQeY/GIRFD3lqNA8ReXg0Cnp5eGo0RQhA
-    /// INITSLOT 0303 [64 datoshi]
+    /// Script: VwQDeErZKCQGRQkiBsoAFLMkIgwdVGhlIGFyZ3VtZW50ICJ0byIgaXMgaW52YWxpZC46ExGIThBR0EGb9mfOEsBweWjBRVOLUEGSXegxStgmNEUMLlRoZSB0b2tlbiB3aXRoIGdpdmVuICJ0b2tlbklkIiBkb2VzIG5vdCBleGlzdC46cWk3AAByahDOc2tB+CfsjCQECUBreJgmJXhKahBR0EVqNwEASnlowUVTi1BB5j8YhEUPeWs0DxF5eDQKenl4azRFCEA=
+    /// INITSLOT 0403 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
     /// ISTYPE 28 'ByteString' [2 datoshi]
@@ -283,29 +298,37 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
     /// CAT [2048 datoshi]
     /// SWAP [2 datoshi]
     /// SYSCALL 925DE831 'System.Storage.Get' [32768 datoshi]
-    /// CALLT 0000 [32768 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIFNOT 34 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHDATA1 54686520746F6B656E207769746820676976656E2022746F6B656E49642220646F6573206E6F742065786973742E [8 datoshi]
+    /// THROW [512 datoshi]
     /// STLOC1 [2 datoshi]
     /// LDLOC1 [2 datoshi]
-    /// PUSH0 [1 datoshi]
-    /// PICKITEM [64 datoshi]
+    /// CALLT 0000 [32768 datoshi]
     /// STLOC2 [2 datoshi]
     /// LDLOC2 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// STLOC3 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// SYSCALL F827EC8C 'System.Runtime.CheckWitness' [1024 datoshi]
     /// JMPIF 04 [2 datoshi]
     /// PUSHF [1 datoshi]
     /// RET [0 datoshi]
-    /// LDLOC2 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// LDARG0 [2 datoshi]
     /// NOTEQUAL [32 datoshi]
     /// JMPIFNOT 25 [2 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
-    /// LDLOC1 [2 datoshi]
+    /// LDLOC2 [2 datoshi]
     /// PUSH0 [1 datoshi]
     /// ROT [2 datoshi]
     /// SETITEM [8192 datoshi]
     /// DROP [2 datoshi]
-    /// LDLOC1 [2 datoshi]
+    /// LDLOC2 [2 datoshi]
     /// CALLT 0100 [32768 datoshi]
     /// DUP [2 datoshi]
     /// LDARG1 [2 datoshi]
@@ -319,7 +342,7 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
     /// DROP [2 datoshi]
     /// PUSHM1 [1 datoshi]
     /// LDARG1 [2 datoshi]
-    /// LDLOC2 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// CALL 0F [512 datoshi]
     /// PUSH1 [1 datoshi]
     /// LDARG1 [2 datoshi]
@@ -328,7 +351,7 @@ public abstract class Contract_NEP11(Neo.SmartContract.Testing.SmartContractInit
     /// LDARG2 [2 datoshi]
     /// LDARG1 [2 datoshi]
     /// LDARG0 [2 datoshi]
-    /// LDLOC2 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// CALL 45 [512 datoshi]
     /// PUSHT [1 datoshi]
     /// RET [0 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NEP11.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NEP11.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing.Exceptions;
 using Neo.SmartContract.Testing;
 
 namespace Neo.Compiler.CSharp.UnitTests
@@ -28,5 +29,28 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             Assert.AreEqual(0, Contract.Decimals);
         }
+
+        [TestMethod]
+        public void UnitTest_Properties_ValidateTokenIdLength()
+        {
+            var ex = Assert.ThrowsException<TestException>(() => Contract.Properties(new byte[65]));
+            StringAssert.Contains(ex.InnerException?.Message ?? ex.Message, "64 or less bytes long");
+        }
+
+        [TestMethod]
+        public void UnitTest_Properties_MissingToken_Throws()
+        {
+            var ex = Assert.ThrowsException<TestException>(() => Contract.Properties(new byte[] { 0x01 }));
+            StringAssert.Contains(ex.InnerException?.Message ?? ex.Message, "does not exist");
+        }
+
+        [TestMethod]
+        public void UnitTest_Transfer_MissingToken_Throws()
+        {
+            var to = TestEngine.GetNewSigner().Account;
+            var ex = Assert.ThrowsException<TestException>(() => Contract.Transfer(to, new byte[] { 0x02 }, null));
+            StringAssert.Contains(ex.InnerException?.Message ?? ex.Message, "does not exist");
+        }
+
     }
 }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
@@ -12,6 +12,7 @@
 using System.Numerics;
 using Neo.SmartContract.Framework.Attributes;
 using Neo.SmartContract.Framework.Interfaces;
+using Neo.SmartContract.Framework.Services;
 
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
@@ -25,7 +26,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 
         public override string Symbol { [Safe] get; } = "EXAMPLE";
 
-        public void OnNEP11Payment(UInt160 from, BigInteger amount, string tokenId, object? data = null)
+        public void OnNEP11Payment(UInt160 from, BigInteger amount, ByteString tokenId, object? data = null)
         {
         }
     }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard26.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard26.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Services;
 using System.ComponentModel;
 using System.Numerics;
 using Neo.SmartContract.Framework.Interfaces;
@@ -24,7 +25,7 @@ namespace Neo.SmartContract.Framework.TestContracts
     [SupportedStandards(NepStandard.Nep26)]
     public class Contract_SupportedStandard26 : SmartContract, INEP26
     {
-        public void OnNEP11Payment(UInt160 from, BigInteger amount, string tokenId, object? data = null)
+        public void OnNEP11Payment(UInt160 from, BigInteger amount, ByteString tokenId, object? data = null)
         {
         }
     }

--- a/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SupportedStandardsTest.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract;
 using Neo.SmartContract.Testing;
 
 namespace Neo.SmartContract.Framework.UnitTests
@@ -49,6 +50,18 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestStandardNEP11PayableAttribute()
         {
             CollectionAssert.AreEqual(Contract_SupportedStandard26.Manifest.SupportedStandards, new string[] { "NEP-26" });
+        }
+
+        [TestMethod]
+        public void TestStandardNEP11PayableTokenIdType()
+        {
+            var onPayment26 = Contract_SupportedStandard26.Manifest.Abi.GetMethod("onNEP11Payment", 4);
+            Assert.IsNotNull(onPayment26);
+            Assert.AreEqual(ContractParameterType.ByteArray, onPayment26!.Parameters[2].Type);
+
+            var onPayment11 = Contract_SupportedStandard11Enum.Manifest.Abi.GetMethod("onNEP11Payment", 4);
+            Assert.IsNotNull(onPayment11);
+            Assert.AreEqual(ContractParameterType.ByteArray, onPayment11!.Parameters[2].Type);
         }
 
         [TestMethod]

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_SupportedStandard11Enum.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_SupportedStandard11Enum.cs
@@ -13,12 +13,12 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_SupportedStandard11Enum"",""groups"":[],""features"":{},""supportedstandards"":[""NEP-11""],""abi"":{""methods"":[{""name"":""symbol"",""parameters"":[],""returntype"":""String"",""offset"":819,""safe"":true},{""name"":""decimals"",""parameters"":[],""returntype"":""Integer"",""offset"":3,""safe"":true},{""name"":""totalSupply"",""parameters"":[],""returntype"":""Integer"",""offset"":5,""safe"":true},{""name"":""balanceOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""Integer"",""offset"":25,""safe"":true},{""name"":""ownerOf"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Hash160"",""offset"":203,""safe"":true},{""name"":""properties"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Map"",""offset"":362,""safe"":true},{""name"":""tokens"",""parameters"":[],""returntype"":""InteropInterface"",""offset"":409,""safe"":true},{""name"":""tokensOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""InteropInterface"",""offset"":437,""safe"":true},{""name"":""transfer"",""parameters"":[{""name"":""to"",""type"":""Hash160""},{""name"":""tokenId"",""type"":""ByteArray""},{""name"":""data"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":519,""safe"":false},{""name"":""testStandard"",""parameters"":[],""returntype"":""Boolean"",""offset"":802,""safe"":false},{""name"":""onNEP11Payment"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""String""},{""name"":""data"",""type"":""Any""}],""returntype"":""Void"",""offset"":836,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":808,""safe"":false}],""events"":[{""name"":""Transfer"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""to"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""ByteArray""}]}]},""permissions"":[{""contract"":""0x726cb6e0cd8628a1350a611384688911ab75f51b"",""methods"":[""sha256""]},{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""deserialize"",""serialize""]},{""contract"":""0xfffdc93764dbaddd97c48f252a53ea4643faa3fd"",""methods"":[""getContract""]},{""contract"":""*"",""methods"":[""onNEP11Payment""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_SupportedStandard11Enum"",""groups"":[],""features"":{},""supportedstandards"":[""NEP-11""],""abi"":{""methods"":[{""name"":""symbol"",""parameters"":[],""returntype"":""String"",""offset"":996,""safe"":true},{""name"":""decimals"",""parameters"":[],""returntype"":""Integer"",""offset"":3,""safe"":true},{""name"":""totalSupply"",""parameters"":[],""returntype"":""Integer"",""offset"":5,""safe"":true},{""name"":""balanceOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""Integer"",""offset"":25,""safe"":true},{""name"":""ownerOf"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Hash160"",""offset"":203,""safe"":true},{""name"":""properties"",""parameters"":[{""name"":""tokenId"",""type"":""ByteArray""}],""returntype"":""Map"",""offset"":362,""safe"":true},{""name"":""tokens"",""parameters"":[],""returntype"":""InteropInterface"",""offset"":530,""safe"":true},{""name"":""tokensOf"",""parameters"":[{""name"":""owner"",""type"":""Hash160""}],""returntype"":""InteropInterface"",""offset"":558,""safe"":true},{""name"":""transfer"",""parameters"":[{""name"":""to"",""type"":""Hash160""},{""name"":""tokenId"",""type"":""ByteArray""},{""name"":""data"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":640,""safe"":false},{""name"":""testStandard"",""parameters"":[],""returntype"":""Boolean"",""offset"":979,""safe"":false},{""name"":""onNEP11Payment"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""ByteArray""},{""name"":""data"",""type"":""Any""}],""returntype"":""Void"",""offset"":1013,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":985,""safe"":false}],""events"":[{""name"":""Transfer"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""to"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""ByteArray""}]}]},""permissions"":[{""contract"":""0x726cb6e0cd8628a1350a611384688911ab75f51b"",""methods"":[""sha256""]},{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""deserialize"",""serialize""]},{""contract"":""0xfffdc93764dbaddd97c48f252a53ea4643faa3fd"",""methods"":[""getContract""]},{""contract"":""*"",""methods"":[""onNEP11Payment""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA7znO4OTpJcbCoGp54UQN2G/OrAtkZXNlcmlhbGl6ZQEAAQ/A7znO4OTpJcbCoGp54UQN2G/OrAlzZXJpYWxpemUBAAEP/aP6Q0bqUyolj8SX3a3bZDfJ/f8LZ2V0Q29udHJhY3QBAAEPAAD9UwMQzkAQQAwBAEH2tGviQZJd6DFK2CYERRBAVwEBeErZKCQGRQkiBsoAFLMkJQwgVGhlIGFyZ3VtZW50ICJvd25lciIgaXMgaW52YWxpZC46QZv2Z84REYhOEFHQUBLAcHhowUVTi1BBkl3oMUrYJgVFEEDbIUBXAgJBm/ZnzhERiE4QUdBQEsBweGjBRVOLUEGSXegxStgmBkUQIgTbIXFpeZ5xaRC1JgQJQGmxJBB4aMFFU4tQQS9Yxe0iD2l4aMFFU4tQQeY/GIQIQFcDAXjKAEC3JjwMN1RoZSBhcmd1bWVudCAidG9rZW5JZCIgc2hvdWxkIGJlIDY0IG9yIGxlc3MgYnl0ZXMgbG9uZy46ExGIThBR0EGb9mfOEsBweGjBRVOLUEGSXegxStgmNEUMLlRoZSB0b2tlbiB3aXRoIGdpdmVuICJ0b2tlbklkIiBkb2VzIG5vdCBleGlzdC46cWk3AAByahDOQFcCARMRiE4QUdBBm/ZnzhLAcHhowUVTi1BBkl3oMTcAAHHISgwEbmFtZWkRztBAVwEAExGIThBR0EGb9mfOEsBwE2jBRUHfMLiaQFcBAXhK2SgkBkUJIgbKABSzJCQMH1RoZSBhcmd1bWVudCAib3duZXIiIGlzIGludmFsaWQ6FBGIThBR0EGb9mfOEsBwE3howUVTi1BB3zC4mkBXAwN4StkoJAZFCSIGygAUsyQiDB1UaGUgYXJndW1lbnQgInRvIiBpcyBpbnZhbGlkLjoTEYhOEFHQQZv2Z84SwHB5aMFFU4tQQZJd6DE3AABxaRDOcmpB+CfsjCQECUBqeJgmJXhKaRBR0EVpNwEASnlowUVTi1BB5j8YhEUPeWo0DxF5eDQKenl4ajRFCEBXAgN6eDXZ/f//RUGb9mfOFBGIThBR0FASwHB4eYvbKHF6ELcmEBBpaMFFU4tQQeY/GIRAaWjBRVOLUEEvWMXtQFcBBHoReXgUwAwIVHJhbnNmZXJBlQFvYXlwaNgmBQkiCnk3AgBwaNiqJiB7ehF4FMAfDA5vbk5FUDExUGF5bWVudHlBYn1bUkVACEBXAAVAVgIKQP7//xHAYEBYDAdFWEFNUExFEsAjwfz//1gMB0VYQU1QTEUSwCLUQBXujUM=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA7znO4OTpJcbCoGp54UQN2G/OrAtkZXNlcmlhbGl6ZQEAAQ/A7znO4OTpJcbCoGp54UQN2G/OrAlzZXJpYWxpemUBAAEP/aP6Q0bqUyolj8SX3a3bZDfJ/f8LZ2V0Q29udHJhY3QBAAEPAAD9BAQQzkAQQAwBAEH2tGviQZJd6DFK2CYERRBAVwEBeErZKCQGRQkiBsoAFLMkJQwgVGhlIGFyZ3VtZW50ICJvd25lciIgaXMgaW52YWxpZC46QZv2Z84REYhOEFHQUBLAcHhowUVTi1BBkl3oMUrYJgVFEEDbIUBXAgJBm/ZnzhERiE4QUdBQEsBweGjBRVOLUEGSXegxStgmBkUQIgTbIXFpeZ5xaRC1JgQJQGmxJBB4aMFFU4tQQS9Yxe0iD2l4aMFFU4tQQeY/GIQIQFcDAXjKAEC3JjwMN1RoZSBhcmd1bWVudCAidG9rZW5JZCIgc2hvdWxkIGJlIDY0IG9yIGxlc3MgYnl0ZXMgbG9uZy46ExGIThBR0EGb9mfOEsBweGjBRVOLUEGSXegxStgmNEUMLlRoZSB0b2tlbiB3aXRoIGdpdmVuICJ0b2tlbklkIiBkb2VzIG5vdCBleGlzdC46cWk3AAByahDOQFcDAXjKAEC3JjwMN1RoZSBhcmd1bWVudCAidG9rZW5JZCIgc2hvdWxkIGJlIDY0IG9yIGxlc3MgYnl0ZXMgbG9uZy46ExGIThBR0EGb9mfOEsBweGjBRVOLUEGSXegxStgmNEUMLlRoZSB0b2tlbiB3aXRoIGdpdmVuICJ0b2tlbklkIiBkb2VzIG5vdCBleGlzdC46cWk3AAByyEoMBG5hbWVqEc7QQFcBABMRiE4QUdBBm/ZnzhLAcBNowUVB3zC4mkBXAQF4StkoJAZFCSIGygAUsyQkDB9UaGUgYXJndW1lbnQgIm93bmVyIiBpcyBpbnZhbGlkOhQRiE4QUdBBm/ZnzhLAcBN4aMFFU4tQQd8wuJpAVwQDeErZKCQGRQkiBsoAFLMkIgwdVGhlIGFyZ3VtZW50ICJ0byIgaXMgaW52YWxpZC46ExGIThBR0EGb9mfOEsBweWjBRVOLUEGSXegxStgmNEUMLlRoZSB0b2tlbiB3aXRoIGdpdmVuICJ0b2tlbklkIiBkb2VzIG5vdCBleGlzdC46cWk3AAByahDOc2tB+CfsjCQECUBreJgmJXhKahBR0EVqNwEASnlowUVTi1BB5j8YhEUPeWs0DxF5eDQKenl4azRFCEBXAgN6eDUo/f//RUGb9mfOFBGIThBR0FASwHB4eYvbKHF6ELcmEBBpaMFFU4tQQeY/GIRAaWjBRVOLUEEvWMXtQFcBBHoReXgUwAwIVHJhbnNmZXJBlQFvYXlwaNgmBQkiCnk3AgBwaNiqJiB7ehF4FMAfDA5vbk5FUDExUGF5bWVudHlBYn1bUkVACEBXAAVAVgIKj/3//xHAYEBYDAdFWEFNUExFEsAjEPz//1gMB0VYQU1QTEUSwCLUQLDGeBE=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -162,8 +162,15 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// Safe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIBExGIThBR0EGb9mfOEsBweGjBRVOLUEGSXegxNwAAcchKDARuYW1laRHO0EA=
-    /// INITSLOT 0201 [64 datoshi]
+    /// Script: VwMBeMoAQLcmPAw3VGhlIGFyZ3VtZW50ICJ0b2tlbklkIiBzaG91bGQgYmUgNjQgb3IgbGVzcyBieXRlcyBsb25nLjoTEYhOEFHQQZv2Z84SwHB4aMFFU4tQQZJd6DFK2CY0RQwuVGhlIHRva2VuIHdpdGggZ2l2ZW4gInRva2VuSWQiIGRvZXMgbm90IGV4aXN0LjpxaTcAAHLISgwEbmFtZWoRztBA
+    /// INITSLOT 0301 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// SIZE [4 datoshi]
+    /// PUSHINT8 40 [1 datoshi]
+    /// GT [8 datoshi]
+    /// JMPIFNOT 3C [2 datoshi]
+    /// PUSHDATA1 54686520617267756D656E742022746F6B656E4964222073686F756C64206265203634206F72206C657373206279746573206C6F6E672E [8 datoshi]
+    /// THROW [512 datoshi]
     /// PUSH3 [1 datoshi]
     /// PUSH1 [1 datoshi]
     /// NEWBUFFER [256 datoshi]
@@ -183,12 +190,20 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// CAT [2048 datoshi]
     /// SWAP [2 datoshi]
     /// SYSCALL 925DE831 'System.Storage.Get' [32768 datoshi]
-    /// CALLT 0000 [32768 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIFNOT 34 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHDATA1 54686520746F6B656E207769746820676976656E2022746F6B656E49642220646F6573206E6F742065786973742E [8 datoshi]
+    /// THROW [512 datoshi]
     /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// CALLT 0000 [32768 datoshi]
+    /// STLOC2 [2 datoshi]
     /// NEWMAP [8 datoshi]
     /// DUP [2 datoshi]
     /// PUSHDATA1 6E616D65 'name' [8 datoshi]
-    /// LDLOC1 [2 datoshi]
+    /// LDLOC2 [2 datoshi]
     /// PUSH1 [1 datoshi]
     /// PICKITEM [64 datoshi]
     /// SETITEM [8192 datoshi]
@@ -254,7 +269,7 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("onNEP11Payment")]
-    public abstract void OnNEP11Payment(UInt160? from, BigInteger? amount, string? tokenId, object? data = null);
+    public abstract void OnNEP11Payment(UInt160? from, BigInteger? amount, byte[]? tokenId, object? data = null);
 
     /// <summary>
     /// Unsafe method
@@ -271,8 +286,8 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwMDeErZKCQGRQkiBsoAFLMkIgwdVGhlIGFyZ3VtZW50ICJ0byIgaXMgaW52YWxpZC46ExGIThBR0EGb9mfOEsBweWjBRVOLUEGSXegxNwAAcWkQznJqQfgn7IwkBAlAaniYJiV4SmkQUdBFaTcBAEp5aMFFU4tQQeY/GIRFD3lqNA8ReXg0Cnp5eGo0RQhA
-    /// INITSLOT 0303 [64 datoshi]
+    /// Script: VwQDeErZKCQGRQkiBsoAFLMkIgwdVGhlIGFyZ3VtZW50ICJ0byIgaXMgaW52YWxpZC46ExGIThBR0EGb9mfOEsBweWjBRVOLUEGSXegxStgmNEUMLlRoZSB0b2tlbiB3aXRoIGdpdmVuICJ0b2tlbklkIiBkb2VzIG5vdCBleGlzdC46cWk3AAByahDOc2tB+CfsjCQECUBreJgmJXhKahBR0EVqNwEASnlowUVTi1BB5j8YhEUPeWs0DxF5eDQKenl4azRFCEA=
+    /// INITSLOT 0403 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
     /// ISTYPE 28 'ByteString' [2 datoshi]
@@ -305,29 +320,37 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// CAT [2048 datoshi]
     /// SWAP [2 datoshi]
     /// SYSCALL 925DE831 'System.Storage.Get' [32768 datoshi]
-    /// CALLT 0000 [32768 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIFNOT 34 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHDATA1 54686520746F6B656E207769746820676976656E2022746F6B656E49642220646F6573206E6F742065786973742E [8 datoshi]
+    /// THROW [512 datoshi]
     /// STLOC1 [2 datoshi]
     /// LDLOC1 [2 datoshi]
-    /// PUSH0 [1 datoshi]
-    /// PICKITEM [64 datoshi]
+    /// CALLT 0000 [32768 datoshi]
     /// STLOC2 [2 datoshi]
     /// LDLOC2 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// STLOC3 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// SYSCALL F827EC8C 'System.Runtime.CheckWitness' [1024 datoshi]
     /// JMPIF 04 [2 datoshi]
     /// PUSHF [1 datoshi]
     /// RET [0 datoshi]
-    /// LDLOC2 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// LDARG0 [2 datoshi]
     /// NOTEQUAL [32 datoshi]
     /// JMPIFNOT 25 [2 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
-    /// LDLOC1 [2 datoshi]
+    /// LDLOC2 [2 datoshi]
     /// PUSH0 [1 datoshi]
     /// ROT [2 datoshi]
     /// SETITEM [8192 datoshi]
     /// DROP [2 datoshi]
-    /// LDLOC1 [2 datoshi]
+    /// LDLOC2 [2 datoshi]
     /// CALLT 0100 [32768 datoshi]
     /// DUP [2 datoshi]
     /// LDARG1 [2 datoshi]
@@ -341,7 +364,7 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// DROP [2 datoshi]
     /// PUSHM1 [1 datoshi]
     /// LDARG1 [2 datoshi]
-    /// LDLOC2 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// CALL 0F [512 datoshi]
     /// PUSH1 [1 datoshi]
     /// LDARG1 [2 datoshi]
@@ -350,7 +373,7 @@ public abstract class Contract_SupportedStandard11Enum(Neo.SmartContract.Testing
     /// LDARG2 [2 datoshi]
     /// LDARG1 [2 datoshi]
     /// LDARG0 [2 datoshi]
-    /// LDLOC2 [2 datoshi]
+    /// LDLOC3 [2 datoshi]
     /// CALL 45 [512 datoshi]
     /// PUSHT [1 datoshi]
     /// RET [0 datoshi]

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_SupportedStandard26.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_SupportedStandard26.cs
@@ -13,7 +13,7 @@ public abstract class Contract_SupportedStandard26(Neo.SmartContract.Testing.Sma
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_SupportedStandard26"",""groups"":[],""features"":{},""supportedstandards"":[""NEP-26""],""abi"":{""methods"":[{""name"":""onNEP11Payment"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""String""},{""name"":""data"",""type"":""Any""}],""returntype"":""Void"",""offset"":0,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""*"",""methods"":""*""}],""trusts"":[],""extra"":{""Description"":""\u003CDescription Here\u003E"",""Author"":""\u003CYour Name Or Company Here\u003E"",""Version"":""\u003CVersion String Here\u003E"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_SupportedStandard26"",""groups"":[],""features"":{},""supportedstandards"":[""NEP-26""],""abi"":{""methods"":[{""name"":""onNEP11Payment"",""parameters"":[{""name"":""from"",""type"":""Hash160""},{""name"":""amount"",""type"":""Integer""},{""name"":""tokenId"",""type"":""ByteArray""},{""name"":""data"",""type"":""Any""}],""returntype"":""Void"",""offset"":0,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""*"",""methods"":""*""}],""trusts"":[],""extra"":{""Description"":""\u003CDescription Here\u003E"",""Author"":""\u003CYour Name Or Company Here\u003E"",""Version"":""\u003CVersion String Here\u003E"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
@@ -33,7 +33,7 @@ public abstract class Contract_SupportedStandard26(Neo.SmartContract.Testing.Sma
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("onNEP11Payment")]
-    public abstract void OnNEP11Payment(UInt160? from, BigInteger? amount, string? tokenId, object? data = null);
+    public abstract void OnNEP11Payment(UInt160? from, BigInteger? amount, byte[]? tokenId, object? data = null);
 
     #endregion
 }


### PR DESCRIPTION
Split from #1516.

Scope:
- NEP-11 runtime safety and validation updates
- INEP26 tokenId type alignment
- Remove duplicate ownerOf validation path
- Update related framework/compiler artifacts

Validation:
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --filter "FullyQualifiedName~UnitTest_NEP11"
- dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj -c Release