### PR TITLE
feat(framework): add Ownable base class

### DIFF
--- a/src/Neo.SmartContract.Framework/Attributes/OnlyOwnerAttribute.cs
+++ b/src/Neo.SmartContract.Framework/Attributes/OnlyOwnerAttribute.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// OnlyOwnerAttribute.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using Neo.SmartContract.Framework.Services;
+
+namespace Neo.SmartContract.Framework.Attributes
+{
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = false)]
+    public class OnlyOwnerAttribute : ModifierAttribute
+    {
+        private readonly byte[] _key;
+
+        public OnlyOwnerAttribute(byte prefix = 0xFF)
+        {
+            _key = [prefix];
+        }
+
+        public override void Enter()
+        {
+            UInt160? owner = (UInt160)Storage.Get(_key)!;
+            if (owner is null || !Runtime.CheckWitness(owner))
+                throw new InvalidOperationException("No Authorization!");
+        }
+
+        public override void Exit()
+        {
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/Ownable.cs
+++ b/src/Neo.SmartContract.Framework/Ownable.cs
@@ -1,0 +1,67 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Ownable.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+
+namespace Neo.SmartContract.Framework
+{
+    public abstract class Ownable : SmartContract
+    {
+        private const byte Prefix_Owner = 0xFF;
+
+        [Safe]
+        public static UInt160? GetOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_Owner })!;
+        }
+
+        protected static bool IsOwner()
+        {
+            UInt160? owner = GetOwner();
+            return owner is not null && Runtime.CheckWitness(owner);
+        }
+
+        public delegate void OnSetOwnerDelegate(UInt160? previousOwner, UInt160? newOwner);
+
+        [DisplayName("SetOwner")]
+        public static event OnSetOwnerDelegate OnSetOwner = null!;
+
+        public static void SetOwner(UInt160 newOwner)
+        {
+            if (!IsOwner())
+                throw new System.InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(newOwner.IsValid && !newOwner.IsZero, "owner must be valid");
+
+            UInt160? previousOwner = GetOwner();
+            ExecutionEngine.Assert(previousOwner != newOwner, "owner must change");
+
+            Storage.Put(new[] { Prefix_Owner }, newOwner);
+            OnSetOwner(previousOwner, newOwner);
+        }
+
+        protected static void InitializeOwner(object? data, bool update)
+        {
+            if (update)
+                return;
+
+            data ??= Runtime.Transaction.Sender;
+
+            UInt160 initialOwner = (UInt160)data;
+            ExecutionEngine.Assert(initialOwner.IsValid && !initialOwner.IsZero, "owner must be valid");
+
+            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OnSetOwner(null, initialOwner);
+        }
+    }
+}

--- a/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
@@ -76,10 +76,9 @@ namespace Neo.SmartContract.Testing.TestingStandards
 
             // Merge coverlet json
 
-            if (Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN") is string mergeWith &&
-                !string.IsNullOrEmpty(mergeWith))
+            if (ResolveCoverageMergePath() is string mergeWith)
             {
-                new CoverletJsonFormat([.. list]).Write(Environment.ExpandEnvironmentVariables(mergeWith), true);
+                new CoverletJsonFormat([.. list]).Write(mergeWith, true);
 
                 Console.WriteLine($"Coverage merged with: {mergeWith}");
             }
@@ -87,6 +86,39 @@ namespace Neo.SmartContract.Testing.TestingStandards
             // Ensure that the coverage is more than X% at the end of the tests
 
             Assert.IsTrue(coverage.CoveredLinesPercentage >= requiredCoverage, $"Coverage is {coverage.CoveredLinesPercentage:P2}, less than {requiredCoverage:P2}");
+        }
+
+        private static string? ResolveCoverageMergePath()
+        {
+            var direct = Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN");
+            if (!string.IsNullOrWhiteSpace(direct))
+                return Environment.ExpandEnvironmentVariables(direct);
+
+            // CI uses an env var with the MSBuild argument used for coverlet merge:
+            // COVERLET_MERGE_WITH=/p:MergeWith=/path/to/coverage.json
+            var mergeWithArg = Environment.GetEnvironmentVariable("COVERLET_MERGE_WITH");
+            if (string.IsNullOrWhiteSpace(mergeWithArg))
+                return null;
+
+            const string Prefix = "/p:MergeWith=";
+            var index = mergeWithArg.IndexOf(Prefix, StringComparison.OrdinalIgnoreCase);
+            if (index < 0)
+                return null;
+
+            var value = mergeWithArg[(index + Prefix.Length)..].Trim();
+            if (value.Length == 0)
+                return null;
+
+            // If multiple MSBuild args were concatenated, only keep the MergeWith value.
+            var spaceIndex = value.IndexOf(' ');
+            if (spaceIndex >= 0)
+                value = value[..spaceIndex];
+
+            value = value.Trim().Trim('"');
+            if (value.Length == 0)
+                return null;
+
+            return Environment.ExpandEnvironmentVariables(value);
         }
     }
 }

