### PR TITLE
feat(security): add witness and unbounded-operation analyzers

### DIFF
--- a/docs/framework/ReentrantAttack.md
+++ b/docs/framework/ReentrantAttack.md
@@ -76,11 +76,15 @@ By using these attributes, Neo C# smart contract developers can easily add reent
 
 ## Limitations and Known Risks
 
-### Cross-Contract Reentrancy Is Not Detected
+### Cross-Contract Reentrancy Depends on Key Coverage
 
-The `[NoReentrant]` and `[NoReentrantMethod]` attributes only protect against reentrancy within a single contract. If Contract A calls Contract B, and Contract B calls back into Contract A through a different entry point that is not protected, the reentrancy will not be detected. The analyzer does not perform cross-contract reentrancy analysis.
+The reentrancy flag is stored in contract storage, so it remains visible during callback flows such as Contract A -> Contract B -> Contract A.
 
-Developers must manually audit cross-contract call chains and apply reentrancy guards on all externally callable methods that modify state, not just the methods that initiate outbound calls.
+If the callback enters a method protected by the same lock key, reentry is blocked. This is automatic with `[NoReentrant]` because all decorated methods share one key.
+
+With `[NoReentrantMethod]`, each method uses its own key by default. A callback into a different method (or an unprotected method) can still execute unless you explicitly configure a shared key.
+
+For cross-contract call chains, protect all externally callable state-changing methods and use shared keys where method-level guards must behave as one lock.
 
 ### Unhandled Exceptions May Leave the Lock Permanently Set
 

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/CheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/CheckWitnessAnalyzer.cs
@@ -42,7 +42,7 @@ namespace Neo.Compiler.SecurityAnalyzer
             {
                 if (droppedCheckWitnessResults.Count == 0)
                     return "";
-                string result = $"[SEC] The returned values of CheckWitness at the following instruction addresses are DROPped:{Environment.NewLine}" +
+                string result = $"[SECURITY] The returned values of CheckWitness at the following instruction addresses are DROPped:{Environment.NewLine}" +
                     $"\t{string.Join(", ", droppedCheckWitnessResults)}{Environment.NewLine}" +
                     $"You should typically `Assert(CheckWitness({nameof(UInt160)} someone))`{Environment.NewLine}" +
                     $"instead of just `CheckWitness({nameof(UInt160)} someone)`{Environment.NewLine}";

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
@@ -1,0 +1,115 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// MissingCheckWitnessAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Json;
+using Neo.Optimizer;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo.Compiler.SecurityAnalyzer
+{
+    /// <summary>
+    /// Detects public methods that perform state changes (storage writes)
+    /// without any CheckWitness call in the same method.
+    /// </summary>
+    public static class MissingCheckWitnessAnalyzer
+    {
+        public class MissingCheckWitnessVulnerability
+        {
+            public readonly List<string> vulnerableMethodNames;
+            public readonly JToken? debugInfo;
+
+            public MissingCheckWitnessVulnerability(
+                List<string> vulnerableMethodNames,
+                JToken? debugInfo = null)
+            {
+                this.vulnerableMethodNames = vulnerableMethodNames;
+                this.debugInfo = debugInfo;
+            }
+
+            public string GetWarningInfo(bool print = false)
+            {
+                if (vulnerableMethodNames.Count == 0)
+                    return "";
+                string result = $"[SEC] The following public methods write to storage without CheckWitness verification:{Environment.NewLine}" +
+                    $"\t{string.Join(", ", vulnerableMethodNames)}{Environment.NewLine}" +
+                    $"Consider adding `Runtime.CheckWitness()` before performing storage writes to prevent unauthorized access.{Environment.NewLine}";
+                if (print)
+                    Console.Write(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Analyzes the contract for public methods that write to storage
+        /// without calling CheckWitness.
+        /// </summary>
+        /// <param name="nef">Nef file</param>
+        /// <param name="manifest">Manifest</param>
+        /// <param name="debugInfo">Debug information</param>
+        public static MissingCheckWitnessVulnerability AnalyzeMissingCheckWitness(
+            NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
+        {
+            (int addr, VM.Instruction instruction)[] instructions =
+                ((Script)nef.Script).EnumerateInstructions().ToArray();
+
+            // Build a sorted list of method offsets to determine method boundaries
+            ContractMethodDescriptor[] methods = manifest.Abi.Methods;
+            int[] sortedOffsets = methods.Select(m => m.Offset).OrderBy(o => o).ToArray();
+
+            List<string> vulnerableMethods = new();
+
+            foreach (ContractMethodDescriptor method in methods)
+            {
+                // Skip internal methods
+                if (method.Name.StartsWith("_"))
+                    continue;
+
+                int methodStart = method.Offset;
+                // Method end is the start of the next method, or end of script
+                int nextMethodIndex = Array.IndexOf(sortedOffsets, methodStart) + 1;
+                int methodEnd = nextMethodIndex < sortedOffsets.Length
+                    ? sortedOffsets[nextMethodIndex]
+                    : int.MaxValue;
+
+                bool hasStorageWrite = false;
+                bool hasCheckWitness = false;
+
+                foreach ((int addr, VM.Instruction instruction) in instructions)
+                {
+                    if (addr < methodStart)
+                        continue;
+                    if (addr >= methodEnd)
+                        break;
+
+                    if (instruction.OpCode == OpCode.SYSCALL)
+                    {
+                        if (instruction.TokenU32 == ApplicationEngine.System_Storage_Put.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Delete.Hash)
+                            hasStorageWrite = true;
+
+                        if (instruction.TokenU32 == ApplicationEngine.System_Runtime_CheckWitness.Hash)
+                            hasCheckWitness = true;
+                    }
+                }
+
+                if (hasStorageWrite && !hasCheckWitness)
+                    vulnerableMethods.Add(method.Name);
+            }
+
+            return new MissingCheckWitnessVulnerability(vulnerableMethods, debugInfo);
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Neo.Compiler.SecurityAnalyzer
 {
     /// <summary>
     /// Detects public methods that perform state changes (storage writes)
-    /// without any CheckWitness call in the same method.
+    /// without any CheckWitness call in the method or its static helper calls.
     /// </summary>
     public static class MissingCheckWitnessAnalyzer
     {
@@ -65,9 +65,20 @@ namespace Neo.Compiler.SecurityAnalyzer
             (int addr, VM.Instruction instruction)[] instructions =
                 ((Script)nef.Script).EnumerateInstructions().ToArray();
 
-            // Build a sorted list of method offsets to determine method boundaries
+            // Build a sorted list of method offsets to determine method boundaries.
+            // Include static call targets to cover private helper methods not present in ABI.
             ContractMethodDescriptor[] methods = manifest.Abi.Methods;
-            int[] sortedOffsets = methods.Select(m => m.Offset).OrderBy(o => o).ToArray();
+            HashSet<int> methodStartOffsets = methods.Select(m => m.Offset).ToHashSet();
+            foreach ((int addr, VM.Instruction instruction) in instructions)
+            {
+                if (instruction.OpCode != OpCode.CALL && instruction.OpCode != OpCode.CALL_L)
+                    continue;
+
+                int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                if (target >= 0)
+                    methodStartOffsets.Add(target);
+            }
+            int[] sortedOffsets = methodStartOffsets.OrderBy(o => o).ToArray();
 
             List<string> vulnerableMethods = new();
 
@@ -77,21 +88,44 @@ namespace Neo.Compiler.SecurityAnalyzer
                 if (method.Name.StartsWith("_"))
                     continue;
 
-                int methodStart = method.Offset;
-                // Method end is the start of the next method, or end of script
-                int nextMethodIndex = Array.IndexOf(sortedOffsets, methodStart) + 1;
-                int methodEnd = nextMethodIndex < sortedOffsets.Length
-                    ? sortedOffsets[nextMethodIndex]
-                    : int.MaxValue;
+                (bool hasStorageWrite, bool hasCheckWitness) = AnalyzeMethodAndStaticHelpers(
+                    method.Offset,
+                    instructions,
+                    sortedOffsets,
+                    methodStartOffsets);
 
-                bool hasStorageWrite = false;
-                bool hasCheckWitness = false;
+                if (hasStorageWrite && !hasCheckWitness)
+                    vulnerableMethods.Add(method.Name);
+            }
 
+            return new MissingCheckWitnessVulnerability(vulnerableMethods, debugInfo);
+        }
+
+        private static (bool hasStorageWrite, bool hasCheckWitness) AnalyzeMethodAndStaticHelpers(
+            int methodStart,
+            (int addr, VM.Instruction instruction)[] instructions,
+            int[] sortedOffsets,
+            HashSet<int> methodStartOffsets)
+        {
+            bool hasStorageWrite = false;
+            bool hasCheckWitness = false;
+
+            Stack<int> pendingMethodStarts = new();
+            HashSet<int> visitedMethodStarts = new();
+            pendingMethodStarts.Push(methodStart);
+
+            while (pendingMethodStarts.Count > 0)
+            {
+                int currentStart = pendingMethodStarts.Pop();
+                if (!visitedMethodStarts.Add(currentStart))
+                    continue;
+
+                int currentEnd = GetMethodEnd(currentStart, sortedOffsets);
                 foreach ((int addr, VM.Instruction instruction) in instructions)
                 {
-                    if (addr < methodStart)
+                    if (addr < currentStart)
                         continue;
-                    if (addr >= methodEnd)
+                    if (addr >= currentEnd)
                         break;
 
                     if (instruction.OpCode == OpCode.SYSCALL)
@@ -102,14 +136,31 @@ namespace Neo.Compiler.SecurityAnalyzer
 
                         if (instruction.TokenU32 == ApplicationEngine.System_Runtime_CheckWitness.Hash)
                             hasCheckWitness = true;
+
+                        continue;
+                    }
+
+                    if (instruction.OpCode == OpCode.CALL || instruction.OpCode == OpCode.CALL_L)
+                    {
+                        int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                        if (methodStartOffsets.Contains(target))
+                            pendingMethodStarts.Push(target);
                     }
                 }
-
-                if (hasStorageWrite && !hasCheckWitness)
-                    vulnerableMethods.Add(method.Name);
             }
 
-            return new MissingCheckWitnessVulnerability(vulnerableMethods, debugInfo);
+            return (hasStorageWrite, hasCheckWitness);
+        }
+
+        private static int GetMethodEnd(int methodStart, int[] sortedOffsets)
+        {
+            int methodIndex = Array.BinarySearch(sortedOffsets, methodStart);
+            if (methodIndex < 0)
+                methodIndex = ~methodIndex;
+
+            return methodIndex + 1 < sortedOffsets.Length
+                ? sortedOffsets[methodIndex + 1]
+                : int.MaxValue;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
@@ -43,7 +43,7 @@ namespace Neo.Compiler.SecurityAnalyzer
             {
                 if (vulnerableMethodNames.Count == 0)
                     return "";
-                string result = $"[SEC] The following public methods write to storage without CheckWitness verification:{Environment.NewLine}" +
+                string result = $"[SECURITY] The following public methods write to storage without CheckWitness verification:{Environment.NewLine}" +
                     $"\t{string.Join(", ", vulnerableMethodNames)}{Environment.NewLine}" +
                     $"Consider adding `Runtime.CheckWitness()` before performing storage writes to prevent unauthorized access.{Environment.NewLine}";
                 if (print)

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
@@ -28,11 +28,11 @@ namespace Neo.Compiler.SecurityAnalyzer
     {
         public class MissingCheckWitnessVulnerability
         {
-            public readonly List<string> vulnerableMethodNames;
+            public readonly IReadOnlyList<string> vulnerableMethodNames;
             public readonly JToken? debugInfo;
 
             public MissingCheckWitnessVulnerability(
-                List<string> vulnerableMethodNames,
+                IReadOnlyList<string> vulnerableMethodNames,
                 JToken? debugInfo = null)
             {
                 this.vulnerableMethodNames = vulnerableMethodNames;
@@ -131,7 +131,9 @@ namespace Neo.Compiler.SecurityAnalyzer
                     if (instruction.OpCode == OpCode.SYSCALL)
                     {
                         if (instruction.TokenU32 == ApplicationEngine.System_Storage_Put.Hash
-                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Delete.Hash)
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Delete.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Put.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Delete.Hash)
                             hasStorageWrite = true;
 
                         if (instruction.TokenU32 == ApplicationEngine.System_Runtime_CheckWitness.Hash)

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/OpCodeExtensions.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/OpCodeExtensions.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OpCodeExtensions.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.VM;
+
+namespace Neo.Compiler.SecurityAnalyzer
+{
+    internal static class OpCodeExtensions
+    {
+        public static bool IsJumpInstruction(this OpCode opCode)
+        {
+            return opCode == OpCode.JMP
+                || opCode == OpCode.JMP_L
+                || opCode == OpCode.JMPIF
+                || opCode == OpCode.JMPIF_L
+                || opCode == OpCode.JMPIFNOT
+                || opCode == OpCode.JMPIFNOT_L
+                || opCode == OpCode.JMPEQ
+                || opCode == OpCode.JMPEQ_L
+                || opCode == OpCode.JMPNE
+                || opCode == OpCode.JMPNE_L
+                || opCode == OpCode.JMPGT
+                || opCode == OpCode.JMPGT_L
+                || opCode == OpCode.JMPGE
+                || opCode == OpCode.JMPGE_L
+                || opCode == OpCode.JMPLT
+                || opCode == OpCode.JMPLT_L
+                || opCode == OpCode.JMPLE
+                || opCode == OpCode.JMPLE_L;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
@@ -73,7 +73,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                 foreach ((BasicBlock callBlock, HashSet<BasicBlock> writeBlocks) in vulnerabilityPairs)
                 {
                     StringBuilder additional = new();
-                    additional.AppendLine($"[SEC] Potential Re-entrancy vulnerability detected");
+                    additional.AppendLine($"[SECURITY] Potential Re-entrancy vulnerability detected");
                     additional.AppendLine($"  Issue: Contract calls external code before writing to storage, allowing potential re-entrancy attacks");
 
                     // Add source location information for contract calls

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
@@ -23,6 +23,8 @@ namespace Neo.Compiler.SecurityAnalyzer
             ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(nef, manifest, debugInfo).GetWarningInfo(print: true);
             WriteInTryAnalyzer.AnalyzeWriteInTry(nef, manifest, debugInfo).GetWarningInfo(print: true);
             CheckWitnessAnalyzer.AnalyzeCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
+            MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
+            UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(nef, manifest, debugInfo).GetWarningInfo(print: true);
             if (!UpdateAnalyzer.AnalyzeUpdate(nef, manifest, debugInfo))
                 Console.WriteLine("[SEC] This contract cannot be updated, or maybe you used abstract code styles to update it.");
         }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
@@ -26,7 +26,7 @@ namespace Neo.Compiler.SecurityAnalyzer
             MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
             UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(nef, manifest, debugInfo).GetWarningInfo(print: true);
             if (!UpdateAnalyzer.AnalyzeUpdate(nef, manifest, debugInfo))
-                Console.WriteLine("[SEC] This contract cannot be updated, or maybe you used abstract code styles to update it.");
+                Console.WriteLine("[SECURITY] This contract cannot be updated, or maybe you used abstract code styles to update it.");
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
@@ -1,0 +1,104 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnboundedOperationAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Json;
+using Neo.Optimizer;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo.Compiler.SecurityAnalyzer
+{
+    /// <summary>
+    /// Detects potential Gas DoS patterns by identifying backward jumps
+    /// that could indicate unbounded loops.
+    /// </summary>
+    public static class UnboundedOperationAnalyzer
+    {
+        public class UnboundedOperationVulnerability
+        {
+            public readonly List<int> backwardJumpAddresses;
+            public readonly JToken? debugInfo;
+
+            public UnboundedOperationVulnerability(
+                List<int> backwardJumpAddresses,
+                JToken? debugInfo = null)
+            {
+                this.backwardJumpAddresses = backwardJumpAddresses;
+                this.debugInfo = debugInfo;
+            }
+
+            public string GetWarningInfo(bool print = false)
+            {
+                if (backwardJumpAddresses.Count == 0)
+                    return "";
+                string result = $"[SEC] Potential unbounded operations (backward jumps) detected at instruction addresses:{Environment.NewLine}" +
+                    $"\t{string.Join(", ", backwardJumpAddresses)}{Environment.NewLine}" +
+                    $"Unbounded loops can lead to excessive GAS consumption (DoS). Consider adding iteration limits.{Environment.NewLine}";
+                if (print)
+                    Console.Write(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Analyzes the contract for backward jumps that may indicate unbounded loops.
+        /// </summary>
+        /// <param name="nef">Nef file</param>
+        /// <param name="manifest">Manifest</param>
+        /// <param name="debugInfo">Debug information</param>
+        public static UnboundedOperationVulnerability AnalyzeUnboundedOperations(
+            NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
+        {
+            (int addr, VM.Instruction instruction)[] instructions =
+                ((Script)nef.Script).EnumerateInstructions().ToArray();
+
+            List<int> backwardJumps = new();
+
+            foreach ((int addr, VM.Instruction instruction) in instructions)
+            {
+                if (!IsJumpInstruction(instruction.OpCode))
+                    continue;
+
+                int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                if (target < addr)
+                    backwardJumps.Add(addr);
+            }
+
+            return new UnboundedOperationVulnerability(backwardJumps, debugInfo);
+        }
+
+        private static bool IsJumpInstruction(OpCode opCode)
+        {
+            return opCode == OpCode.JMP
+                || opCode == OpCode.JMP_L
+                || opCode == OpCode.JMPIF
+                || opCode == OpCode.JMPIF_L
+                || opCode == OpCode.JMPIFNOT
+                || opCode == OpCode.JMPIFNOT_L
+                || opCode == OpCode.JMPEQ
+                || opCode == OpCode.JMPEQ_L
+                || opCode == OpCode.JMPNE
+                || opCode == OpCode.JMPNE_L
+                || opCode == OpCode.JMPGT
+                || opCode == OpCode.JMPGT_L
+                || opCode == OpCode.JMPGE
+                || opCode == OpCode.JMPGE_L
+                || opCode == OpCode.JMPLT
+                || opCode == OpCode.JMPLT_L
+                || opCode == OpCode.JMPLE
+                || opCode == OpCode.JMPLE_L;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
@@ -28,11 +28,11 @@ namespace Neo.Compiler.SecurityAnalyzer
     {
         public class UnboundedOperationVulnerability
         {
-            public readonly List<int> backwardJumpAddresses;
+            public readonly IReadOnlyList<int> backwardJumpAddresses;
             public readonly JToken? debugInfo;
 
             public UnboundedOperationVulnerability(
-                List<int> backwardJumpAddresses,
+                IReadOnlyList<int> backwardJumpAddresses,
                 JToken? debugInfo = null)
             {
                 this.backwardJumpAddresses = backwardJumpAddresses;
@@ -43,7 +43,7 @@ namespace Neo.Compiler.SecurityAnalyzer
             {
                 if (backwardJumpAddresses.Count == 0)
                     return "";
-                string result = $"[SEC] Potential unbounded operations (backward jumps) detected at instruction addresses:{Environment.NewLine}" +
+                string result = $"[SECURITY] Potential unbounded operations (backward jumps) detected at instruction addresses:{Environment.NewLine}" +
                     $"\t{string.Join(", ", backwardJumpAddresses)}{Environment.NewLine}" +
                     $"Unbounded loops can lead to excessive GAS consumption (DoS). Consider adding iteration limits.{Environment.NewLine}";
                 if (print)
@@ -68,7 +68,7 @@ namespace Neo.Compiler.SecurityAnalyzer
 
             foreach ((int addr, VM.Instruction instruction) in instructions)
             {
-                if (!IsJumpInstruction(instruction.OpCode))
+                if (!instruction.OpCode.IsJumpInstruction())
                     continue;
 
                 int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
@@ -77,28 +77,6 @@ namespace Neo.Compiler.SecurityAnalyzer
             }
 
             return new UnboundedOperationVulnerability(backwardJumps, debugInfo);
-        }
-
-        private static bool IsJumpInstruction(OpCode opCode)
-        {
-            return opCode == OpCode.JMP
-                || opCode == OpCode.JMP_L
-                || opCode == OpCode.JMPIF
-                || opCode == OpCode.JMPIF_L
-                || opCode == OpCode.JMPIFNOT
-                || opCode == OpCode.JMPIFNOT_L
-                || opCode == OpCode.JMPEQ
-                || opCode == OpCode.JMPEQ_L
-                || opCode == OpCode.JMPNE
-                || opCode == OpCode.JMPNE_L
-                || opCode == OpCode.JMPGT
-                || opCode == OpCode.JMPGT_L
-                || opCode == OpCode.JMPGE
-                || opCode == OpCode.JMPGE_L
-                || opCode == OpCode.JMPLT
-                || opCode == OpCode.JMPLT_L
-                || opCode == OpCode.JMPLE
-                || opCode == OpCode.JMPLE_L;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/WriteInTryAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/WriteInTryAnalyzer.cs
@@ -65,7 +65,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                     }
 
                     StringBuilder additional = new();
-                    additional.AppendLine($"[SEC] Writing storage in `try` block is risky - writes may not be properly reverted on exceptions");
+                    additional.AppendLine($"[SECURITY] Writing storage in `try` block is risky - writes may not be properly reverted on exceptions");
 
                     // Add source location information if available
                     if (debugInfo != null)

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_MissingCheckWitness.cs
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Contract_MissingCheckWitness.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+
+namespace Neo.Compiler.CSharp.TestContracts
+{
+    public class Contract_MissingCheckWitness : SmartContract.Framework.SmartContract
+    {
+        // Vulnerable: writes storage without CheckWitness
+        public static void UnsafeUpdate(byte[] key, byte[] value)
+        {
+            var context = Storage.CurrentContext;
+            Storage.Put(context, key, value);
+        }
+
+        // Safe: checks witness before writing storage
+        public static void SafeUpdate(UInt160 owner, byte[] key, byte[] value)
+        {
+            ExecutionEngine.Assert(Runtime.CheckWitness(owner));
+            var context = Storage.CurrentContext;
+            Storage.Put(context, key, value);
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_MissingCheckWitness.cs
@@ -30,5 +30,18 @@ namespace Neo.Compiler.CSharp.TestContracts
             var context = Storage.CurrentContext;
             Storage.Put(context, key, value);
         }
+
+        private static bool IsOwner(UInt160 owner)
+        {
+            return Runtime.CheckWitness(owner);
+        }
+
+        // Safe: witness validation is delegated to helper method
+        public static void SafeUpdateViaHelper(UInt160 owner, byte[] key, byte[] value)
+        {
+            ExecutionEngine.Assert(IsOwner(owner));
+            var context = Storage.CurrentContext;
+            Storage.Put(context, key, value);
+        }
     }
 }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_MissingCheckWitness.cs
@@ -23,6 +23,13 @@ namespace Neo.Compiler.CSharp.TestContracts
             Storage.Put(context, key, value);
         }
 
+        // Vulnerable: writes local storage without CheckWitness
+        public static void UnsafeLocalUpdate(byte[] prefix, byte[] key, byte[] value)
+        {
+            var storage = new LocalStorageMap(prefix);
+            storage.Put(key, value);
+        }
+
         // Safe: checks witness before writing storage
         public static void SafeUpdate(UInt160 owner, byte[] key, byte[] value)
         {

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_UnboundedOperation.cs
@@ -1,0 +1,30 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Contract_UnboundedOperation.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+
+namespace Neo.Compiler.CSharp.TestContracts
+{
+    public class Contract_UnboundedOperation : SmartContract.Framework.SmartContract
+    {
+        // Contains a loop that will produce backward jumps
+        public static int Sum(int n)
+        {
+            int total = 0;
+            for (int i = 0; i < n; i++)
+            {
+                total += i;
+            }
+            return total;
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_MissingCheckWitness.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.SecurityAnalyzer;
+using Neo.SmartContract.Testing;
+
+namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
+{
+    [TestClass]
+    public class MissingCheckWitnessTests : DebugAndTestBase<Contract_MissingCheckWitness>
+    {
+        [TestMethod]
+        public void Test_MissingCheckWitness()
+        {
+            var result = MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(NefFile, Manifest, null);
+            // UnsafeUpdate writes storage without CheckWitness - should be flagged
+            Assert.IsTrue(result.vulnerableMethodNames.Contains("unsafeUpdate"));
+            // SafeUpdate has CheckWitness - should NOT be flagged
+            Assert.IsFalse(result.vulnerableMethodNames.Contains("safeUpdate"));
+        }
+
+        [TestMethod]
+        public void Test_MissingCheckWitness_WarningInfo()
+        {
+            var result = MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(NefFile, Manifest, null);
+            string warning = result.GetWarningInfo(print: false);
+            Assert.IsTrue(warning.Contains("[SEC]"));
+            Assert.IsTrue(warning.Contains("unsafeUpdate"));
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
@@ -26,6 +26,8 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.IsTrue(result.vulnerableMethodNames.Contains("unsafeUpdate"));
             // SafeUpdate has CheckWitness - should NOT be flagged
             Assert.IsFalse(result.vulnerableMethodNames.Contains("safeUpdate"));
+            // SafeUpdateViaHelper delegates CheckWitness to helper - should NOT be flagged
+            Assert.IsFalse(result.vulnerableMethodNames.Contains("safeUpdateViaHelper"));
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
@@ -12,6 +12,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.SecurityAnalyzer;
 using Neo.SmartContract.Testing;
+using System.Linq;
 
 namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
 {
@@ -24,6 +25,8 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             var result = MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(NefFile, Manifest, null);
             // UnsafeUpdate writes storage without CheckWitness - should be flagged
             Assert.IsTrue(result.vulnerableMethodNames.Contains("unsafeUpdate"));
+            // UnsafeLocalUpdate writes local storage without CheckWitness - should be flagged
+            Assert.IsTrue(result.vulnerableMethodNames.Contains("unsafeLocalUpdate"));
             // SafeUpdate has CheckWitness - should NOT be flagged
             Assert.IsFalse(result.vulnerableMethodNames.Contains("safeUpdate"));
             // SafeUpdateViaHelper delegates CheckWitness to helper - should NOT be flagged
@@ -35,8 +38,9 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         {
             var result = MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(NefFile, Manifest, null);
             string warning = result.GetWarningInfo(print: false);
-            Assert.IsTrue(warning.Contains("[SEC]"));
+            Assert.IsTrue(warning.Contains("[SECURITY]"));
             Assert.IsTrue(warning.Contains("unsafeUpdate"));
+            Assert.IsTrue(warning.Contains("unsafeLocalUpdate"));
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
@@ -44,7 +44,7 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             string warningInfo = v.GetWarningInfo(print: false);
 
             // Verify enhanced diagnostic format
-            Assert.IsTrue(warningInfo.Contains("[SEC] Potential Re-entrancy vulnerability detected"));
+            Assert.IsTrue(warningInfo.Contains("[SECURITY] Potential Re-entrancy vulnerability detected"));
             Assert.IsTrue(warningInfo.Contains("External contract calls:"));
             Assert.IsTrue(warningInfo.Contains("Storage writes that occur after external calls:"));
             Assert.IsTrue(warningInfo.Contains("Recommendation:"));

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_UnboundedOperation.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.SecurityAnalyzer;
+using Neo.SmartContract.Testing;
+
+namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
+{
+    [TestClass]
+    public class UnboundedOperationTests : DebugAndTestBase<Contract_UnboundedOperation>
+    {
+        [TestMethod]
+        public void Test_UnboundedOperation()
+        {
+            var result = UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(NefFile, Manifest, null);
+            // The for loop in Sum should produce at least one backward jump
+            Assert.IsTrue(result.backwardJumpAddresses.Count > 0);
+        }
+
+        [TestMethod]
+        public void Test_UnboundedOperation_WarningInfo()
+        {
+            var result = UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(NefFile, Manifest, null);
+            string warning = result.GetWarningInfo(print: false);
+            Assert.IsTrue(warning.Contains("[SEC]"));
+            Assert.IsTrue(warning.Contains("backward jump"));
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
@@ -31,7 +31,7 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         {
             var result = UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(NefFile, Manifest, null);
             string warning = result.GetWarningInfo(print: false);
-            Assert.IsTrue(warning.Contains("[SEC]"));
+            Assert.IsTrue(warning.Contains("[SECURITY]"));
             Assert.IsTrue(warning.Contains("backward jump"));
         }
     }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
@@ -22,8 +22,9 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         public void Test_UnboundedOperation()
         {
             var result = UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(NefFile, Manifest, null);
-            // The for loop in Sum should produce at least one backward jump
-            Assert.IsTrue(result.backwardJumpAddresses.Count > 0);
+            // The for loop in Sum currently compiles into a single backward jump at address 113.
+            Assert.AreEqual(1, result.backwardJumpAddresses.Count);
+            Assert.AreEqual(113, result.backwardJumpAddresses[0]);
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_WriteInTry.cs
@@ -63,7 +63,7 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             string warningInfo = v.GetWarningInfo(print: false);
 
             // Verify enhanced diagnostic format
-            Assert.IsTrue(warningInfo.Contains("[SEC] Writing storage in `try` block is risky"));
+            Assert.IsTrue(warningInfo.Contains("[SECURITY] Writing storage in `try` block is risky"));
             Assert.IsTrue(warningInfo.Contains("Recommendation:"));
             Assert.IsTrue(warningInfo.Contains("writes may not be properly reverted on exceptions"));
             Assert.IsTrue(warningInfo.Contains("Try block addresses:"));

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MissingCheckWitness.cs
@@ -1,0 +1,65 @@
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Numerics;
+
+#pragma warning disable CS0067
+
+namespace Neo.SmartContract.Testing;
+
+public abstract class Contract_MissingCheckWitness(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), IContractInfo
+{
+    #region Compiled data
+
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MissingCheckWitness"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unsafeUpdate"",""parameters"":[{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""safeUpdate"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":18,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+
+    /// <summary>
+    /// Optimization: "All"
+    /// </summary>
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACtXAQJBm/ZnznB5eGhB5j8YhEBXAQN4Qfgn7Iw5QZv2Z85wenloQeY/GIRAAla8Yw==").AsSerializable<Neo.SmartContract.NefFile>();
+
+    #endregion
+
+    #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEDeEH4J+yMOUGb9mfOcHp5aEHmPxiEQA==
+    /// INITSLOT 0103 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// SYSCALL F827EC8C 'System.Runtime.CheckWitness' [1024 datoshi]
+    /// ASSERT [1 datoshi]
+    /// SYSCALL 9BF667CE 'System.Storage.GetContext' [16 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// SYSCALL E63F1884 'System.Storage.Put' [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("safeUpdate")]
+    public abstract void SafeUpdate(UInt160? owner, byte[]? key, byte[]? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwECQZv2Z85weXhoQeY/GIRA
+    /// INITSLOT 0102 [64 datoshi]
+    /// SYSCALL 9BF667CE 'System.Storage.GetContext' [16 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// SYSCALL E63F1884 'System.Storage.Put' [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("unsafeUpdate")]
+    public abstract void UnsafeUpdate(byte[]? key, byte[]? value);
+
+    #endregion
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MissingCheckWitness.cs
@@ -13,12 +13,12 @@ public abstract class Contract_MissingCheckWitness(Neo.SmartContract.Testing.Sma
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MissingCheckWitness"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unsafeUpdate"",""parameters"":[{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""safeUpdate"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":18,""safe"":false},{""name"":""safeUpdateViaHelper"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":53,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MissingCheckWitness"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unsafeUpdate"",""parameters"":[{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""unsafeLocalUpdate"",""parameters"":[{""name"":""prefix"",""type"":""ByteArray""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":18,""safe"":false},{""name"":""safeUpdate"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":38,""safe"":false},{""name"":""safeUpdateViaHelper"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":73,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEtXAQJBm/ZnznB5eGhB5j8YhEBXAQN4Qfgn7Iw5QZv2Z85wenloQeY/GIRAVwABeEH4J+yMQFcBA3g08jlBm/ZnznB6eWhB5j8YhEA0GPO0").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF9XAQJBm/ZnznB5eGhB5j8YhEBXAQN4EcBwenlowUVQi0E5DOMKQFcBA3hB+CfsjDlBm/ZnznB6eWhB5j8YhEBXAAF4Qfgn7IxAVwEDeDTyOUGb9mfOcHp5aEHmPxiEQOEf7e4=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -63,6 +63,29 @@ public abstract class Contract_MissingCheckWitness(Neo.SmartContract.Testing.Sma
     /// </remarks>
     [DisplayName("safeUpdateViaHelper")]
     public abstract void SafeUpdateViaHelper(UInt160? owner, byte[]? key, byte[]? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEDeBHAcHp5aMFFUItBOQzjCkA=
+    /// INITSLOT 0103 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// PACK [2048 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// UNPACK [2048 datoshi]
+    /// DROP [2 datoshi]
+    /// SWAP [2 datoshi]
+    /// CAT [2048 datoshi]
+    /// SYSCALL 390CE30A 'System.Storage.Local.Put' [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("unsafeLocalUpdate")]
+    public abstract void UnsafeLocalUpdate(byte[]? prefix, byte[]? key, byte[]? value);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MissingCheckWitness.cs
@@ -13,12 +13,12 @@ public abstract class Contract_MissingCheckWitness(Neo.SmartContract.Testing.Sma
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MissingCheckWitness"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unsafeUpdate"",""parameters"":[{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""safeUpdate"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":18,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MissingCheckWitness"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unsafeUpdate"",""parameters"":[{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""safeUpdate"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":18,""safe"":false},{""name"":""safeUpdateViaHelper"",""parameters"":[{""name"":""owner"",""type"":""Hash160""},{""name"":""key"",""type"":""ByteArray""},{""name"":""value"",""type"":""ByteArray""}],""returntype"":""Void"",""offset"":53,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACtXAQJBm/ZnznB5eGhB5j8YhEBXAQN4Qfgn7Iw5QZv2Z85wenloQeY/GIRAAla8Yw==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEtXAQJBm/ZnznB5eGhB5j8YhEBXAQN4Qfgn7Iw5QZv2Z85wenloQeY/GIRAVwABeEH4J+yMQFcBA3g08jlBm/ZnznB6eWhB5j8YhEA0GPO0").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -43,6 +43,26 @@ public abstract class Contract_MissingCheckWitness(Neo.SmartContract.Testing.Sma
     /// </remarks>
     [DisplayName("safeUpdate")]
     public abstract void SafeUpdate(UInt160? owner, byte[]? key, byte[]? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEDeDTyOUGb9mfOcHp5aEHmPxiEQA==
+    /// INITSLOT 0103 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALL F2 [512 datoshi]
+    /// ASSERT [1 datoshi]
+    /// SYSCALL 9BF667CE 'System.Storage.GetContext' [16 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDARG2 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// SYSCALL E63F1884 'System.Storage.Put' [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("safeUpdateViaHelper")]
+    public abstract void SafeUpdateViaHelper(UInt160? owner, byte[]? key, byte[]? value);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_UnboundedOperation.cs
@@ -1,0 +1,86 @@
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Numerics;
+
+#pragma warning disable CS0067
+
+namespace Neo.SmartContract.Testing;
+
+public abstract class Contract_UnboundedOperation(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), IContractInfo
+{
+    #region Compiled data
+
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_UnboundedOperation"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""sum"",""parameters"":[{""name"":""n"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+
+    /// <summary>
+    /// Optimization: "All"
+    /// </summary>
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHVXAgEQcBBxImdoaZ5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcGlKnEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9xRWl4tSSYaED9Xhjv").AsSerializable<Neo.SmartContract.NefFile>();
+
+    #endregion
+
+    #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwIBEHAQcSJnaGmeSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BpSpxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcUVpeLUkmGhA
+    /// INITSLOT 0201 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// JMP 67 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// INC [4 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LT [8 datoshi]
+    /// JMPIF 98 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("sum")]
+    public abstract BigInteger? Sum(BigInteger? n);
+
+    #endregion
+}


### PR DESCRIPTION
Split from #1516.

Scope:
- Add MissingCheckWitness analyzer
- Add UnboundedOperation analyzer
- Wire new analyzers into analyzer registry
- Add dedicated contracts/tests/artifacts
- Add ReentrantAttack framework doc note

Validation:
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --filter "FullyQualifiedName~SecurityAnalyzer"