### PR TITLE
Rename #1544: SafeMath method names

### DIFF
--- a/src/Neo.SmartContract.Framework/SafeMath.cs
+++ b/src/Neo.SmartContract.Framework/SafeMath.cs
@@ -14,42 +14,63 @@ using System.Numerics;
 namespace Neo.SmartContract.Framework
 {
     /// <summary>
-    /// Provides unsigned-style arithmetic helpers for <see cref="BigInteger"/> that fault on
+    /// Provides unsigned-style arithmetic helpers for BigInteger that fault on
     /// negative inputs, underflow, and division/modulo by zero.
+    /// In NEO, any overflow or underflow will cause the execution to abort whether or not the SafeMath methods are used.
     /// </summary>
     public static class SafeMath
     {
-        public static BigInteger Add(BigInteger left, BigInteger right)
+        /// <summary>
+        /// Adds two non-negative BigIntegers and returns the result.
+        /// Faults if any operand is negative or the result overflows.
+        /// </summary>
+        public static BigInteger UnsignedAdd(BigInteger left, BigInteger right)
         {
             ExecutionEngine.Assert(left >= 0 && right >= 0, "negative values are not supported");
             return left + right;
         }
 
-        public static BigInteger Sub(BigInteger left, BigInteger right)
+        /// <summary>
+        /// Subtracts a non-negative BigInteger from another non-negative BigInteger and returns the result.
+        /// Faults if any operand is negative or the result is negative.
+        /// </summary>
+        public static BigInteger UnsignedSub(BigInteger left, BigInteger right)
         {
             ExecutionEngine.Assert(left >= 0 && right >= 0, "negative values are not supported");
             ExecutionEngine.Assert(left >= right, "result would be negative");
             return left - right;
         }
 
-        public static BigInteger Mul(BigInteger left, BigInteger right)
+        /// <summary>
+        /// Multiplies two non-negative BigIntegers and returns the result.
+        /// Faults if any operand is negative or the result overflows.
+        /// </summary>
+        public static BigInteger UnsignedMul(BigInteger left, BigInteger right)
         {
             ExecutionEngine.Assert(left >= 0 && right >= 0, "negative values are not supported");
             return left * right;
         }
 
-        public static BigInteger Div(BigInteger left, BigInteger right)
+        /// <summary>
+        /// Divides a non-negative BigInteger by another non-negative BigInteger and returns the result.
+        /// Faults if the dividend is negative or the divisor is non-positive.
+        /// </summary>
+        public static BigInteger UnsignedDiv(BigInteger dividend, BigInteger divisor)
         {
-            ExecutionEngine.Assert(left >= 0 && right >= 0, "negative values are not supported");
-            ExecutionEngine.Assert(right != 0, "division by zero");
-            return left / right;
+            ExecutionEngine.Assert(dividend >= 0, "the dividend must be non-negative");
+            ExecutionEngine.Assert(divisor > 0, "the divisor must be positive");
+            return dividend / divisor;
         }
 
-        public static BigInteger Mod(BigInteger left, BigInteger right)
+        /// <summary>
+        /// Returns the remainder of the division of a non-negative BigInteger by another non-negative BigInteger.
+        /// Faults if the dividend is negative or the divisor is non-positive.
+        /// </summary>
+        public static BigInteger UnsignedMod(BigInteger dividend, BigInteger divisor)
         {
-            ExecutionEngine.Assert(left >= 0 && right >= 0, "negative values are not supported");
-            ExecutionEngine.Assert(right != 0, "modulo by zero");
-            return left % right;
+            ExecutionEngine.Assert(dividend >= 0, "the dividend must be non-negative");
+            ExecutionEngine.Assert(divisor > 0, "the divisor must be positive");
+            return dividend % divisor;
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/SafeMathTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/SafeMathTest.cs
@@ -24,11 +24,11 @@ public class SafeMathTest
         var engine = new TestEngine(true);
         var contract = engine.Deploy<SafeMathContractProxy>(nef, manifest);
 
-        Assert.AreEqual(new BigInteger(9), contract.Add(4, 5));
-        Assert.AreEqual(new BigInteger(7), contract.Sub(10, 3));
-        Assert.AreEqual(new BigInteger(42), contract.Mul(6, 7));
-        Assert.AreEqual(new BigInteger(5), contract.Div(20, 4));
-        Assert.AreEqual(new BigInteger(2), contract.Mod(20, 6));
+        Assert.AreEqual(new BigInteger(9), contract.UnsignedAdd(4, 5));
+        Assert.AreEqual(new BigInteger(7), contract.UnsignedSub(10, 3));
+        Assert.AreEqual(new BigInteger(42), contract.UnsignedMul(6, 7));
+        Assert.AreEqual(new BigInteger(5), contract.UnsignedDiv(20, 4));
+        Assert.AreEqual(new BigInteger(2), contract.UnsignedMod(20, 6));
 
         DynamicCoverageMergeHelper.Merge(contract, debugInfo);
     }
@@ -40,20 +40,20 @@ public class SafeMathTest
         var engine = new TestEngine(true);
         var contract = engine.Deploy<SafeMathContractProxy>(nef, manifest);
 
-        var addNegative = Assert.ThrowsException<TestException>(() => contract.Add(-1, 1));
+        var addNegative = Assert.ThrowsException<TestException>(() => contract.UnsignedAdd(-1, 1));
         StringAssert.Contains(addNegative.InnerException?.Message ?? addNegative.Message, "negative values are not supported");
 
-        var subUnderflow = Assert.ThrowsException<TestException>(() => contract.Sub(1, 2));
+        var subUnderflow = Assert.ThrowsException<TestException>(() => contract.UnsignedSub(1, 2));
         StringAssert.Contains(subUnderflow.InnerException?.Message ?? subUnderflow.Message, "result would be negative");
 
-        var mulNegative = Assert.ThrowsException<TestException>(() => contract.Mul(-1, 2));
+        var mulNegative = Assert.ThrowsException<TestException>(() => contract.UnsignedMul(-1, 2));
         StringAssert.Contains(mulNegative.InnerException?.Message ?? mulNegative.Message, "negative values are not supported");
 
-        var divByZero = Assert.ThrowsException<TestException>(() => contract.Div(1, 0));
-        StringAssert.Contains(divByZero.InnerException?.Message ?? divByZero.Message, "division by zero");
+        var divByZero = Assert.ThrowsException<TestException>(() => contract.UnsignedDiv(1, 0));
+        StringAssert.Contains(divByZero.InnerException?.Message ?? divByZero.Message, "the divisor must be positive");
 
-        var modByZero = Assert.ThrowsException<TestException>(() => contract.Mod(1, 0));
-        StringAssert.Contains(modByZero.InnerException?.Message ?? modByZero.Message, "modulo by zero");
+        var modByZero = Assert.ThrowsException<TestException>(() => contract.UnsignedMod(1, 0));
+        StringAssert.Contains(modByZero.InnerException?.Message ?? modByZero.Message, "the divisor must be positive");
 
         DynamicCoverageMergeHelper.Merge(contract, debugInfo);
     }
@@ -65,17 +65,17 @@ public class SafeMathTest
         var engine = new TestEngine(true);
         var contract = engine.Deploy<SafeMathContractProxy>(nef, manifest);
 
-        var addNegative = Assert.ThrowsException<TestException>(() => contract.Add(1, -1));
+        var addNegative = Assert.ThrowsException<TestException>(() => contract.UnsignedAdd(1, -1));
         StringAssert.Contains(addNegative.InnerException?.Message ?? addNegative.Message, "negative values are not supported");
 
-        var mulNegative = Assert.ThrowsException<TestException>(() => contract.Mul(2, -1));
+        var mulNegative = Assert.ThrowsException<TestException>(() => contract.UnsignedMul(2, -1));
         StringAssert.Contains(mulNegative.InnerException?.Message ?? mulNegative.Message, "negative values are not supported");
 
-        var divNegative = Assert.ThrowsException<TestException>(() => contract.Div(2, -1));
-        StringAssert.Contains(divNegative.InnerException?.Message ?? divNegative.Message, "negative values are not supported");
+        var divNegative = Assert.ThrowsException<TestException>(() => contract.UnsignedDiv(2, -1));
+        StringAssert.Contains(divNegative.InnerException?.Message ?? divNegative.Message, "the divisor must be positive");
 
-        var modNegative = Assert.ThrowsException<TestException>(() => contract.Mod(2, -1));
-        StringAssert.Contains(modNegative.InnerException?.Message ?? modNegative.Message, "negative values are not supported");
+        var modNegative = Assert.ThrowsException<TestException>(() => contract.UnsignedMod(2, -1));
+        StringAssert.Contains(modNegative.InnerException?.Message ?? modNegative.Message, "the divisor must be positive");
 
         DynamicCoverageMergeHelper.Merge(contract, debugInfo);
     }
