### PR TITLE
refactor: remove compiler dependency on testing

### DIFF
--- a/src/Neo.Compiler.CSharp/Extensions/ArtifactExtensions.cs
+++ b/src/Neo.Compiler.CSharp/Extensions/ArtifactExtensions.cs
@@ -13,7 +13,6 @@ using Neo.Disassembler.CSharp;
 using Neo.Extensions;
 using Neo.Json;
 using Neo.SmartContract.Manifest;
-using Neo.SmartContract.Testing.TestingStandards;
 using Neo.VM;
 using System;
 using System.Collections.Generic;
@@ -25,6 +24,12 @@ namespace Neo.SmartContract.Testing.Extensions
 {
     public static class ArtifactExtensions
     {
+        private const string TestingSmartContractType = "Neo.SmartContract.Testing.SmartContract";
+        private const string TestingSmartContractInitializeType = "Neo.SmartContract.Testing.SmartContractInitialize";
+        private const string TestingNep17StandardType = "Neo.SmartContract.Testing.TestingStandards.INep17Standard";
+        private const string TestingOwnableType = "Neo.SmartContract.Testing.TestingStandards.IOwnable";
+        private const string TestingVerificableType = "Neo.SmartContract.Testing.TestingStandards.IVerificable";
+
         static readonly string[] _protectedWords =
         [
             "abstract",
@@ -125,14 +130,14 @@ namespace Neo.SmartContract.Testing.Extensions
                 NewLine = "\n"
             };
 
-            var inheritance = new List<Type>
+            var inheritance = new List<string>
             {
-                typeof(SmartContract)
+                TestingSmartContractType
             };
 
-            if (manifest.IsNep17()) inheritance.Add(typeof(INep17Standard));
-            if (manifest.IsOwnable()) inheritance.Add(typeof(IOwnable));
-            if (manifest.IsVerificable()) inheritance.Add(typeof(IVerificable));
+            if (IsNep17(manifest)) inheritance.Add(TestingNep17StandardType);
+            if (IsOwnable(manifest)) inheritance.Add(TestingOwnableType);
+            if (IsVerificable(manifest)) inheritance.Add(TestingVerificableType);
 
             sourceCode.WriteLine("using Neo.Cryptography.ECC;");
             sourceCode.WriteLine("using Neo.Extensions;");
@@ -145,7 +150,7 @@ namespace Neo.SmartContract.Testing.Extensions
             sourceCode.WriteLine("");
             sourceCode.WriteLine("namespace Neo.SmartContract.Testing;");
             sourceCode.WriteLine("");
-            sourceCode.WriteLine($"public abstract class {name}({typeof(SmartContractInitialize).FullName} initialize) : " + FormatInheritance(inheritance, "initialize") + ", IContractInfo");
+            sourceCode.WriteLine($"public abstract class {name}({TestingSmartContractInitializeType} initialize) : {FormatInheritance(inheritance, "initialize")}, IContractInfo");
             sourceCode.WriteLine("{");
 
             // Write compiled data
@@ -311,7 +316,7 @@ namespace Neo.SmartContract.Testing.Extensions
         /// <param name="ev">Event</param>
         /// <param name="inheritance">Inheritance</param>
         /// <returns>Source</returns>
-        private static string CreateSourceEventFromManifest(ContractEventDescriptor ev, IList<Type> inheritance)
+        private static string CreateSourceEventFromManifest(ContractEventDescriptor ev, IList<string> inheritance)
         {
             var builder = new StringBuilder();
             using var sourceCode = new StringWriter(builder)
@@ -323,13 +328,13 @@ namespace Neo.SmartContract.Testing.Extensions
             {
                 case "Transfer":
                     {
-                        if (inheritance.Contains(typeof(INep17Standard)) && ev.Parameters.Length == 3 &&
+                        if (inheritance.Contains(TestingNep17StandardType) && ev.Parameters.Length == 3 &&
                             ev.Parameters[0].Type == ContractParameterType.Hash160 &&
                             ev.Parameters[1].Type == ContractParameterType.Hash160 &&
                             ev.Parameters[2].Type == ContractParameterType.Integer)
                         {
                             sourceCode.WriteLine($"    [DisplayName(\"{ev.Name}\")]");
-                            sourceCode.WriteLine($"    public event {typeof(INep17Standard).FullName}.delTransfer? OnTransfer;");
+                            sourceCode.WriteLine($"    public event {TestingNep17StandardType}.delTransfer? OnTransfer;");
                             return builder.ToString();
                         }
 
@@ -337,12 +342,12 @@ namespace Neo.SmartContract.Testing.Extensions
                     }
                 case "SetOwner":
                     {
-                        if (inheritance.Contains(typeof(IOwnable)) && ev.Parameters.Length == 2 &&
+                        if (inheritance.Contains(TestingOwnableType) && ev.Parameters.Length == 2 &&
                             ev.Parameters[0].Type == ContractParameterType.Hash160 &&
                             ev.Parameters[1].Type == ContractParameterType.Hash160)
                         {
                             sourceCode.WriteLine($"    [DisplayName(\"{ev.Name}\")]");
-                            sourceCode.WriteLine($"    public event {typeof(IOwnable).FullName}.delSetOwner? OnSetOwner;");
+                            sourceCode.WriteLine($"    public event {TestingOwnableType}.delSetOwner? OnSetOwner;");
                             return builder.ToString();
                         }
 
@@ -596,11 +601,32 @@ namespace Neo.SmartContract.Testing.Extensions
             };
         }
 
-        private static string FormatInheritance(List<Type> inheritance, string initializeParam)
+        private static bool IsNep17(ContractManifest manifest)
         {
-            var formattedInheritance = inheritance.Select(type => (type == typeof(SmartContract)
-                    ? $"{type.FullName}({initializeParam})"
-                    : type.FullName)!)
+            return manifest.SupportedStandards.Any(u => u == "NEP-17");
+        }
+
+        private static bool IsOwnable(ContractManifest manifest)
+        {
+            return
+                manifest.Abi.Methods.Any(u => u.Name == "getOwner" && u.Safe && u.Parameters.Length == 0) &&
+                manifest.Abi.Methods.Any(u => u.Name == "setOwner" && !u.Safe && u.Parameters.Length == 1 && u.Parameters[0].Type == ContractParameterType.Hash160) &&
+                manifest.Abi.Events.Any(u => u.Name == "SetOwner" && u.Parameters.Length == 2 &&
+                    u.Parameters[0].Type == ContractParameterType.Hash160 &&
+                    u.Parameters[1].Type == ContractParameterType.Hash160);
+        }
+
+        private static bool IsVerificable(ContractManifest manifest)
+        {
+            var method = manifest.Abi.GetMethod("verify", 0);
+            return method is { Safe: true } && method.ReturnType == ContractParameterType.Boolean;
+        }
+
+        private static string FormatInheritance(List<string> inheritance, string initializeParam)
+        {
+            var formattedInheritance = inheritance.Select(type => type == TestingSmartContractType
+                    ? $"{type}({initializeParam})"
+                    : type)
                 .ToList();
             return string.Join(", ", formattedInheritance);
         }

--- a/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
+++ b/src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
@@ -38,10 +38,7 @@
     <ProjectReference Include="..\Neo.SmartContract.Framework\Neo.SmartContract.Framework.csproj">
       <Aliases>scfx</Aliases>
     </ProjectReference>
-    <ProjectReference Include="..\Neo.SmartContract.Testing\Neo.SmartContract.Testing.csproj">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>compile; build</IncludeAssets>
-    </ProjectReference>
+    <ProjectReference Include="..\Neo.Disassembler.CSharp\Neo.Disassembler.CSharp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -502,7 +502,7 @@ namespace Neo.Compiler
                                 RuntimeAssemblyResolver.CreateFrameworkReference("System.Memory.dll"),
                                 MetadataReference.CreateFromFile(RuntimeAssemblyResolver.ResolveAssemblyFromType(typeof(IO.MemoryReader))),
                                 MetadataReference.CreateFromFile(RuntimeAssemblyResolver.ResolveAssemblyFromType(typeof(NeoSystem))),
-                                MetadataReference.CreateFromFile(RuntimeAssemblyResolver.ResolveAssemblyFromType(typeof(SmartContract.Testing.TestEngine)))
+                                MetadataReference.CreateFromFile(RuntimeAssemblyResolver.ResolveDependencyAssembly("Neo.SmartContract.Testing.dll"))
                             };
 
                             CSharpCompilationOptions csOptions = new(

--- a/src/Neo.Compiler.CSharp/RuntimeAssemblyResolver.cs
+++ b/src/Neo.Compiler.CSharp/RuntimeAssemblyResolver.cs
@@ -109,6 +109,44 @@ namespace Neo.Compiler
             return ResolveFrameworkAssembly($"{assemblyName}.dll");
         }
 
+        internal static string ResolveDependencyAssembly(string fileName)
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+#pragma warning disable IL3000
+                    if (!string.IsNullOrEmpty(assembly.Location)
+                        && string.Equals(Path.GetFileName(assembly.Location), fileName, StringComparison.OrdinalIgnoreCase)
+                        && File.Exists(assembly.Location))
+                    {
+                        return assembly.Location;
+                    }
+#pragma warning restore IL3000
+                }
+                catch
+                {
+                    // Ignore dynamic or inaccessible assemblies and continue searching.
+                }
+            }
+
+            foreach (var baseDir in EnumerateBaseDirectories())
+            {
+                if (string.IsNullOrEmpty(baseDir))
+                    continue;
+
+                var candidate = Path.Combine(baseDir, fileName);
+                if (File.Exists(candidate))
+                    return candidate;
+
+                var refsCandidate = Path.Combine(baseDir, "refs", fileName);
+                if (File.Exists(refsCandidate))
+                    return refsCandidate;
+            }
+
+            throw new FileNotFoundException($"Unable to locate dependency assembly '{fileName}'.", fileName);
+        }
+
         private static bool TryResolveFrameworkAssemblyPath(string fileName, out string? path)
         {
             foreach (var baseDir in EnumerateBaseDirectories())

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/NeoDebugInfo.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/NeoDebugInfo.cs
@@ -1,0 +1,121 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NeoDebugInfo.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Neo.Compiler.SecurityAnalyzer
+{
+    internal sealed class NeoDebugInfo
+    {
+        private static readonly Regex SequencePointRegex = new(@"^(\d+)\[(-?\d+)\](\d+)\:(\d+)\-(\d+)\:(\d+)$");
+
+        internal readonly IReadOnlyList<string> Documents;
+        internal readonly IReadOnlyList<Method> Methods;
+
+        internal NeoDebugInfo(IReadOnlyList<string> documents, IReadOnlyList<Method> methods)
+        {
+            Documents = documents;
+            Methods = methods;
+        }
+
+        internal sealed class SourceLocation
+        {
+            public string FileName { get; init; } = string.Empty;
+            public int Line { get; init; }
+            public int Column { get; init; }
+            public string? CodeSnippet { get; init; }
+        }
+
+        internal readonly struct Method
+        {
+            public readonly (int Start, int End) Range;
+            public readonly IReadOnlyList<SequencePoint> SequencePoints;
+
+            public Method((int Start, int End) range, IReadOnlyList<SequencePoint> sequencePoints)
+            {
+                Range = range;
+                SequencePoints = sequencePoints;
+            }
+        }
+
+        internal readonly struct SequencePoint
+        {
+            public readonly int Address;
+            public readonly int Document;
+            public readonly (int Line, int Column) Start;
+
+            public SequencePoint(int address, int document, (int Line, int Column) start)
+            {
+                Address = address;
+                Document = document;
+                Start = start;
+            }
+        }
+
+        internal static NeoDebugInfo FromDebugInfoJson(JObject json)
+        {
+            if (json["documents"] is not JArray jDocs)
+                throw new ArgumentNullException("documents must be an array");
+
+            if (json["methods"] is not JArray jMethods)
+                throw new ArgumentNullException("methods must be an array");
+
+            var documents = jDocs.Select(doc => doc?.GetString()!)
+                .Where(doc => doc is not null)
+                .ToList();
+            var methods = jMethods.Select(method => MethodFromJson(method as JObject)).ToList();
+
+            return new NeoDebugInfo(documents, methods);
+        }
+
+        private static Method MethodFromJson(JObject? json)
+        {
+            if (json is null)
+                throw new ArgumentNullException("Method can't be null");
+
+            if (json["sequence-points"] is not JArray jSequence)
+                throw new ArgumentNullException("sequence-points must be an array");
+
+            var range = RangeFromJson(json["range"]?.GetString() ?? throw new ArgumentNullException("method.range can't be null"));
+            var sequencePoints = jSequence.Select(sequence => SequencePointFromJson(sequence?.GetString())).ToList();
+
+            return new Method(range, sequencePoints);
+        }
+
+        private static (int Start, int End) RangeFromJson(string range)
+        {
+            var values = range.Split('-');
+            return values.Length == 2
+                ? (int.Parse(values[0]), int.Parse(values[1]))
+                : throw new FormatException($"Invalid range '{range}'");
+        }
+
+        private static SequencePoint SequencePointFromJson(string? sequence)
+        {
+            if (sequence is null)
+                throw new ArgumentNullException("Sequence point can't be null");
+
+            Match match = SequencePointRegex.Match(sequence);
+            if (match.Groups.Count != 7)
+                throw new FormatException($"Invalid Sequence Point '{sequence}'");
+
+            int address = int.Parse(match.Groups[1].Value);
+            int document = int.Parse(match.Groups[2].Value);
+            var start = (int.Parse(match.Groups[3].Value), int.Parse(match.Groups[4].Value));
+
+            return new SequencePoint(address, document, start);
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
@@ -13,7 +13,6 @@ using Neo.Json;
 using Neo.Optimizer;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
-using Neo.SmartContract.Testing.Coverage;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/WriteInTryAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/WriteInTryAnalyzer.cs
@@ -13,7 +13,6 @@ using Neo.Json;
 using Neo.Optimizer;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
-using Neo.SmartContract.Testing.Coverage;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_NeoDebugInfo.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_NeoDebugInfo.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_NeoDebugInfo.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Json;
+using Neo.Compiler.SecurityAnalyzer;
+using System;
+
+namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
+{
+    [TestClass]
+    public class NeoDebugInfoTests
+    {
+        [TestMethod]
+        public void FromDebugInfoJson_Parses_Minimal_Valid_DebugInfo()
+        {
+            var json = (JObject)JToken.Parse("""
+            {
+              "documents": ["a.cs"],
+              "methods": [
+                {
+                  "range": "10-20",
+                  "sequence-points": ["12[0]3:4-3:9"]
+                }
+              ]
+            }
+            """)!;
+
+            var debugInfo = NeoDebugInfo.FromDebugInfoJson(json);
+
+            Assert.AreEqual(1, debugInfo.Documents.Count);
+            Assert.AreEqual("a.cs", debugInfo.Documents[0]);
+            Assert.AreEqual(1, debugInfo.Methods.Count);
+            Assert.AreEqual(10, debugInfo.Methods[0].Range.Start);
+            Assert.AreEqual(20, debugInfo.Methods[0].Range.End);
+            Assert.AreEqual(12, debugInfo.Methods[0].SequencePoints[0].Address);
+            Assert.AreEqual(0, debugInfo.Methods[0].SequencePoints[0].Document);
+            Assert.AreEqual(3, debugInfo.Methods[0].SequencePoints[0].Start.Line);
+            Assert.AreEqual(4, debugInfo.Methods[0].SequencePoints[0].Start.Column);
+        }
+
+        [TestMethod]
+        public void FromDebugInfoJson_Throws_When_Methods_Is_Not_Array()
+        {
+            var json = new JObject
+            {
+                ["documents"] = new JArray("a.cs"),
+                ["methods"] = new JString("invalid")
+            };
+
+            Assert.ThrowsException<ArgumentNullException>(() => NeoDebugInfo.FromDebugInfoJson(json));
+        }
+
+        [TestMethod]
+        public void FromDebugInfoJson_Throws_When_Range_Is_Invalid()
+        {
+            var json = (JObject)JToken.Parse("""
+            {
+              "documents": ["a.cs"],
+              "methods": [
+                {
+                  "range": "invalid",
+                  "sequence-points": ["12[0]3:4-3:9"]
+                }
+              ]
+            }
+            """)!;
+
+            Assert.ThrowsException<FormatException>(() => NeoDebugInfo.FromDebugInfoJson(json));
+        }
+
+        [TestMethod]
+        public void FromDebugInfoJson_Throws_When_SequencePoint_Is_Invalid()
+        {
+            var json = (JObject)JToken.Parse("""
+            {
+              "documents": ["a.cs"],
+              "methods": [
+                {
+                  "range": "10-20",
+                  "sequence-points": ["bad-sequence-point"]
+                }
+              ]
+            }
+            """)!;
+
+            Assert.ThrowsException<FormatException>(() => NeoDebugInfo.FromDebugInfoJson(json));
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NewCommand.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NewCommand.cs
@@ -189,6 +189,23 @@ namespace Neo.Compiler.CSharp.UnitTests
                          "Expected compilation success message.");
         }
 
+        [TestMethod]
+        public void TestGeneratedContractArtifactLibraryCompilation()
+        {
+            string contractName = "ArtifactLibraryContract";
+
+            var generateResult = RunCompilerCommand($"new {contractName} -t Basic --output \"{_testOutputPath}\"");
+            Assert.AreEqual(0, generateResult.ExitCode);
+
+            string projectPath = Path.Combine(_testOutputPath, contractName, $"{contractName}.csproj");
+            UseLocalFrameworkReference(projectPath);
+
+            var compileResult = RunCompilerCommand($"\"{projectPath}\" --generate-artifacts Library");
+
+            Assert.AreEqual(0, compileResult.ExitCode, $"Artifact compilation failed. Output: {compileResult.StdOut}{compileResult.StdErr}");
+            Assert.IsTrue(File.Exists(Path.Combine(_testOutputPath, contractName, "bin", "sc", $"{contractName}.artifacts.dll")));
+        }
+
         private CommandResult RunCompilerCommand(string arguments)
         {
             var args = SplitArgs(arguments);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ProjectBoundaries.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ProjectBoundaries.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_ProjectBoundaries.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests
+{
+    [TestClass]
+    public class ProjectBoundaryTests
+    {
+        [TestMethod]
+        public void CompilerProject_DoesNotReference_TestingProject()
+        {
+            string csprojPath = Path.GetFullPath(Path.Combine(
+                AppContext.BaseDirectory,
+                "..", "..", "..", "..", "..",
+                "src", "Neo.Compiler.CSharp", "Neo.Compiler.CSharp.csproj"));
+
+            var project = XDocument.Load(csprojPath);
+            var references = project.Descendants("ProjectReference");
+
+            Assert.IsFalse(
+                references.Any(reference => (string?)reference.Attribute("Include") is string include
+                    && include.Contains("Neo.SmartContract.Testing.csproj")),
+                "Neo.Compiler.CSharp.csproj should not reference Neo.SmartContract.Testing.csproj");
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_RuntimeAssemblyResolver.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_RuntimeAssemblyResolver.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_RuntimeAssemblyResolver.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace Neo.Compiler.CSharp.UnitTests
+{
+    [TestClass]
+    public class RuntimeAssemblyResolverTests
+    {
+        [TestMethod]
+        public void ResolveDependencyAssembly_Finds_Loaded_TestingAssembly()
+        {
+            string path = RuntimeAssemblyResolver.ResolveDependencyAssembly("Neo.SmartContract.Testing.dll");
+
+            Assert.IsTrue(File.Exists(path));
+            StringAssert.EndsWith(path, "Neo.SmartContract.Testing.dll");
+        }
+
+        [TestMethod]
+        public void ResolveDependencyAssembly_Throws_For_MissingAssembly()
+        {
+            Assert.ThrowsException<FileNotFoundException>(() =>
+                RuntimeAssemblyResolver.ResolveDependencyAssembly("Definitely.Missing.Dependency.dll"));
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
@@ -13,6 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\..\src\Neo.Compiler.CSharp\Neo.Compiler.CSharp.csproj" />
 		<ProjectReference Include="..\..\src\Neo.SmartContract.Testing\Neo.SmartContract.Testing.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
Summary:
- move artifact generation extensions out of Neo.SmartContract.Testing and into the compiler side
- replace the compiler's use of testing coverage types with a compiler-local minimal debug-info parser for security analyzers
- remove the Neo.Compiler.CSharp -> Neo.SmartContract.Testing project reference
- keep artifact-generation behavior stable by preserving the original extension namespace and output format
- add a boundary regression test that asserts the compiler project no longer references the testing project

Validation:
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj -c Release
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --filter FullyQualifiedName~ProjectBoundaryTests
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj -c Release --filter FullyQualifiedName~ArtifactExtensionsTests

Issue:
- follows issue #1514 item P1-15: break Compiler -> Testing reverse dependency