### PR TITLE
docs(compiler): fix pattern comment typos

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/BinaryPattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/BinaryPattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet a binary pattern to OpCodes.
+    /// Convert a binary pattern to OpCodes.
     /// </summary>
     /// <param name="model">The semantic model providing context and information about binary pattern.</param>
     /// <param name="pattern">The binary pattern to be converted.</param>
@@ -43,7 +43,7 @@ internal partial class MethodConvert
     }
 
     /// <summary>
-    /// Convet a "and" pattern to OpCodes.
+    /// Convert an "and" pattern to OpCodes.
     /// </summary>
     /// <remarks>
     /// Conjunctive "and" pattern that matches an expression when both patterns match the expression.
@@ -90,7 +90,7 @@ internal partial class MethodConvert
     }
 
     /// <summary>
-    /// Convet a "or" pattern to OpCodes.
+    /// Convert an "or" pattern to OpCodes.
     /// </summary>
     /// <remarks>
     /// Disjunctive "or" pattern that matches an expression when either pattern matches the expression.

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/ConstantPattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/ConstantPattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet a constant pattern to OpCodes.
+    /// Convert a constant pattern to OpCodes.
     /// </summary>
     /// <param name="model">The semantic model providing context and information about constant pattern.</param>
     /// <param name="pattern">The constant pattern to be converted.</param>

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/DeclarationPattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/DeclarationPattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet declaration pattern to OpCodes.
+    /// Convert a declaration pattern to OpCodes.
     /// </summary>
     /// <param name="model">The semantic model providing context and information about declaration pattern.</param>
     /// <param name="pattern">The declaration pattern to be converted.</param>

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/NotPattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/NotPattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet a "not" pattern to OpCodes.
+    /// Convert a "not" pattern to OpCodes.
     /// </summary>
     /// <remarks>
     /// Negation "not" pattern that matches an expression when the negated pattern doesn't match the expression.

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/ParenthesizedPattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/ParenthesizedPattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet a parenthesized pattern to OpCodes.
+    /// Convert a parenthesized pattern to OpCodes.
     /// </summary>
     /// <param name="model">The semantic model providing context and information about parenthesized pattern.</param>
     /// <param name="pattern">The parenthesized pattern to be converted.</param>

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/Pattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/Pattern.cs
@@ -32,29 +32,29 @@ internal partial class MethodConvert
     {
         switch (pattern)
         {
-            //Convet "and" / "or" pattern  to OpCodes.
+            // Convert "and" / "or" patterns to OpCodes.
             //Example: return value is > 1 and < 100;
             //Example: return value is >= 80 or <= 20;
             case BinaryPatternSyntax binaryPattern:
                 ConvertBinaryPattern(model, binaryPattern, localIndex);
                 break;
-            //Convet constant pattern to OpCodes.
+            // Convert a constant pattern to OpCodes.
             //Example: return value is > 1;
             //Example: return value is null;
             case ConstantPatternSyntax constantPattern:
                 ConvertConstantPattern(model, constantPattern, localIndex);
                 break;
-            //Convet declaration pattern to OpCodes.
+            // Convert a declaration pattern to OpCodes.
             //Example: if (greeting is string message)
             case DeclarationPatternSyntax declarationPattern:
                 ConvertDeclarationPattern(model, declarationPattern, localIndex);
                 break;
-            //Convet discard pattern (_) to OpCodes.
+            // Convert a discard pattern (_) to OpCodes.
             //Example: if (greeting2 is string _)
             case DiscardPatternSyntax:
                 Push(true);
                 break;
-            //Convet relational pattern to OpCodes.
+            // Convert a relational pattern to OpCodes.
             //Example: return value is > 1;
             case RelationalPatternSyntax relationalPattern:
                 ConvertRelationalPattern(model, relationalPattern, localIndex);
@@ -69,12 +69,12 @@ internal partial class MethodConvert
             case TypePatternSyntax typePattern:
                 ConvertTypePattern(model, typePattern, localIndex);
                 break;
-            //Convet "not" pattern  to OpCodes.
+            // Convert a "not" pattern to OpCodes.
             //Example: return value is not null;
             case UnaryPatternSyntax unaryPattern when unaryPattern.OperatorToken.ValueText == "not":
                 ConvertNotPattern(model, unaryPattern, localIndex);
                 break;
-            //Convet parenthesized to OpCodes.
+            // Convert a parenthesized pattern to OpCodes.
             //Example: return value is (> 1 and < 100);
             case ParenthesizedPatternSyntax parenthesizedPattern:
                 ConvertParenthesizedPatternSyntax(model, parenthesizedPattern, localIndex);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RelationalPattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RelationalPattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet relational pattern to OpCodes.
+    /// Convert a relational pattern to OpCodes.
     /// </summary>
     /// <param name="model">The semantic model providing context and information about convert pattern.</param>
     /// <param name="pattern">The convert pattern to be converted.</param>

--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/TypePattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/TypePattern.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler;
 internal partial class MethodConvert
 {
     /// <summary>
-    /// Convet type pattern to OpCodes.
+    /// Convert a type pattern to OpCodes.
     /// </summary>
     /// <param name="model">The semantic model providing context and information about type pattern.</param>
     /// <param name="pattern">The type pattern to be converted.</param>


### PR DESCRIPTION
## Summary
- fix remaining `Convet` typos in compiler pattern conversion comments and XML docs
- keep the PR limited to text-only cleanup on latest `master-n3`

## Context
Validated against current `master-n3`: the broader P3 typo list has mostly already been fixed, and the remaining live typo hits were the compiler pattern comment/doc strings using `Convet`.

## Testing
- dotnet build src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj
