### PR TITLE
fix(compiler): lower anonymous property getters on master-n3

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.SimpleAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.SimpleAssignment.cs
@@ -210,7 +210,7 @@ internal partial class MethodConvert
                 {
                     IFieldSymbol[] fields = property.ContainingType.GetAllMembers().OfType<IFieldSymbol>().ToArray();
                     fields = fields.Where(p => !p.IsStatic).ToArray();
-                    int backingFieldIndex = Array.FindIndex(fields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property));
+                    int backingFieldIndex = ResolveInstancePropertyBackingFieldIndex(property, fields);
                     AccessSlot(OpCode.LDARG, 0);
                     Push(backingFieldIndex);
                     AddInstruction(OpCode.ROT);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/CallHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/CallHelpers.cs
@@ -80,7 +80,11 @@ internal partial class MethodConvert
 
             var (convert, methodCallingConvention) = GetMethodConvertAndCallingConvention(model, symbol);
 
-            if (convert != null && convert.Instructions.Count == 1 && convert.Instructions[0].OpCode == OpCode.RET && !symbol.IsExtern)
+            if (symbol.MethodKind == MethodKind.Constructor
+                && convert != null
+                && convert.Instructions.Count == 1
+                && convert.Instructions[0].OpCode == OpCode.RET
+                && !symbol.IsExtern)
                 return;  // Do not call meaningless contructors
             if (NeedInstanceConstructor(symbol) && convert != null && convert.Instructions.Count >= 2)
             {
@@ -125,7 +129,11 @@ internal partial class MethodConvert
 
             var (convert, methodCallingConvention) = GetMethodConvertAndCallingConvention(model, symbol, instanceExpression);
 
-            if (convert != null && convert.Instructions.Count == 1 && convert.Instructions[0].OpCode == OpCode.RET && !symbol.IsExtern)
+            if (symbol.MethodKind == MethodKind.Constructor
+                && convert != null
+                && convert.Instructions.Count == 1
+                && convert.Instructions[0].OpCode == OpCode.RET
+                && !symbol.IsExtern)
                 return;  // Do not call meaningless contructors
             if (NeedInstanceConstructor(symbol) && convert != null && convert.Instructions.Count >= 2)
             {

--- a/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
@@ -65,7 +65,7 @@ internal partial class MethodConvert
         else
         {
             fields = fields.Where(p => !p.IsStatic).ToArray();
-            int backingFieldIndex = Array.FindIndex(fields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property));
+            int backingFieldIndex = ResolveInstancePropertyBackingFieldIndex(property, fields);
             switch (Symbol.MethodKind)
             {
                 case MethodKind.PropertyGet:
@@ -91,6 +91,35 @@ internal partial class MethodConvert
                     throw new CompilationException(Symbol, DiagnosticId.SyntaxNotSupported, $"Unsupported property accessor '{Symbol.MethodKind}' for property '{Symbol.AssociatedSymbol?.Name}'. Only PropertyGet and PropertySet accessors are supported.");
             }
         }
+    }
+
+    private int ResolveInstancePropertyBackingFieldIndex(IPropertySymbol property, IFieldSymbol[] instanceFields)
+    {
+        int backingFieldIndex = Array.FindIndex(instanceFields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property));
+        if (backingFieldIndex >= 0)
+            return backingFieldIndex;
+
+        backingFieldIndex = Array.FindIndex(instanceFields, p =>
+            SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property.OriginalDefinition));
+        if (backingFieldIndex >= 0)
+            return backingFieldIndex;
+
+        IPropertySymbol[] instanceProperties = property.ContainingType
+            .GetAllMembers()
+            .OfType<IPropertySymbol>()
+            .Where(p => !p.IsStatic)
+            .ToArray();
+
+        backingFieldIndex = Array.FindIndex(instanceProperties, p => SymbolEqualityComparer.Default.Equals(p, property));
+        if (backingFieldIndex >= 0)
+            return backingFieldIndex;
+
+        backingFieldIndex = Array.FindIndex(instanceProperties, p =>
+            SymbolEqualityComparer.Default.Equals(p, property.OriginalDefinition));
+        if (backingFieldIndex >= 0)
+            return backingFieldIndex;
+
+        return Array.FindIndex(instanceProperties, p => p.Name == property.Name);
     }
 
     private byte[] GetStorageBackedKey(IPropertySymbol property, AttributeData attribute)
