### PR TITLE
refactor(compiler): linearize RemoveNops handling

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/BasicOptimizer.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/BasicOptimizer.cs
@@ -18,25 +18,32 @@ namespace Neo.Compiler.Optimizer
     {
         public static void RemoveNops(List<Instruction> instructions)
         {
-            for (int i = 0; i < instructions.Count;)
+            Dictionary<Instruction, List<JumpTarget>> incomingTargets = CollectIncomingTargets(instructions);
+            List<Instruction> retained = new(instructions.Count);
+            Instruction? nextRetained = null;
+
+            for (int i = instructions.Count - 1; i >= 0; i--)
             {
                 Instruction instruction = instructions[i];
-                if (instruction.OpCode == OpCode.NOP)
+
+                bool keepInstruction = instruction.OpCode != OpCode.NOP
+                    || nextRetained is null && incomingTargets.ContainsKey(instruction);
+
+                if (keepInstruction)
                 {
-                    instructions.RemoveAt(i);
-                    foreach (Instruction other in instructions)
-                    {
-                        if (other.Target?.Instruction == instruction)
-                            other.Target.Instruction = instructions[i];
-                        if (other.Target2?.Instruction == instruction)
-                            other.Target2.Instruction = instructions[i];
-                    }
+                    retained.Add(instruction);
+                    nextRetained = instruction;
+                    continue;
                 }
-                else
-                {
-                    i++;
-                }
+
+                if (!incomingTargets.TryGetValue(instruction, out List<JumpTarget>? targets)) continue;
+                foreach (JumpTarget target in targets)
+                    target.Instruction = nextRetained;
             }
+
+            retained.Reverse();
+            instructions.Clear();
+            instructions.AddRange(retained);
         }
 
         public static void CompressJumps(IReadOnlyList<Instruction> instructions)
@@ -78,6 +85,30 @@ namespace Neo.Compiler.Optimizer
                 }
                 if (compressed) instructions.RebuildOffsets();
             } while (compressed);
+        }
+
+        private static Dictionary<Instruction, List<JumpTarget>> CollectIncomingTargets(IReadOnlyList<Instruction> instructions)
+        {
+            Dictionary<Instruction, List<JumpTarget>> incomingTargets = new();
+            foreach (Instruction instruction in instructions)
+            {
+                AddIncomingTarget(instruction.Target);
+                AddIncomingTarget(instruction.Target2);
+            }
+
+            return incomingTargets;
+
+            void AddIncomingTarget(JumpTarget? target)
+            {
+                if (target?.Instruction is null) return;
+                if (!incomingTargets.TryGetValue(target.Instruction, out List<JumpTarget>? targets))
+                {
+                    targets = new List<JumpTarget>();
+                    incomingTargets[target.Instruction] = targets;
+                }
+
+                targets.Add(target);
+            }
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BasicOptimizer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BasicOptimizer.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_BasicOptimizer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.Optimizer;
+using Neo.VM;
+using System.Collections.Generic;
+
+namespace Neo.Compiler.CSharp.UnitTests
+{
+    [TestClass]
+    public class UnitTest_BasicOptimizer
+    {
+        [TestMethod]
+        public void RemoveNops_RedirectsJumpsToNextInstruction()
+        {
+            JumpTarget target = new();
+            Instruction jump = new() { OpCode = OpCode.JMP_L, Target = target };
+            Instruction nop = new() { OpCode = OpCode.NOP };
+            Instruction destination = new() { OpCode = OpCode.RET };
+            target.Instruction = nop;
+
+            List<Instruction> instructions = new() { jump, nop, destination };
+
+            BasicOptimizer.RemoveNops(instructions);
+
+            Assert.AreEqual(2, instructions.Count);
+            Assert.AreSame(destination, target.Instruction);
+            CollectionAssert.AreEqual(new[] { jump, destination }, instructions);
+        }
+
+        [TestMethod]
+        public void RemoveNops_PreservesTerminalTargetedNop()
+        {
+            JumpTarget target = new();
+            Instruction jump = new() { OpCode = OpCode.JMP_L, Target = target };
+            Instruction terminalNop = new() { OpCode = OpCode.NOP };
+            target.Instruction = terminalNop;
+
+            List<Instruction> instructions = new() { jump, terminalNop };
+
+            BasicOptimizer.RemoveNops(instructions);
+
+            Assert.AreEqual(2, instructions.Count);
+            Assert.AreSame(terminalNop, target.Instruction);
+            CollectionAssert.AreEqual(new[] { jump, terminalNop }, instructions);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the quadratic RemoveNops loop with a single backward pass over instructions
- redirect incoming jump targets when removing middle NOPs and preserve terminal targeted NOPs
- add unit tests covering jump retargeting and the trailing-target regression

## Testing
- dotnet format ./neo-devpack-dotnet.sln
- dotnet build ./neo-devpack-dotnet.sln
- dotnet test ./tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_BasicOptimizer
- dotnet build ./neo-devpack-dotnet.sln
- dotnet test ./tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_BasicOptimizer