@@ -87,29 +87,29 @@ using System.Numerics;
 
 public class Contract : SmartContract
 {
-    public static BigInteger Add(BigInteger left, BigInteger right)
+    public static BigInteger UnsignedAdd(BigInteger left, BigInteger right)
     {
-        return SafeMath.Add(left, right);
+        return SafeMath.UnsignedAdd(left, right);
     }
 
-    public static BigInteger Sub(BigInteger left, BigInteger right)
+    public static BigInteger UnsignedSub(BigInteger left, BigInteger right)
     {
-        return SafeMath.Sub(left, right);
+        return SafeMath.UnsignedSub(left, right);
     }
 
-    public static BigInteger Mul(BigInteger left, BigInteger right)
+    public static BigInteger UnsignedMul(BigInteger left, BigInteger right)
     {
-        return SafeMath.Mul(left, right);
+        return SafeMath.UnsignedMul(left, right);
     }
 
-    public static BigInteger Div(BigInteger left, BigInteger right)
+    public static BigInteger UnsignedDiv(BigInteger left, BigInteger right)
     {
-        return SafeMath.Div(left, right);
+        return SafeMath.UnsignedDiv(left, right);
     }
 
-    public static BigInteger Mod(BigInteger left, BigInteger right)
+    public static BigInteger UnsignedMod(BigInteger left, BigInteger right)
     {
-        return SafeMath.Mod(left, right);
+        return SafeMath.UnsignedMod(left, right);
     }
 }";
 