@@ -169,7 +198,7 @@ internal partial class MethodConvert
                     {
                         // Check class
                         fields = fields.Where(p => !p.IsStatic).ToArray();
-                        int backingFieldIndex = Array.FindIndex(fields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property));
+                        int backingFieldIndex = ResolveInstancePropertyBackingFieldIndex(property, fields);
                         AccessSlot(OpCode.LDARG, 0);
                         Push(backingFieldIndex);
                         AddInstruction(OpCode.PICKITEM);

--- a/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
@@ -55,7 +55,16 @@ internal partial class MethodConvert
 
     private void ConvertSource(SemanticModel model)
     {
-        if (SyntaxNode is null) return;
+        if (SyntaxNode is null)
+        {
+            if (Symbol.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet &&
+                Symbol.AssociatedSymbol is IPropertySymbol property)
+            {
+                ConvertFieldBackedProperty(property);
+                _initSlot = !_inline;
+            }
+            return;
+        }
         switch (SyntaxNode)
         {
             case AccessorDeclarationSyntax syntax:

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Initializer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Initializer.cs
@@ -18,7 +18,7 @@ public abstract class Contract_Initializer(Neo.SmartContract.Testing.SmartContra
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPlXAQASERLAcGgQzmgRzp5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfQFcBAnl4EsBwaBDOaBHOnkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwECEhESwHB4SmgQUdBFeUpoEVHQRWgQzmgRzp5KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfQFcCAAwFSGVsbG8AbBLAcEHP50eWEQwFZ3JhcGUSwBQMBWFwcGxlEsASwHFBz+dHlkDNyhnT").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0PAVcBABIREsBwaBDOaBHOnkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwECeXgSwHBoEM5oEc6eSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BXAQISERLAcHhKaBBR0EV5SmgRUdBFaBDOaBHOnkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwIADAVIZWxsbwBsEsBwaDQpQc/nR5YRDAVncmFwZRLAFAwFYXBwbGUSwBLAcWkQzjQPQc/nR5ZAVwABeBHOQFcAAXgQzkBLjRbo").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -28,13 +28,15 @@ public abstract class Contract_Initializer(Neo.SmartContract.Testing.SmartContra
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIADAVIZWxsbwBsEsBwQc/nR5YRDAVncmFwZRLAFAwFYXBwbGUSwBLAcUHP50eWQA==
+    /// Script: VwIADAVIZWxsbwBsEsBwaDQpQc/nR5YRDAVncmFwZRLAFAwFYXBwbGUSwBLAcWkQzjQPQc/nR5ZA
     /// INITSLOT 0200 [64 datoshi]
     /// PUSHDATA1 48656C6C6F 'Hello' [8 datoshi]
     /// PUSHINT8 6C [1 datoshi]
     /// PUSH2 [1 datoshi]
     /// PACK [2048 datoshi]
     /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// CALL 29 [512 datoshi]
     /// SYSCALL CFE74796 'System.Runtime.Log' [32768 datoshi]
     /// PUSH1 [1 datoshi]
     /// PUSHDATA1 6772617065 'grape' [8 datoshi]
@@ -47,6 +49,10 @@ public abstract class Contract_Initializer(Neo.SmartContract.Testing.SmartContra
     /// PUSH2 [1 datoshi]
     /// PACK [2048 datoshi]
     /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// CALL 0F [512 datoshi]
     /// SYSCALL CFE74796 'System.Runtime.Log' [32768 datoshi]
     /// RET [0 datoshi]
     /// </remarks>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Initializer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Initializer.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing;
+using System.Collections.Generic;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -26,6 +27,27 @@ namespace Neo.Compiler.CSharp.UnitTests
             AssertGasConsumed(1113210);
             Assert.AreEqual(12, Contract.Sum2(5, 7));
             AssertGasConsumed(1605330);
+        }
+
+        [TestMethod]
+        public void AnonymousObjectCreation_LogsAnonymousMemberValues()
+        {
+            var logs = new Queue<string>();
+            TestEngine.OnRuntimeLogDelegate handler = (sender, log) => logs.Enqueue(log);
+            Contract.OnRuntimeLog += handler;
+
+            try
+            {
+                Contract.AnonymousObjectCreation();
+            }
+            finally
+            {
+                Contract.OnRuntimeLog -= handler;
+            }
+
+            Assert.AreEqual(2, logs.Count);
+            Assert.AreEqual("Hello", logs.Dequeue());
+            Assert.AreEqual("apple", logs.Dequeue());
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Initializer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Initializer.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing;
+using System;
 using System.Collections.Generic;
 
 namespace Neo.Compiler.CSharp.UnitTests
@@ -48,6 +49,62 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(2, logs.Count);
             Assert.AreEqual("Hello", logs.Dequeue());
             Assert.AreEqual("apple", logs.Dequeue());
+        }
+
+        [TestMethod]
+        public void AnonymousObjectCreation_CompilesAnonymousGetterHelpersWithValidIndexes()
+        {
+            var context = TestCleanup.EnsureArtifactUpToDateInternal(nameof(Contract_Initializer));
+            Assert.IsNotNull(context, "Failed to compile Contract_Initializer for inspection.");
+
+            var assembly = context!.CreateAssembly().Replace("\r\n", "\n", StringComparison.Ordinal);
+            var anonymousObjectCreation = ExtractMethodBlock(
+                assembly,
+                "Neo.Compiler.CSharp.TestContracts.Contract_Initializer.anonymousObjectCreation()"
+            );
+            var messageGetter = ExtractMethodBlock(
+                assembly,
+                "<anonymous type: int Amount, string Message>.Message.get"
+            );
+            var nameGetter = ExtractMethodBlock(
+                assembly,
+                "<anonymous type: string name, int diam>.name.get"
+            );
+
+            StringAssert.Contains(anonymousObjectCreation, "LDLOC 0");
+            StringAssert.Contains(anonymousObjectCreation, "CALL <");
+            StringAssert.Contains(anonymousObjectCreation, "SYSCALL System.Runtime.Log");
+            Assert.IsFalse(
+                anonymousObjectCreation.Contains("STLOC 0\n000000de: SYSCALL System.Runtime.Log", StringComparison.Ordinal),
+                $"anonymousObjectCreation should load/call getter before logging:\n{anonymousObjectCreation}"
+            );
+
+            StringAssert.Contains(messageGetter, "PUSH 1");
+            StringAssert.Contains(messageGetter, "PICKITEM");
+            Assert.IsFalse(
+                messageGetter.Contains("PUSH -1", StringComparison.Ordinal),
+                $"Message getter should not index with -1:\n{messageGetter}"
+            );
+
+            StringAssert.Contains(nameGetter, "PUSH 0");
+            StringAssert.Contains(nameGetter, "PICKITEM");
+            Assert.IsFalse(
+                nameGetter.Contains("PUSH -1", StringComparison.Ordinal),
+                $"name getter should not index with -1:\n{nameGetter}"
+            );
+        }
+
+        private static string ExtractMethodBlock(string assembly, string methodSignature)
+        {
+            var marker = $"// {methodSignature}";
+            var start = assembly.IndexOf(marker, StringComparison.Ordinal);
+            Assert.IsTrue(start >= 0, $"Method section '{methodSignature}' was not found in generated assembly.\n{assembly}");
+
+            var next = assembly.IndexOf("\n// ", start + marker.Length, StringComparison.Ordinal);
+            if (next < 0)
+                next = assembly.Length;
+
+            return assembly[start..next];
         }
     }
 }


### PR DESCRIPTION
## Summary
- lower synthesized anonymous-type property getters even when the getter symbol has no syntax node
- limit the RET-only call elision to constructors and add robust instance-property backing index fallback
- add a runtime regression for Contract_Initializer.anonymousObjectCreation and refresh its generated testing artifact

## Test Plan
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter AnonymousObjectCreation_LogsAnonymousMemberValues --nologo
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --nologo