### PR TITLE
Fix: Oracle.Request definition

### DIFF
--- a/src/Neo.SmartContract.Framework/Native/Oracle.cs
+++ b/src/Neo.SmartContract.Framework/Native/Oracle.cs
@@ -36,8 +36,9 @@ namespace Neo.SmartContract.Framework.Native
         /// <para>
         /// The execution will fail if:
         ///  1. The 'url' is null or length exceeds MaxUrlLength(the default value is 256 bytes).
-        ///  2. The 'filter' is null or length exceeds MaxFilterLength(the default value is 128 bytes).
-        ///  3. The 'callback' is null or length exceeds MaxCallbackLength(the default value is 32 bytes) or starts with '_'.
+        ///  2. The 'filter' length exceeds MaxFilterLength(the default value is 128 bytes).
+        ///    The 'filter' can be null and null means no filter(i.e. return the entire response).
+        ///  3. The 'callback' length exceeds MaxCallbackLength(the default value is 32 bytes) or starts with '_'.
         ///  4. The 'userData' is null or length exceeds MaxUserDataLength(the default value is 512 bytes).
         ///  5. The 'gasForResponse' is less than 0.1 GAS.
         ///  6. Too many pending responses for the specified URL.
@@ -47,8 +48,8 @@ namespace Neo.SmartContract.Framework.Native
         /// <param name="url">The URL to request an Oracle response from.</param>
         /// <param name="filter">The filter(json path expression) to apply to the response.</param>
         /// <param name="callback">The method name of calling contract to call when the response is received.</param>
-        /// <param name="userData">The user data to pass to the callback.</param>
+        /// <param name="userData">The user data to pass to the callback</param>
         /// <param name="gasForResponse">The amount of GAS(in the unit of datoshi) for the response.</param>
-        public static extern void Request(string url, string filter, string callback, object userData, long gasForResponse);
+        public static extern void Request(string url, string? filter, string callback, object? userData, long gasForResponse);
     }
 }

--- a/src/Neo.SmartContract.Framework/Native/Oracle.cs
+++ b/src/Neo.SmartContract.Framework/Native/Oracle.cs
@@ -48,7 +48,7 @@ namespace Neo.SmartContract.Framework.Native
         /// <param name="url">The URL to request an Oracle response from.</param>
         /// <param name="filter">The filter(json path expression) to apply to the response.</param>
         /// <param name="callback">The method name of calling contract to call when the response is received.</param>
-        /// <param name="userData">The user data to pass to the callback</param>
+        /// <param name="userData">The user data to pass to the callback.</param>
         /// <param name="gasForResponse">The amount of GAS(in the unit of datoshi) for the response.</param>
         public static extern void Request(string url, string? filter, string callback, object? userData, long gasForResponse);
     }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_GoTo.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_GoTo.cs
@@ -79,7 +79,7 @@ namespace Neo.Compiler.CSharp.TestContracts
                             break;
                     }
                 }
-            END0:
+        END0:
             ExecutionEngine.Assert(goto_ == false);
             ExecutionEngine.Assert(Storage.Get("\xff\x00")! == "\x01");
             foreach (object i in Storage.Find("\xff"))
@@ -114,7 +114,7 @@ namespace Neo.Compiler.CSharp.TestContracts
                         Storage.Put("\xff\x00", "\x02");
                     }
                 }
-            END2:
+        END2:
             ExecutionEngine.Assert(Storage.Get("\xff\x00")! == "\x02");
             foreach (object i in Storage.Find("\xff"))
                 try
@@ -150,7 +150,7 @@ namespace Neo.Compiler.CSharp.TestContracts
                     ExecutionEngine.Assert(Storage.Get("\xff\x00")! == "\x02");
                     Storage.Put("\xff\x00", "\x03");
                 }
-            END3:
+        END3:
             ExecutionEngine.Assert(Storage.Get("\xff\x00")! == "\x03");
         }
     }


### PR DESCRIPTION

Fix Oracle.Request definition: the `filter` and `userdata` can be null.