--- a/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestCleanupBase.cs
@@ -90,9 +90,9 @@ namespace Neo.SmartContract.Testing.TestingStandards
 
         private static string? ResolveCoverageMergePath()
         {
-            var direct = Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN");
-            if (!string.IsNullOrWhiteSpace(direct))
-                return Environment.ExpandEnvironmentVariables(direct);
+            var direct = NormalizeCoveragePath(Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN"));
+            if (direct is not null)
+                return direct;
 
             // CI uses an env var with the MSBuild argument used for coverlet merge:
             // COVERLET_MERGE_WITH=/p:MergeWith=/path/to/coverage.json
@@ -105,16 +105,40 @@ namespace Neo.SmartContract.Testing.TestingStandards
             if (index < 0)
                 return null;
 
-            var value = mergeWithArg[(index + Prefix.Length)..].Trim();
+            return NormalizeMsBuildArgumentValue(mergeWithArg[(index + Prefix.Length)..]);
+        }
+
+        private static string? NormalizeMsBuildArgumentValue(string value)
+        {
+            value = value.Trim();
             if (value.Length == 0)
                 return null;
 
-            // If multiple MSBuild args were concatenated, only keep the MergeWith value.
-            var spaceIndex = value.IndexOf(' ');
-            if (spaceIndex >= 0)
-                value = value[..spaceIndex];
+            if (value[0] is '"' or '\'')
+            {
+                var quote = value[0];
+                var endQuote = value.IndexOf(quote, 1);
+                if (endQuote <= 1)
+                    return null;
 
-            value = value.Trim().Trim('"');
+                value = value[1..endQuote];
+            }
+            else
+            {
+                var spaceIndex = value.IndexOf(' ');
+                if (spaceIndex >= 0)
+                    value = value[..spaceIndex];
+            }
+
+            return NormalizeCoveragePath(value);
+        }
+
+        private static string? NormalizeCoveragePath(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return null;
+
+            value = value.Trim().Trim('"', '\'');
             if (value.Length == 0)
                 return null;
 

--- a/tests/Neo.SmartContract.Framework.UnitTests/DynamicCoverageMergeHelper.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/DynamicCoverageMergeHelper.cs
@@ -1,0 +1,51 @@
+using System;
+using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Coverage;
+using Neo.SmartContract.Testing.Coverage.Formats;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+internal static class DynamicCoverageMergeHelper
+{
+    public static void Merge(Neo.SmartContract.Testing.SmartContract contract, NeoDebugInfo debugInfo)
+    {
+        if (ResolveCoverageMergePath() is not string path)
+            return;
+
+        var coverage = contract.GetCoverage();
+        if (coverage is null)
+            return;
+
+        new CoverletJsonFormat((coverage, debugInfo)).Write(path, true);
+    }
+
+    private static string? ResolveCoverageMergePath()
+    {
+        var direct = Environment.GetEnvironmentVariable("COVERAGE_MERGE_JOIN");
+        if (!string.IsNullOrWhiteSpace(direct))
+            return Environment.ExpandEnvironmentVariables(direct);
+
+        var mergeWithArg = Environment.GetEnvironmentVariable("COVERLET_MERGE_WITH");
+        if (string.IsNullOrWhiteSpace(mergeWithArg))
+            return null;
+
+        const string prefix = "/p:MergeWith=";
+        var index = mergeWithArg.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+            return null;
+
+        var value = mergeWithArg[(index + prefix.Length)..].Trim();
+        if (value.Length == 0)
+            return null;
+
+        var spaceIndex = value.IndexOf(' ');
+        if (spaceIndex >= 0)
+            value = value[..spaceIndex];
+
+        value = value.Trim().Trim('"', '\'');
+        if (value.Length == 0)
+            return null;
+
+        return Environment.ExpandEnvironmentVariables(value);
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/OwnableTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/OwnableTest.cs
@@ -6,6 +6,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Coverage;
 using Neo.SmartContract.Testing.Exceptions;
 using Neo.SmartContract.Testing.TestingStandards;
 using System;
@@ -25,7 +26,7 @@ public class OwnableTest
     [TestMethod]
     public void Ownable_UsesSenderAsDefaultOwner_And_OnlyOwnerGuardsProtectedMethods()
     {
-        var (nef, manifest) = CompileOwnableContract();
+        var (nef, manifest, debugInfo) = CompileOwnableContract();
         var engine = CreateEngine();
 
         UInt160? previousOwnerRaised = null;
@@ -50,12 +51,14 @@ public class OwnableTest
 
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => contract.ProtectedAction());
+
+        DynamicCoverageMergeHelper.Merge(contract, debugInfo);
     }
 
     [TestMethod]
     public void Ownable_SetOwner_TransfersOwnership_And_RaisesEvent()
     {
-        var (nef, manifest) = CompileOwnableContract();
+        var (nef, manifest, debugInfo) = CompileOwnableContract();
         var engine = CreateEngine();
         var contract = engine.Deploy<OwnableContractProxy>(nef, manifest);
 
@@ -84,9 +87,11 @@ public class OwnableTest
 
         engine.SetTransactionSigners(Alice);
         Assert.ThrowsException<TestException>(() => contract.ProtectedAction());
+
+        DynamicCoverageMergeHelper.Merge(contract, debugInfo);
     }
 
-    private static (NefFile nef, ContractManifest manifest) CompileOwnableContract()
+    private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) CompileOwnableContract()
     {
         const string source = @"using Neo.SmartContract.Framework;
 using Neo.SmartContract.Framework.Attributes;
@@ -130,7 +135,8 @@ public class Contract : Ownable
             var context = contexts[0];
             Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
 
-            return (context.CreateExecutable(), context.CreateManifest());
+            var (nef, manifest, debugInfoJson) = context.CreateResults(repoRoot);
+            return (nef, manifest, NeoDebugInfo.FromDebugInfoJson(debugInfoJson));
         }
         finally
         {

--- a/tests/Neo.SmartContract.Framework.UnitTests/OwnableTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/OwnableTest.cs
@@ -1,0 +1,160 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Exceptions;
+using Neo.SmartContract.Testing.TestingStandards;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using CompilationOptions = Neo.Compiler.CompilationOptions;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+[TestClass]
+public class OwnableTest
+{
+    private static readonly Signer Alice = TestEngine.GetNewSigner();
+    private static readonly Signer Bob = TestEngine.GetNewSigner();
+
+    [TestMethod]
+    public void Ownable_UsesSenderAsDefaultOwner_And_OnlyOwnerGuardsProtectedMethods()
+    {
+        var (nef, manifest) = CompileOwnableContract();
+        var engine = CreateEngine();
+
+        UInt160? previousOwnerRaised = null;
+        UInt160? newOwnerRaised = null;
+
+        var expectedHash = engine.GetDeployHash(nef, manifest);
+        var preview = engine.FromHash<OwnableContractProxy>(expectedHash, false);
+        preview.OnSetOwner += (previous, current) =>
+        {
+            previousOwnerRaised = previous;
+            newOwnerRaised = current;
+        };
+
+        var contract = engine.Deploy<OwnableContractProxy>(nef, manifest);
+
+        Assert.AreEqual(preview.Hash, contract.Hash);
+        Assert.IsNull(previousOwnerRaised);
+        Assert.AreEqual(Alice.Account, newOwnerRaised);
+        Assert.AreEqual(Alice.Account, contract.Owner);
+
+        Assert.IsTrue(contract.ProtectedAction()!.Value);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.ProtectedAction());
+    }
+
+    [TestMethod]
+    public void Ownable_SetOwner_TransfersOwnership_And_RaisesEvent()
+    {
+        var (nef, manifest) = CompileOwnableContract();
+        var engine = CreateEngine();
+        var contract = engine.Deploy<OwnableContractProxy>(nef, manifest);
+
+        UInt160? previousOwnerRaised = null;
+        UInt160? newOwnerRaised = null;
+        contract.OnSetOwner += (previous, current) =>
+        {
+            previousOwnerRaised = previous;
+            newOwnerRaised = current;
+        };
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.Owner = Bob.Account);
+
+        engine.SetTransactionSigners(Alice);
+        contract.Owner = Bob.Account;
+
+        Assert.AreEqual(Alice.Account, previousOwnerRaised);
+        Assert.AreEqual(Bob.Account, newOwnerRaised);
+        Assert.AreEqual(Bob.Account, contract.Owner);
+
+        Assert.ThrowsException<TestException>(() => contract.Owner = UInt160.Zero);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.IsTrue(contract.ProtectedAction()!.Value);
+
+        engine.SetTransactionSigners(Alice);
+        Assert.ThrowsException<TestException>(() => contract.ProtectedAction());
+    }
+
+    private static (NefFile nef, ContractManifest manifest) CompileOwnableContract()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+
+public class Contract : Ownable
+{
+    public static void _deploy(object data, bool update)
+    {
+        InitializeOwner(data, update);
+    }
+
+    [OnlyOwner]
+    public static bool ProtectedAction()
+    {
+        return true;
+    }
+}";
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, source);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            var context = contexts[0];
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+            return (context.CreateExecutable(), context.CreateManifest());
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    private static TestEngine CreateEngine()
+    {
+        var engine = new TestEngine(true);
+        engine.SetTransactionSigners(Alice);
+        return engine;
+    }
+
+    public abstract class OwnableContractProxy(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize), IOwnable
+    {
+        [DisplayName("SetOwner")]
+        public event IOwnable.delSetOwner? OnSetOwner;
+
+        public abstract UInt160? Owner { [DisplayName("getOwner")] get; [DisplayName("setOwner")] set; }
+
+        [DisplayName("protectedAction")]
+        public abstract bool? ProtectedAction();
+    }
+}

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestingStandards/TestCleanupBaseTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestingStandards/TestCleanupBaseTests.cs
@@ -48,6 +48,54 @@ public class TestCleanupBaseTests
     }
 
     [TestMethod]
