### PR TITLE
refactor: deduplicate nep11 manifest validation

### DIFF
--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
@@ -20,12 +20,14 @@ namespace Neo.Compiler;
 
 internal static partial class ContractManifestExtensions
 {
-    private static void ValidateNep11SafeMethod(
+    private static void ValidateNep11SingleParameterSafeMethod(
         System.Collections.Generic.List<CompilationException> errors,
         ContractMethodDescriptor? method,
         string methodName,
         ContractParameterType returnType,
-        params ContractParameterType[] parameterTypes)
+        string returnTypeDescription,
+        ContractParameterType parameterType,
+        string parameterTypeDescription)
     {
         if (method is null)
         {
@@ -40,46 +42,15 @@ internal static partial class ContractManifestExtensions
 
         if (method.ReturnType != returnType)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's return type is not {FormatContractParameterType(returnType)}"));
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's return type is not {returnTypeDescription}"));
 
-        if (method.Parameters.Length != parameterTypes.Length)
+        if (method.Parameters.Length != 1)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's parameters length is not {parameterTypes.Length}"));
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's parameters length is not 1"));
 
-        for (int index = 0; index < Math.Min(method.Parameters.Length, parameterTypes.Length); index++)
-        {
-            if (method.Parameters[index].Type == parameterTypes[index])
-                continue;
-
-            string ordinal = parameterTypes.Length == 1
-                ? "parameters"
-                : index switch
-                {
-                    0 => "first parameters",
-                    1 => "second parameters",
-                    2 => "third parameters",
-                    3 => "fourth parameters",
-                    4 => "fifth parameters",
-                    _ => $"{index + 1}th parameters"
-                };
-
+        if (method.Parameters.Length > 0 && method.Parameters[0].Type != parameterType)
             errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's {ordinal} type is not {FormatContractParameterType(parameterTypes[index])}"));
-        }
-    }
-
-    private static string FormatContractParameterType(ContractParameterType type)
-    {
-        return type switch
-        {
-            ContractParameterType.Hash160 => "a Hash160",
-            ContractParameterType.ByteArray => "a ByteArray",
-            ContractParameterType.InteropInterface => "an InteropInterface",
-            ContractParameterType.Integer => "an Integer",
-            ContractParameterType.Boolean => "a Boolean",
-            ContractParameterType.Any => "a Any",
-            _ => $"a {type}"
-        };
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's parameters type is not {parameterTypeDescription}"));
     }
 
     private static System.Collections.Generic.List<CompilationException>
@@ -188,8 +159,22 @@ internal static partial class ContractManifestExtensions
         // errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
         // $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it is not found in the ABI"));
 
-        ValidateNep11SafeMethod(errors, tokensOfMethod, "tokensOf", ContractParameterType.InteropInterface, ContractParameterType.Hash160);
-        ValidateNep11SafeMethod(errors, ownerOfMethod, "ownerOf", ContractParameterType.Hash160, ContractParameterType.ByteArray);
+        ValidateNep11SingleParameterSafeMethod(
+            errors,
+            tokensOfMethod,
+            "tokensOf",
+            ContractParameterType.InteropInterface,
+            "an InteropInterface",
+            ContractParameterType.Hash160,
+            "a Hash160");
+        ValidateNep11SingleParameterSafeMethod(
+            errors,
+            ownerOfMethod,
+            "ownerOf",
+            ContractParameterType.Hash160,
+            "a Hash160",
+            ContractParameterType.ByteArray,
+            "a ByteArray");
 
 
         if (transferMethod1 is null && transferMethod2 is null)

--- a/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
+++ b/src/Neo.Compiler.CSharp/Manifest/ContractManifestExtension.Nep11.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 extern alias scfx;
+using System;
 using System.Linq;
 using Neo.SmartContract.Manifest;
 using scfx::Neo.SmartContract.Framework;
@@ -19,6 +20,68 @@ namespace Neo.Compiler;
 
 internal static partial class ContractManifestExtensions
 {
+    private static void ValidateNep11SafeMethod(
+        System.Collections.Generic.List<CompilationException> errors,
+        ContractMethodDescriptor? method,
+        string methodName,
+        ContractParameterType returnType,
+        params ContractParameterType[] parameterTypes)
+    {
+        if (method is null)
+        {
+            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it is not found in the ABI"));
+            return;
+        }
+
+        if (!method.Safe)
+            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it is not safe, you should add a 'Safe' attribute to the {methodName} method"));
+
+        if (method.ReturnType != returnType)
+            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's return type is not {FormatContractParameterType(returnType)}"));
+
+        if (method.Parameters.Length != parameterTypes.Length)
+            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's parameters length is not {parameterTypes.Length}"));
+
+        for (int index = 0; index < Math.Min(method.Parameters.Length, parameterTypes.Length); index++)
+        {
+            if (method.Parameters[index].Type == parameterTypes[index])
+                continue;
+
+            string ordinal = parameterTypes.Length == 1
+                ? "parameters"
+                : index switch
+                {
+                    0 => "first parameters",
+                    1 => "second parameters",
+                    2 => "third parameters",
+                    3 => "fourth parameters",
+                    4 => "fifth parameters",
+                    _ => $"{index + 1}th parameters"
+                };
+
+            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
+                $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: {methodName}, it's {ordinal} type is not {FormatContractParameterType(parameterTypes[index])}"));
+        }
+    }
+
+    private static string FormatContractParameterType(ContractParameterType type)
+    {
+        return type switch
+        {
+            ContractParameterType.Hash160 => "a Hash160",
+            ContractParameterType.ByteArray => "a ByteArray",
+            ContractParameterType.InteropInterface => "an InteropInterface",
+            ContractParameterType.Integer => "an Integer",
+            ContractParameterType.Boolean => "a Boolean",
+            ContractParameterType.Any => "a Any",
+            _ => $"a {type}"
+        };
+    }
+
     private static System.Collections.Generic.List<CompilationException>
         CheckNep11Compliant(this ContractManifest manifest)
     {
@@ -125,45 +188,8 @@ internal static partial class ContractManifestExtensions
         // errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
         // $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: balanceOf, it is not found in the ABI"));
 
-        if (tokensOfMethod is null)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it is not found in the ABI"));
-
-        if (tokensOfMethod is { Safe: false })
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it is not safe, you should add a 'Safe' attribute to the tokensOf method"));
-
-        if (tokensOfMethod is not null && tokensOfMethod.ReturnType != ContractParameterType.InteropInterface)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it's return type is not an InteropInterface"));
-
-        if (tokensOfMethod is not null && tokensOfMethod.Parameters.Length != 1)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it's parameters length is not 1"));
-
-        if (tokensOfMethod is not null && tokensOfMethod.Parameters[0].Type != ContractParameterType.Hash160)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: tokensOf, it's parameters type is not a Hash160"));
-
-        if (ownerOfMethod is null)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not found in the ABI"));
-
-        if (ownerOfMethod is { Safe: false })
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it is not safe, you should add a 'Safe' attribute to the ownerOf method"));
-
-        if (ownerOfMethod is not null && ownerOfMethod.ReturnType != ContractParameterType.Hash160)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's return type is not a Hash160"));
-
-        if (ownerOfMethod is not null && ownerOfMethod.Parameters.Length != 1)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters length is not 1"));
-
-        if (ownerOfMethod is not null && ownerOfMethod.Parameters[0].Type != ContractParameterType.ByteArray)
-            errors.Add(new CompilationException(DiagnosticId.IncorrectNEPStandard,
-            $"Incomplete or unsafe NEP standard {NepStandard.Nep11.ToStandard()} implementation: ownerOf, it's parameters type is not a ByteArray"));
+        ValidateNep11SafeMethod(errors, tokensOfMethod, "tokensOf", ContractParameterType.InteropInterface, ContractParameterType.Hash160);
+        ValidateNep11SafeMethod(errors, ownerOfMethod, "ownerOf", ContractParameterType.Hash160, ContractParameterType.ByteArray);
 
 
         if (transferMethod1 is null && transferMethod2 is null)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ManifestStandards.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ManifestStandards.cs
@@ -16,6 +16,8 @@ using Neo.SmartContract.Testing;
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using ContractParameterType = Neo.SmartContract.ContractParameterType;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -63,8 +65,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             JToken tokensOf = methods.First(m => m!["name"]!.GetString() == "tokensOf");
             methods.Remove(tokensOf);
 
-            // Change ownerOf to hit return-type and parameter-type branches while keeping the ABI lookup shape.
+            // Change ownerOf to hit unsafe, return-type, and parameter-type branches while preserving lookup shape.
             JObject ownerOf = (JObject)methods.First(m => m!["name"]!.GetString() == "ownerOf")!;
+            ownerOf["safe"] = false;
             ownerOf["returntype"] = "ByteArray";
             ownerOf["parameters"] = new JArray(
                 new JObject { ["name"] = "tokenId", ["type"] = "Hash160" });
@@ -85,8 +88,66 @@ namespace Neo.Compiler.CSharp.UnitTests
 
             string output = stdout.ToString();
             StringAssert.Contains(output, "tokensOf, it is not found in the ABI");
+            StringAssert.Contains(output, "ownerOf, it is not safe");
             StringAssert.Contains(output, "ownerOf, it's return type is not a Hash160");
             StringAssert.Contains(output, "ownerOf, it's parameters type is not a ByteArray");
+        }
+
+        [TestMethod]
+        public void Nep11_Helper_Reports_LengthMismatch_For_SingleParameterMethods()
+        {
+            Type extensionsType = typeof(CompilationEngine).Assembly.GetType("Neo.Compiler.ContractManifestExtensions")!;
+            MethodInfo helper = extensionsType.GetMethod(
+                "ValidateNep11SingleParameterSafeMethod",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            var errors = new System.Collections.Generic.List<CompilationException>();
+            Type methodParameterType = helper.GetParameters()[1].ParameterType;
+            Type descriptorType = Nullable.GetUnderlyingType(methodParameterType) ?? methodParameterType;
+            object descriptor = Activator.CreateInstance(descriptorType)!;
+            SetMember(descriptorType, descriptor, "Name", "ownerOf");
+            SetMember(descriptorType, descriptor, "ReturnType", ContractParameterType.ByteArray);
+            SetMember(descriptorType, descriptor, "Safe", false);
+            SetMember(descriptorType, descriptor, "Parameters", Array.Empty<ContractParameterDefinition>());
+
+            object? boxedDescriptor = methodParameterType == descriptorType
+                ? descriptor
+                : Activator.CreateInstance(methodParameterType, descriptor);
+
+            helper.Invoke(null,
+            [
+                errors,
+                boxedDescriptor,
+                "ownerOf",
+                ContractParameterType.Hash160,
+                "a Hash160",
+                ContractParameterType.ByteArray,
+                "a ByteArray"
+            ]);
+
+            string[] messages = errors.Select(e => e.Diagnostic.GetMessage()).ToArray();
+            CollectionAssert.Contains(messages, "Incomplete or unsafe NEP standard NEP-11 implementation: ownerOf, it is not safe, you should add a 'Safe' attribute to the ownerOf method");
+            CollectionAssert.Contains(messages, "Incomplete or unsafe NEP standard NEP-11 implementation: ownerOf, it's return type is not a Hash160");
+            CollectionAssert.Contains(messages, "Incomplete or unsafe NEP standard NEP-11 implementation: ownerOf, it's parameters length is not 1");
+        }
+
+        private static void SetMember(Type type, object instance, string name, object value)
+        {
+            FieldInfo? field = type.GetField(name);
+            if (field is not null)
+            {
+                field.SetValue(instance, value);
+                return;
+            }
+
+            PropertyInfo? property = type.GetProperty(name);
+            if (property is not null)
+            {
+                property.SetValue(instance, value);
+                return;
+            }
+
+            Assert.Fail($"Could not find field or property '{name}' on {type.FullName}.");
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ManifestStandards.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ManifestStandards.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_ManifestStandards.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Json;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests
+{
+    [TestClass]
+    public class UnitTest_ManifestStandards
+    {
+        [TestMethod]
+        public void Nep11_InvalidTokensOfAndOwnerOfStillProduceExpectedDiagnostics()
+        {
+            JObject json = (JObject)JToken.Parse(Contract_NEP11.Manifest.ToJson().ToString(false))!;
+            JArray methods = (JArray)json["abi"]!["methods"]!;
+
+            JObject tokensOf = (JObject)methods.First(m => m!["name"]!.GetString() == "tokensOf")!;
+            tokensOf["parameters"]![0]!["type"] = "ByteArray";
+
+            JObject ownerOf = (JObject)methods.First(m => m!["name"]!.GetString() == "ownerOf")!;
+            ownerOf["parameters"]![0]!["type"] = "Hash160";
+
+            ContractManifest manifest = ContractManifest.FromJson(json);
+            var stdout = new StringWriter();
+            TextWriter originalOut = Console.Out;
+
+            try
+            {
+                Console.SetOut(stdout);
+                manifest.CheckStandards();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            string output = stdout.ToString();
+            StringAssert.Contains(output, "tokensOf, it's parameters type is not a Hash160");
+            StringAssert.Contains(output, "ownerOf, it's parameters type is not a ByteArray");
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ManifestStandards.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ManifestStandards.cs
@@ -52,5 +52,41 @@ namespace Neo.Compiler.CSharp.UnitTests
             StringAssert.Contains(output, "tokensOf, it's parameters type is not a Hash160");
             StringAssert.Contains(output, "ownerOf, it's parameters type is not a ByteArray");
         }
+
+        [TestMethod]
+        public void Nep11_InvalidTokensOfAndOwnerOfShapeVariantsStillProduceExpectedDiagnostics()
+        {
+            JObject json = (JObject)JToken.Parse(Contract_NEP11.Manifest.ToJson().ToString(false))!;
+            JArray methods = (JArray)json["abi"]!["methods"]!;
+
+            // Remove tokensOf entirely to hit the helper's null branch.
+            JToken tokensOf = methods.First(m => m!["name"]!.GetString() == "tokensOf");
+            methods.Remove(tokensOf);
+
+            // Change ownerOf to hit return-type and parameter-type branches while keeping the ABI lookup shape.
+            JObject ownerOf = (JObject)methods.First(m => m!["name"]!.GetString() == "ownerOf")!;
+            ownerOf["returntype"] = "ByteArray";
+            ownerOf["parameters"] = new JArray(
+                new JObject { ["name"] = "tokenId", ["type"] = "Hash160" });
+
+            ContractManifest manifest = ContractManifest.FromJson(json);
+            var stdout = new StringWriter();
+            TextWriter originalOut = Console.Out;
+
+            try
+            {
+                Console.SetOut(stdout);
+                manifest.CheckStandards();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            string output = stdout.ToString();
+            StringAssert.Contains(output, "tokensOf, it is not found in the ABI");
+            StringAssert.Contains(output, "ownerOf, it's return type is not a Hash160");
+            StringAssert.Contains(output, "ownerOf, it's parameters type is not a ByteArray");
+        }
     }
 }


### PR DESCRIPTION
Summary:
- extract the repeated NEP-11 safe-method validation logic used by tokensOf and ownerOf into a small helper
- preserve the existing NC3006 diagnostic messages and behavior
- add a regression test that malformed NEP-11 ownerOf/tokensOf signatures still produce the expected diagnostics

Validation:
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --filter FullyQualifiedName~NEP11|FullyQualifiedName~ManifestStandards
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release

Issue:
- follows issue #1514 item P1-6