### PR TITLE
feat(framework): add nep17 and nep11 interfaces

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
@@ -482,6 +482,22 @@ namespace Neo.Compiler
                             break;
                     }
                 }
+
+                foreach (var attribute in symbol.AllInterfaces
+                    .SelectMany(i => i.GetAttributes())
+                    .Where(a => a.AttributeClass?.Name == nameof(SupportedStandardsAttribute)))
+                {
+                    _supportedStandards.UnionWith(
+                        attribute.ConstructorArguments[0].Values
+                            .Select(p => p.Value)
+                            .Select(p =>
+                                p is int ip && Enum.IsDefined(typeof(NepStandard), ip)
+                                    ? ((NepStandard)ip).ToStandard()
+                                    : p as string
+                            )
+                            .Where(v => v != null)!);
+                }
+
                 _className = symbol.Name;
             }
             Dictionary<(string, int), IMethodSymbol> export = new();

--- a/src/Neo.SmartContract.Framework/Attributes/SupportedStandardsAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/SupportedStandardsAttribute.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace Neo.SmartContract.Framework.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
     public class SupportedStandardsAttribute : Attribute
     {
         public SupportedStandardsAttribute(params string[] supportedStandards)

--- a/src/Neo.SmartContract.Framework/Interfaces/INEP11.cs
+++ b/src/Neo.SmartContract.Framework/Interfaces/INEP11.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// INEP11.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework.Services;
+using System.Numerics;
+
+namespace Neo.SmartContract.Framework.Interfaces;
+
+/// <summary>
+/// Interface of the NEP-11 non-fungible token standard.
+/// </summary>
+public interface INEP11
+{
+    /// <summary>
+    /// Contract symbol.
+    /// </summary>
+    public string Symbol { get; }
+
+    /// <summary>
+    /// Contract decimals.
+    /// </summary>
+    public byte Decimals { get; }
+
+    /// <summary>
+    /// Returns the total token supply.
+    /// </summary>
+    public static abstract BigInteger TotalSupply { get; }
+
+    /// <summary>
+    /// Returns the token balance for an account.
+    /// </summary>
+    public static abstract BigInteger BalanceOf(UInt160 owner);
+
+    /// <summary>
+    /// Returns the token owner.
+    /// </summary>
+    public static abstract UInt160 OwnerOf(ByteString tokenId);
+
+    /// <summary>
+    /// Returns the token properties.
+    /// </summary>
+    public Map<string, object> Properties(ByteString tokenId);
+
+    /// <summary>
+    /// Enumerates all token IDs.
+    /// </summary>
+    public static abstract Iterator Tokens();
+
+    /// <summary>
+    /// Enumerates the token IDs owned by an account.
+    /// </summary>
+    public static abstract Iterator TokensOf(UInt160 owner);
+
+    /// <summary>
+    /// Transfers a token.
+    /// </summary>
+    public static abstract bool Transfer(UInt160 to, ByteString tokenId, object? data = null);
+}

--- a/src/Neo.SmartContract.Framework/Interfaces/INEP11.cs
+++ b/src/Neo.SmartContract.Framework/Interfaces/INEP11.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.SmartContract.Framework.Attributes;
 using Neo.SmartContract.Framework.Services;
 using System.Numerics;
 
@@ -17,6 +18,7 @@ namespace Neo.SmartContract.Framework.Interfaces;
 /// <summary>
 /// Interface of the NEP-11 non-fungible token standard.
 /// </summary>
+[SupportedStandards(NepStandard.Nep11)]
 public interface INEP11
 {
     /// <summary>

--- a/src/Neo.SmartContract.Framework/Interfaces/INEP17.cs
+++ b/src/Neo.SmartContract.Framework/Interfaces/INEP17.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// INEP17.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Numerics;
+
+namespace Neo.SmartContract.Framework.Interfaces;
+
+/// <summary>
+/// Interface of the NEP-17 fungible token standard.
+/// </summary>
+public interface INEP17
+{
+    /// <summary>
+    /// Contract symbol.
+    /// </summary>
+    public string Symbol { get; }
+
+    /// <summary>
+    /// Contract decimals.
+    /// </summary>
+    public byte Decimals { get; }
+
+    /// <summary>
+    /// Returns the total token supply.
+    /// </summary>
+    public static abstract BigInteger TotalSupply { get; }
+
+    /// <summary>
+    /// Returns the token balance for an account.
+    /// </summary>
+    public static abstract BigInteger BalanceOf(UInt160 owner);
+
+    /// <summary>
+    /// Transfers tokens between accounts.
+    /// </summary>
+    public static abstract bool Transfer(UInt160 from, UInt160 to, BigInteger amount, object? data = null);
+}

--- a/src/Neo.SmartContract.Framework/Interfaces/INEP17.cs
+++ b/src/Neo.SmartContract.Framework/Interfaces/INEP17.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.SmartContract.Framework.Attributes;
 using System.Numerics;
 
 namespace Neo.SmartContract.Framework.Interfaces;
@@ -16,6 +17,7 @@ namespace Neo.SmartContract.Framework.Interfaces;
 /// <summary>
 /// Interface of the NEP-17 fungible token standard.
 /// </summary>
+[SupportedStandards(NepStandard.Nep17)]
 public interface INEP17
 {
     /// <summary>

--- a/src/Neo.SmartContract.Framework/Nep11Token.cs
+++ b/src/Neo.SmartContract.Framework/Nep11Token.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Interfaces;
 using Neo.SmartContract.Framework.Native;
 using Neo.SmartContract.Framework.Services;
 using System;
@@ -22,7 +23,7 @@ namespace Neo.SmartContract.Framework
     [SupportedStandards(NepStandard.Nep11)]
     [ContractPermission(Permission.Any, Method.OnNEP11Payment)]
     [ExcludeFromCodeCoverage]
-    public abstract class Nep11Token<TokenState> : TokenContract
+    public abstract class Nep11Token<TokenState> : TokenContract, INEP11
         where TokenState : Nep11TokenState
     {
         public delegate void OnTransferDelegate(UInt160? from, UInt160? to, BigInteger amount, ByteString tokenId);
@@ -76,7 +77,7 @@ namespace Neo.SmartContract.Framework
             return accountMap.Find(owner, FindOptions.KeysOnly | FindOptions.RemovePrefix);
         }
 
-        public static bool Transfer(UInt160 to, ByteString tokenId, object data)
+        public static bool Transfer(UInt160 to, ByteString tokenId, object? data = null)
         {
             if (!to.IsValid) throw new Exception("The argument \"to\" is invalid.");
             if (tokenId.Length > 64) throw new Exception("The argument \"tokenId\" should be 64 or less bytes long.");

--- a/src/Neo.SmartContract.Framework/Nep17Token.cs
+++ b/src/Neo.SmartContract.Framework/Nep17Token.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Interfaces;
 using Neo.SmartContract.Framework.Native;
 using Neo.SmartContract.Framework.Services;
 using System;
@@ -20,14 +21,14 @@ namespace Neo.SmartContract.Framework
 {
     [SupportedStandards(NepStandard.Nep17)]
     [ContractPermission(Permission.Any, Method.OnNEP17Payment)]
-    public abstract class Nep17Token : TokenContract
+    public abstract class Nep17Token : TokenContract, INEP17
     {
         public delegate void OnTransferDelegate(UInt160? from, UInt160? to, BigInteger amount);
 
         [DisplayName("Transfer")]
         public static event OnTransferDelegate OnTransfer = null!;
 
-        public static bool Transfer(UInt160 from, UInt160 to, BigInteger amount, object data)
+        public static bool Transfer(UInt160 from, UInt160 to, BigInteger amount, object? data = null)
         {
             if (!from.IsValid) throw new Exception("The argument \"from\" is invalid.");
             if (!to.IsValid) throw new Exception("The argument \"to\" is invalid.");

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InterfaceSupportedStandards.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InterfaceSupportedStandards.cs
@@ -1,0 +1,113 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Manifest;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_InterfaceSupportedStandards
+{
+    [TestMethod]
+    public void Nep17Interface_ContributesSupportedStandardToManifest()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Interfaces;
+using System.Numerics;
+
+public class Contract : SmartContract, INEP17
+{
+    public string Symbol => ""TKN"";
+    public byte Decimals => 8;
+
+    [Safe]
+    public static BigInteger TotalSupply => 0;
+
+    [Safe]
+    public static BigInteger BalanceOf(UInt160 owner) => 0;
+
+    public static bool Transfer(UInt160 from, UInt160 to, BigInteger amount, object? data = null) => true;
+}";
+
+        var manifest = CompileSingleContract(source).CreateManifest();
+
+        CollectionAssert.Contains(manifest.SupportedStandards, "NEP-17");
+    }
+
+    [TestMethod]
+    public void Nep11Interface_ContributesSupportedStandardToManifest()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Interfaces;
+using Neo.SmartContract.Framework.Services;
+using System.Numerics;
+
+public class Contract : SmartContract, INEP11
+{
+    public string Symbol => ""NFT"";
+    public byte Decimals => 0;
+
+    [Safe]
+    public static BigInteger TotalSupply => 0;
+
+    [Safe]
+    public static BigInteger BalanceOf(UInt160 owner) => 0;
+
+    [Safe]
+    public static UInt160 OwnerOf(ByteString tokenId) => UInt160.Zero;
+
+    public Map<string, object> Properties(ByteString tokenId) => new();
+
+    [Safe]
+    public static Iterator Tokens() => Storage.Find(Storage.CurrentContext, new byte[] { });
+
+    [Safe]
+    public static Iterator TokensOf(UInt160 owner) => Storage.Find(Storage.CurrentContext, owner);
+
+    public static bool Transfer(UInt160 to, ByteString tokenId, object? data = null) => true;
+}";
+
+        var manifest = CompileSingleContract(source).CreateManifest();
+
+        CollectionAssert.Contains(manifest.SupportedStandards, "NEP-11");
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            var context = contexts[0];
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+            return context;
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard11Enum.cs
@@ -17,7 +17,7 @@ using Neo.SmartContract.Framework.Services;
 namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 {
     [SupportedStandards(NepStandard.Nep11)]
-    public class Contract_SupportedStandard11Enum : Nep11Token<Nep11TokenState>, INEP26
+    public class Contract_SupportedStandard11Enum : Nep11Token<Nep11TokenState>, INEP11, INEP26
     {
         public static bool TestStandard()
         {

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard17Enum.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_SupportedStandard17Enum.cs
@@ -24,7 +24,7 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
     [ContractSourceCode("https://github.com/neo-project/neo-devpack-dotnet/tree/master/src/Neo.SmartContract.Template")]
     [ContractPermission(Permission.Any, Method.Any)]
     [SupportedStandards(NepStandard.Nep17)]
-    public class Contract_SupportedStandard17Enum : Nep17Token, INEP27
+    public class Contract_SupportedStandard17Enum : Nep17Token, INEP17, INEP27
     {
         public override string Symbol { [Safe] get; } = "EXAMPLE";
         public override byte Decimals { [Safe] get; } = 0;

--- a/tests/Neo.SmartContract.Framework.UnitTests/NepStandardInterfaceTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/NepStandardInterfaceTest.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NepStandardInterfaceTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+extern alias scfx;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Neo.SmartContract.Framework.UnitTests
+{
+    [TestClass]
+    public class NepStandardInterfaceTest
+    {
+        [TestMethod]
+        public void Nep17Token_Implements_NEP17_Interface()
+        {
+            Assert.IsTrue(typeof(scfx::Neo.SmartContract.Framework.Interfaces.INEP17)
+                .IsAssignableFrom(typeof(scfx::Neo.SmartContract.Framework.Nep17Token)));
+
+            var transfer = typeof(scfx::Neo.SmartContract.Framework.Interfaces.INEP17)
+                .GetMethod(nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP17.Transfer));
+            Assert.IsNotNull(transfer);
+            Assert.AreEqual(4, transfer!.GetParameters().Length);
+        }
+
+        [TestMethod]
+        public void Nep11Token_Implements_NEP11_Interface()
+        {
+            Assert.IsTrue(typeof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11)
+                .IsAssignableFrom(typeof(scfx::Neo.SmartContract.Framework.Nep11Token<scfx::Neo.SmartContract.Framework.Nep11TokenState>)));
+
+            var methods = typeof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11).GetMethods().Select(m => m.Name).ToArray();
+            CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.OwnerOf));
+            CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.Properties));
+            CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.Transfer));
+            CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.Tokens));
+            CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.TokensOf));
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/NepStandardInterfaceTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/NepStandardInterfaceTest.cs
@@ -13,6 +13,8 @@ extern alias scfx;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using NepStandard = scfx::Neo.SmartContract.Framework.NepStandard;
+using SupportedStandardsAttribute = scfx::Neo.SmartContract.Framework.Attributes.SupportedStandardsAttribute;
 
 namespace Neo.SmartContract.Framework.UnitTests
 {
@@ -43,6 +45,26 @@ namespace Neo.SmartContract.Framework.UnitTests
             CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.Transfer));
             CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.Tokens));
             CollectionAssert.Contains(methods, nameof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11.TokensOf));