+    public void ResolveCoverageMergePath_TreatsWhitespaceCoverageMergeJoinAsUnset()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", "   "),
+            ("COVERLET_MERGE_WITH", "/p:MergeWith=/tmp/fallback-coverage.json"));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.AreEqual("/tmp/fallback-coverage.json", path);
+    }
+
+    [TestMethod]
+    public void ResolveCoverageMergePath_StripsQuotedMergePathAndTrailingArguments()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", null),
+            ("COVERLET_MERGE_WITH", "/p:MergeWith=\"/tmp/coverage report.json\" /p:CollectCoverage=true"));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.AreEqual("/tmp/coverage report.json", path);
+    }
+
+    [TestMethod]
+    public void ResolveCoverageMergePath_ReturnsNullWhenMergeWithPrefixIsMissing()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", null),
+            ("COVERLET_MERGE_WITH", "/p:CollectCoverage=true"));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.IsNull(path);
+    }
+
+    [TestMethod]
+    public void ResolveCoverageMergePath_ReturnsNullWhenMergeWithValueIsEmpty()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", null),
+            ("COVERLET_MERGE_WITH", "/p:MergeWith=\"\""));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.IsNull(path);
+    }
+
+    [TestMethod]
     public void ResolveCoverageMergePath_ReturnsNullWhenUnset()
     {
         using var _ = new EnvironmentVariablesScope(

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestingStandards/TestCleanupBaseTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestingStandards/TestCleanupBaseTests.cs
@@ -1,0 +1,84 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestCleanupBaseTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing.TestingStandards;
+using System;
+using System.Reflection;
+
+namespace Neo.SmartContract.Testing.UnitTests.TestingStandards;
+
+[TestClass]
+public class TestCleanupBaseTests
+{
+    private static readonly MethodInfo ResolveCoverageMergePathMethod =
+        typeof(TestCleanupBase).GetMethod("ResolveCoverageMergePath", BindingFlags.Static | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("ResolveCoverageMergePath method not found.");
+
+    [TestMethod]
+    public void ResolveCoverageMergePath_PrefersCoverageMergeJoin()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", "/tmp/direct-coverage.json"),
+            ("COVERLET_MERGE_WITH", "/p:MergeWith=/tmp/fallback-coverage.json"));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.AreEqual("/tmp/direct-coverage.json", path);
+    }
+
+    [TestMethod]
+    public void ResolveCoverageMergePath_FallsBackToCoverletMergeWithArgument()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", null),
+            ("COVERLET_MERGE_WITH", "/p:MergeWith=/tmp/merged-coverage.json"));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.AreEqual("/tmp/merged-coverage.json", path);
+    }
+
+    [TestMethod]
+    public void ResolveCoverageMergePath_ReturnsNullWhenUnset()
+    {
+        using var _ = new EnvironmentVariablesScope(
+            ("COVERAGE_MERGE_JOIN", null),
+            ("COVERLET_MERGE_WITH", null));
+
+        var path = (string?)ResolveCoverageMergePathMethod.Invoke(null, null);
+
+        Assert.IsNull(path);
+    }
+
+    private sealed class EnvironmentVariablesScope : IDisposable
+    {
+        private readonly (string Name, string? Value)[] _original;
+
+        public EnvironmentVariablesScope(params (string Name, string? Value)[] variables)
+        {
+            _original = [.. Array.ConvertAll(variables, variable => (variable.Name, Environment.GetEnvironmentVariable(variable.Name)))];
+
+            foreach (var (name, value) in variables)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var (name, value) in _original)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a minimal framework Ownable base class and a built-in [OnlyOwner] modifier attribute.

- Ownable provides: getOwner/setOwner ABI surface + SetOwner event + InitializeOwner helper for _deploy.
- OnlyOwner attribute gates methods by Runtime.CheckWitness(owner).
- Includes new framework unit tests exercising default-owner initialization and ownership transfer.

Verification:
- dotnet format
- dotnet build neo-devpack-dotnet.sln (x2)
- dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj (x2)