### PR TITLE
test(testing): add gas assertion tolerance helpers

### DIFF
--- a/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
@@ -123,6 +123,33 @@ public class TestBase<T> where T : SmartContract, IContractInfo
         Assert.AreEqual(0, _contractLogs.Count);
     }
 
+    protected void AssertGasConsumedInRangeCore(long minimumGasConsumed, long maximumGasConsumed)
+    {
+        if (minimumGasConsumed > maximumGasConsumed)
+        {
+            Assert.Fail($"Expected gas assertion minimum {minimumGasConsumed} to be less than or equal to maximum {maximumGasConsumed}.");
+        }
+
+        long actualGasConsumed = Engine.FeeConsumed.Value;
+        if (actualGasConsumed < minimumGasConsumed || actualGasConsumed > maximumGasConsumed)
+        {
+            Assert.Fail($"Expected consumed gas to be between {minimumGasConsumed} and {maximumGasConsumed} datoshi, but was {actualGasConsumed}.");
+        }
+    }
+
+    protected void AssertGasConsumedWithToleranceCore(long expectedGasConsumed, long tolerance)
+    {
+        if (tolerance < 0)
+        {
+            Assert.Fail($"Expected gas tolerance to be non-negative, but was {tolerance}.");
+        }
+
+        checked
+        {
+            AssertGasConsumedInRangeCore(expectedGasConsumed - tolerance, expectedGasConsumed + tolerance);
+        }
+    }
+
     #endregion
 
     [TestCleanup]

--- a/tests/Neo.Compiler.CSharp.UnitTests/DebugAndTestBase.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/DebugAndTestBase.cs
@@ -86,6 +86,18 @@ public class DebugAndTestBase<T> : TestBase<T>
     protected void AssertGasConsumed(long gasConsumed)
     {
         if (TestGasConsume)
-            Assert.AreEqual(gasConsumed, Engine.FeeConsumed.Value);
+            AssertGasConsumedInRangeCore(gasConsumed, gasConsumed);
+    }
+
+    protected void AssertGasConsumed(long expectedGasConsumed, long tolerance)
+    {
+        if (TestGasConsume)
+            AssertGasConsumedWithToleranceCore(expectedGasConsumed, tolerance);
+    }
+
+    protected void AssertGasConsumedInRange(long minimumGasConsumed, long maximumGasConsumed)
+    {
+        if (TestGasConsume)
+            AssertGasConsumedInRangeCore(minimumGasConsumed, maximumGasConsumed);
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/DebugAndTestBase.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/DebugAndTestBase.cs
@@ -30,6 +30,18 @@ public class DebugAndTestBase<T> : TestBase<T>
     protected void AssertGasConsumed(long gasConsumed)
     {
         if (TestGasConsume)
-            Assert.AreEqual(gasConsumed, Engine.FeeConsumed.Value);
+            AssertGasConsumedInRangeCore(gasConsumed, gasConsumed);
+    }
+
+    protected void AssertGasConsumed(long expectedGasConsumed, long tolerance)
+    {
+        if (TestGasConsume)
+            AssertGasConsumedWithToleranceCore(expectedGasConsumed, tolerance);
+    }
+
+    protected void AssertGasConsumedInRange(long minimumGasConsumed, long maximumGasConsumed)
+    {
+        if (TestGasConsume)
+            AssertGasConsumedInRangeCore(minimumGasConsumed, maximumGasConsumed);
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/GasAssertionRangeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/GasAssertionRangeTest.cs
@@ -47,11 +47,30 @@ public class GasAssertionRangeTest : DebugAndTestBase<Contract_String>
     }
 
     [TestMethod]
+    public void AssertGasConsumed_FailsForNegativeTolerance()
+    {
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => AssertGasConsumed(1_000, -1));
+
+        StringAssert.Contains(exception.Message, "non-negative");
+    }
+
+    [TestMethod]
     public void AssertGasConsumedInRange_FailsForInvalidWindow()
     {
         var exception = Assert.ThrowsExactly<AssertFailedException>(() => AssertGasConsumedInRange(1_100, 900));
 
         StringAssert.Contains(exception.Message, "minimum");
         StringAssert.Contains(exception.Message, "maximum");
+    }
+
+    [TestMethod]
+    public void AssertGasConsumedInRange_FailsWhenActualGasIsBelowMinimum()
+    {
+        Engine.FeeConsumed.Value = 1_000;
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => AssertGasConsumedInRange(1_001, 1_100));
+
+        StringAssert.Contains(exception.Message, "between 1001 and 1100");
+        StringAssert.Contains(exception.Message, "1000");
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/GasAssertionRangeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/GasAssertionRangeTest.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// GasAssertionRangeTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+[TestClass]
+public class GasAssertionRangeTest : DebugAndTestBase<Contract_String>
+{
+    [TestMethod]
+    public void AssertGasConsumed_AllowsAbsoluteTolerance()
+    {
+        Engine.FeeConsumed.Value = 1_000;
+
+        AssertGasConsumed(950, 50);
+        AssertGasConsumed(1_050, 50);
+    }
+
+    [TestMethod]
+    public void AssertGasConsumedInRange_AllowsInclusiveRange()
+    {
+        Engine.FeeConsumed.Value = 1_000;
+
+        AssertGasConsumedInRange(1_000, 1_000);
+        AssertGasConsumedInRange(900, 1_100);
+    }
+
+    [TestMethod]
+    public void AssertGasConsumed_FailsOutsideTolerance()
+    {
+        Engine.FeeConsumed.Value = 1_000;
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => AssertGasConsumed(900, 50));
+
+        StringAssert.Contains(exception.Message, "between 850 and 950");
+        StringAssert.Contains(exception.Message, "1000");
+    }
+
+    [TestMethod]
+    public void AssertGasConsumedInRange_FailsForInvalidWindow()
+    {
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => AssertGasConsumedInRange(1_100, 900));
+
+        StringAssert.Contains(exception.Message, "minimum");
+        StringAssert.Contains(exception.Message, "maximum");
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable gas assertion helpers for inclusive ranges and absolute tolerances in `TestBase<T>`
- expose the new helpers through both compiler and framework `DebugAndTestBase` wrappers while preserving the existing gas-test toggle
- add framework unit coverage for tolerance and range success/failure cases

## Context
- addresses the remaining P2 roadmap item `Testing: Gas assertion tolerance ranges` from #1514
- keeps this PR focused on that single P2 issue

## Test Plan
- dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj --filter GasAssertionRangeTest
- dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj --filter StringTest
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_Contract1
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter TestEngineTests