+        }
+
+        [TestMethod]
+        public void Nep17Interface_Defines_SupportedStandardAttribute()
+        {
+            var attribute = typeof(scfx::Neo.SmartContract.Framework.Interfaces.INEP17)
+                .GetCustomAttributes(typeof(SupportedStandardsAttribute), false)
+                .SingleOrDefault() as SupportedStandardsAttribute;
+
+            Assert.IsNotNull(attribute);
+        }
+
+        [TestMethod]
+        public void Nep11Interface_Defines_SupportedStandardAttribute()
+        {
+            var attribute = typeof(scfx::Neo.SmartContract.Framework.Interfaces.INEP11)
+                .GetCustomAttributes(typeof(SupportedStandardsAttribute), false)
+                .SingleOrDefault() as SupportedStandardsAttribute;
+
+            Assert.IsNotNull(attribute);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add framework-level `INEP17` and `INEP11` interfaces for token contracts
- wire `Nep17Token` and `Nep11Token` to the new interfaces and align nullable transfer payload signatures
- update standard framework test contracts and add framework unit tests covering the new interface surface

## Testing
- dotnet format ./neo-devpack-dotnet.sln
- dotnet build ./neo-devpack-dotnet.sln
- dotnet test ./tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj
- dotnet build ./neo-devpack-dotnet.sln
- dotnet test ./tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj