### PR TITLE
test(analyzer): backfill coverage for existing analyzers

### DIFF
--- a/tests/Neo.SmartContract.Analyzer.UnitTests/CharMethodsUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/CharMethodsUsageAnalyzerUnitTest.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CharMethodsUsageAnalyzerUnitTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.CharMethodsUsageAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class CharMethodsUsageAnalyzerUnitTest
+    {
+        [TestMethod]
+        public async Task UnsupportedCharCompareTo_ShouldReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    void TestMethod()
+    {
+        char c = 'a';
+        var result = c.CompareTo('b');
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(CharMethodsUsageAnalyzer.DiagnosticId)
+                .WithSpan(7, 22, 7, 38)
+                .WithArguments("CompareTo");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task UnsupportedCharGetHashCode_ShouldReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    void TestMethod()
+    {
+        char c = 'a';
+        var result = c.GetHashCode();
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(CharMethodsUsageAnalyzer.DiagnosticId)
+                .WithLocation(7, 22)
+                .WithArguments("GetHashCode");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task UnsupportedCharIsNumber_ShouldReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    void TestMethod()
+    {
+        var result = char.IsNumber('5');
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(CharMethodsUsageAnalyzer.DiagnosticId)
+                .WithSpan(6, 22, 6, 40)
+                .WithArguments("IsNumber");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task SupportedCharMethods_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    void TestMethod()
+    {
+        char c = 'a';
+        var result = char.IsLetter(c);
+        var result2 = char.IsDigit(c);
+        var result3 = char.IsWhiteSpace(c);
+        var result4 = char.ToLower(c);
+        var result5 = char.ToUpper(c);
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/InitialValueAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/InitialValueAnalyzerUnitTest.cs
@@ -1,0 +1,89 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// InitialValueAnalyzerUnitTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.InitialValueAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class InitialValueAnalyzerUnitTest
+    {
+        [TestMethod]
+        public async Task FieldWithoutAttribute_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    private static readonly string _address = ""hello"";
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task FieldWithRegularInitializer_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    private static readonly int _value = 42;
+    private static readonly string _name = ""test"";
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task FieldWithNonTargetAttribute_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+using System;
+
+[AttributeUsage(AttributeTargets.Field)]
+class MyCustomAttribute : Attribute
+{
+    public MyCustomAttribute(string value) { }
+}
+
+class TestClass
+{
+    [MyCustom(""some_value"")]
+    private static readonly string _address = default!;
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task FieldWithInitialValueAttributeAndNonDefaultInit_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+using System;
+
+[AttributeUsage(AttributeTargets.Field)]
+class InitialValueAttribute : Attribute
+{
+    public InitialValueAttribute(string value) { }
+}
+
+class TestClass
+{
+    [InitialValue(""some_value"")]
+    private static readonly string _address = ""actual_value"";
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/NepStandardImplementationAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/NepStandardImplementationAnalyzerUnitTest.cs
@@ -308,7 +308,7 @@ public class NepStandardImplementationAnalyzerUnitTest
                                                  [Neo.SmartContract.Framework.Attributes.SupportedStandards(Neo.SmartContract.Framework.NepStandard.Nep26)]
                                                  public class SampleNep26 : Neo.SmartContract.Framework.Interfaces.INEP26
                                                  {
-                                                     public void OnNEP11Payment(Neo.SmartContract.Framework.UInt160 from, System.Numerics.BigInteger amount, string tokenId, object data = null)
+                                                     public void OnNEP11Payment(Neo.SmartContract.Framework.UInt160 from, System.Numerics.BigInteger amount, Neo.SmartContract.Framework.ByteString tokenId, object data = null)
                                                      {
                                                      }
                                                  }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/NotifyEventNameAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/NotifyEventNameAnalyzerUnitTest.cs
@@ -1,0 +1,86 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NotifyEventNameAnalyzerUnitTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.NotifyEventNameAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class NotifyEventNameAnalyzerUnitTest
+    {
+        [TestMethod]
+        public async Task NonNotifyInvocation_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void Main()
+    {
+        var s = ""hello"";
+        var result = s.Contains(""ell"");
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task NotifyOnNonEventMember_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class Notifier
+{
+    public void Notify(string name, string arg1, int arg2) { }
+}
+
+class TestClass
+{
+    public void Main()
+    {
+        var n = new Notifier();
+        n.Notify(""Transfer"", ""to"", 100);
+    }
+}";
+
+            // The analyzer only triggers on member access named "Notify" and checks
+            // events in the containing type. With no events, the name won't match
+            // any DisplayName, so a diagnostic IS expected.
+            var expected = VerifyCS.Diagnostic(NotifyEventNameAnalyzer.DiagnosticId)
+                .WithLocation(12, 18)
+                .WithArguments("Transfer");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task MethodNotNamedNotify_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class Sender
+{
+    public void Send(string name) { }
+}
+
+class TestClass
+{
+    public void Main()
+    {
+        var s = new Sender();
+        s.Send(""Transfer"");
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/RefKeywordUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/RefKeywordUsageAnalyzerUnitTest.cs
@@ -1,0 +1,125 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RefKeywordUsageAnalyzerUnitTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.RefKeywordUsageAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class RefKeywordUsageAnalyzerUnitTest
+    {
+        [TestMethod]
+        public async Task InParameterInMethod_ShouldReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void TestMethod(in int value)
+    {
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(RefKeywordUsageAnalyzer.DiagnosticId)
+                .WithLocation(4, 28)
+                .WithArguments("method declaration ('in' parameter)");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task RefReadonlyParameterInMethod_ShouldReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void TestMethod(ref readonly int value)
+    {
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(RefKeywordUsageAnalyzer.DiagnosticId)
+                .WithLocation(4, 28)
+                .WithArguments("method declaration ('ref readonly' parameter)");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task InArgumentInInvocation_ShouldReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void Callee(in int value) { }
+    public void Caller()
+    {
+        int x = 5;
+        Callee(in x);
+    }
+}";
+
+            var expected = new[]
+            {
+                VerifyCS.Diagnostic(RefKeywordUsageAnalyzer.DiagnosticId)
+                    .WithLocation(4, 24)
+                    .WithArguments("method declaration ('in' parameter)"),
+                VerifyCS.Diagnostic(RefKeywordUsageAnalyzer.DiagnosticId)
+                    .WithLocation(8, 16)
+                    .WithArguments("method invocation ('in' argument)")
+            };
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task RegularRefParameter_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void TestMethod(ref int value)
+    {
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task OutParameter_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void TestMethod(out int value)
+    {
+        value = 0;
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task NoRefKeyword_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+class TestClass
+{
+    public void TestMethod(int value)
+    {
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/SystemMathUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/SystemMathUsageAnalyzerUnitTest.cs
@@ -1,0 +1,102 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SystemMathUsageAnalyzerUnitTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.SystemMathUsageAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class SystemMathUsageAnalyzerUnitTest
+    {
+        [TestMethod]
+        public async Task UnsupportedMathSqrt_ShouldReportDiagnostic()
+        {
+            var test = @"
+using System;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        var result = Math.Sqrt(4.0);
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
+                .WithSpan(8, 22, 8, 36)
+                .WithArguments("Sqrt");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task UnsupportedMathCos_ShouldReportDiagnostic()
+        {
+            var test = @"
+using System;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        var result = Math.Cos(1.0);
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
+                .WithSpan(8, 22, 8, 35)
+                .WithArguments("Cos");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task UnsupportedMathLog_ShouldReportDiagnostic()
+        {
+            var test = @"
+using System;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        var result = Math.Log(10.0);
+    }
+}";
+
+            var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
+                .WithSpan(8, 22, 8, 36)
+                .WithArguments("Log");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task SupportedMathMethods_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+using System;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        var result = Math.Max(1, 2);
+        var result2 = Math.Min(1, 2);
+        var result3 = Math.Abs(-1);
+        var result4 = Math.Sign(-5);
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/VolatileKeywordUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/VolatileKeywordUsageAnalyzerUnitTest.cs
@@ -1,0 +1,88 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// VolatileKeywordUsageAnalyzerUnitTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    Neo.SmartContract.Analyzer.VolatileKeywordUsageAnalyzer,
+    Neo.SmartContract.Analyzer.VolatileKeywordRemovalCodeFixProvider>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class VolatileKeywordUsageAnalyzerUnitTest
+    {
+        [TestMethod]
+        public async Task VolatileField_ShouldReportDiagnostic()
+        {
+            var test = """
+                       class TestClass
+                       {
+                           private volatile int _counter;
+                       }
+                       """;
+
+            var expected = Verifier.Diagnostic(VolatileKeywordUsageAnalyzer.DiagnosticId)
+                .WithSpan(3, 26, 3, 34)
+                .WithArguments("field declaration");
+            await Verifier.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task VolatileField_CodeFix_RemovesVolatile()
+        {
+            var test = """
+                       class TestClass
+                       {
+                           private volatile int _counter;
+                       }
+                       """;
+
+            var fixedCode = """
+                            class TestClass
+                            {
+                                private int _counter;
+                            }
+                            """;
+
+            var expected = Verifier.Diagnostic(VolatileKeywordUsageAnalyzer.DiagnosticId)
+                .WithSpan(3, 26, 3, 34)
+                .WithArguments("field declaration");
+            await Verifier.VerifyCodeFixAsync(test, expected, fixedCode);
+        }
+
+        [TestMethod]
+        public async Task NonVolatileField_ShouldNotReportDiagnostic()
+        {
+            var test = """
+                       class TestClass
+                       {
+                           private int _counter;
+                       }
+                       """;
+
+            await Verifier.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task StaticField_ShouldNotReportDiagnostic()
+        {
+            var test = """
+                       class TestClass
+                       {
+                           private static int _counter;
+                       }
+                       """;
+
+            await Verifier.VerifyAnalyzerAsync(test);
+        }
+    }
+}


### PR DESCRIPTION
Split from #1516.

Scope:
- Add unit tests for previously untested analyzers
- Keep production analyzer logic unchanged

Validation:
- dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj -c Release