@@ -151,19 +151,19 @@ public class Contract : SmartContract
     public abstract class SafeMathContractProxy(SmartContractInitialize initialize)
         : Neo.SmartContract.Testing.SmartContract(initialize)
     {
-        [DisplayName("add")]
-        public abstract BigInteger? Add(BigInteger? left, BigInteger? right);
+        [DisplayName("unsignedAdd")]
+        public abstract BigInteger? UnsignedAdd(BigInteger? left, BigInteger? right);
 
-        [DisplayName("sub")]
-        public abstract BigInteger? Sub(BigInteger? left, BigInteger? right);
+        [DisplayName("unsignedSub")]
+        public abstract BigInteger? UnsignedSub(BigInteger? left, BigInteger? right);
 
-        [DisplayName("mul")]
-        public abstract BigInteger? Mul(BigInteger? left, BigInteger? right);
+        [DisplayName("unsignedMul")]
+        public abstract BigInteger? UnsignedMul(BigInteger? left, BigInteger? right);
 
-        [DisplayName("div")]
-        public abstract BigInteger? Div(BigInteger? left, BigInteger? right);
+        [DisplayName("unsignedDiv")]
+        public abstract BigInteger? UnsignedDiv(BigInteger? left, BigInteger? right);
 
-        [DisplayName("mod")]
-        public abstract BigInteger? Mod(BigInteger? left, BigInteger? right);
+        [DisplayName("unsignedMod")]
+        public abstract BigInteger? UnsignedMod(BigInteger? left, BigInteger? right);
     }
 }


### PR DESCRIPTION

Rename #1544, the method names of SafeMath method.

It's clearer to add `Unsigned` prefix.