### PR TITLE
feat(security): add symbolic execution path analyzer

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/Reachability.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/Reachability.cs
@@ -30,6 +30,7 @@ namespace Neo.Optimizer
             Dictionary<int, BranchType> coveredMap = oldContractCoverage.coveredMap;
             List<(int, Instruction)> oldAddressAndInstructionsList = oldContractCoverage.addressAndInstructions;
             Dictionary<int, Instruction> oldAddressToInstruction = oldContractCoverage.addressToInstructions;
+            Dictionary<int, int> oldSequencePointAddressToNew = new();
             //DumpNef.GenerateDumpNef(nef, debugInfo);
             //coveredMap.Where(kv => !kv.Value).Select(kv => (kv.Key, oldAddressToInstruction[kv.Key].OpCode)).ToList();
             System.Collections.Specialized.OrderedDictionary simplifiedInstructionsToAddress = new();
@@ -38,8 +39,13 @@ namespace Neo.Optimizer
             {
                 if (coveredMap[a] != BranchType.UNCOVERED && i.OpCode != OpCode.NOP)
                 {
+                    oldSequencePointAddressToNew[a] = currentAddress;
                     simplifiedInstructionsToAddress.Add(i, currentAddress);
                     currentAddress += i.Size;
+                }
+                else
+                {
+                    oldSequencePointAddressToNew[a] = currentAddress;
                 }
             }
             // retarget all NOP jump targets
@@ -64,7 +70,7 @@ namespace Neo.Optimizer
             return AssetBuilder.BuildOptimizedAssets(nef, manifest, debugInfo,
                 simplifiedInstructionsToAddress,
                 oldContractCoverage.jumpInstructionSourceToTargets, oldContractCoverage.tryInstructionSourceToTargets,
-                oldAddressToInstruction);
+                oldAddressToInstruction, oldSequencePointAddressToNew);
         }
 
         public static Dictionary<int, BranchType>

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
@@ -23,6 +23,7 @@ namespace Neo.Compiler.SecurityAnalyzer
             ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(nef, manifest, debugInfo).GetWarningInfo(print: true);
             WriteInTryAnalyzer.AnalyzeWriteInTry(nef, manifest, debugInfo).GetWarningInfo(print: true);
             CheckWitnessAnalyzer.AnalyzeCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
+            SymbolicExecutionAnalyzer.Analyze(nef, manifest, debugInfo).GetWarningInfo(print: true);
             MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
             UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(nef, manifest, debugInfo).GetWarningInfo(print: true);
             if (!UpdateAnalyzer.AnalyzeUpdate(nef, manifest, debugInfo))

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicExecutor.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicExecutor.cs
@@ -1,0 +1,564 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SymbolicExecutor.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Json;
+using Neo.Optimizer;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using VMInstruction = Neo.VM.Instruction;
+
+namespace Neo.Compiler.SecurityAnalyzer.SymbolicExecution
+{
+    internal enum SymbolicWarningKind
+    {
+        UnguardedUpdate,
+        UnguardedDestroy,
+        VerifyStorageWrite,
+        AnalysisIncomplete,
+    }
+
+    internal sealed record SymbolicWarning(SymbolicWarningKind Kind, string EntryPoint, int Address);
+
+    internal sealed class SymbolicFindings
+    {
+        public bool HasUnguardedUpdate { get; private set; }
+        public bool HasUnguardedDestroy { get; private set; }
+        public bool HasVerifyStorageWrite { get; private set; }
+        public bool AnalysisIncomplete { get; private set; }
+        public List<SymbolicWarning> Warnings { get; } = new();
+
+        public void RecordUnguardedUpdate(string entryPoint, int address, bool isDestroy)
+        {
+            if (isDestroy)
+            {
+                HasUnguardedDestroy = true;
+                Warnings.Add(new SymbolicWarning(SymbolicWarningKind.UnguardedDestroy, entryPoint, address));
+            }
+            else
+            {
+                HasUnguardedUpdate = true;
+                Warnings.Add(new SymbolicWarning(SymbolicWarningKind.UnguardedUpdate, entryPoint, address));
+            }
+        }
+
+        public void RecordVerifyStorageWrite(string entryPoint, int address)
+        {
+            HasVerifyStorageWrite = true;
+            Warnings.Add(new SymbolicWarning(SymbolicWarningKind.VerifyStorageWrite, entryPoint, address));
+        }
+
+        public void MarkIncomplete()
+        {
+            if (AnalysisIncomplete)
+                return;
+            AnalysisIncomplete = true;
+            Warnings.Add(new SymbolicWarning(SymbolicWarningKind.AnalysisIncomplete, string.Empty, -1));
+        }
+    }
+
+    internal sealed class SymbolicExecutor
+    {
+        public const int MaxPaths = 512;
+        public const int MaxSteps = 50000;
+        public const int MaxDepth = 128;
+
+        private static readonly HashSet<OpCode> ConditionalJumps = OpCodeTypes.conditionalJump
+            .Union(OpCodeTypes.conditionalJump_L)
+            .ToHashSet();
+
+        private static readonly HashSet<OpCode> UnconditionalJumps = OpCodeTypes.unconditionalJump;
+
+        private static readonly HashSet<uint> StorageWriteSyscalls = new()
+        {
+            ApplicationEngine.System_Storage_Put.Hash,
+            ApplicationEngine.System_Storage_Delete.Hash,
+            ApplicationEngine.System_Storage_Local_Put.Hash,
+            ApplicationEngine.System_Storage_Local_Delete.Hash,
+        };
+
+        private (int address, VMInstruction instruction)[] _instructions = Array.Empty<(int, VMInstruction)>();
+        private Dictionary<int, int> _addressToIndex = new();
+        private MethodToken[] _tokens = Array.Empty<MethodToken>();
+        private int _totalPaths;
+        private int _totalSteps;
+        private SymbolicFindings _findings = new();
+
+        public SymbolicFindings Analyze(NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
+        {
+            _findings = new SymbolicFindings();
+            _totalPaths = 0;
+            _totalSteps = 0;
+
+            (nef, manifest, _) = Reachability.RemoveUncoveredInstructions(nef, manifest, debugInfo as JObject);
+
+            Script script = nef.Script;
+            _instructions = script.EnumerateInstructions().ToArray();
+            _addressToIndex = _instructions
+                .Select((entry, index) => (entry.address, index))
+                .ToDictionary(entry => entry.address, entry => entry.index);
+            _tokens = nef.Tokens;
+
+            foreach (var method in manifest.Abi.Methods)
+            {
+                if (!_addressToIndex.TryGetValue(method.Offset, out int startIndex))
+                    continue;
+                bool isVerify = string.Equals(method.Name, "verify", StringComparison.OrdinalIgnoreCase);
+                ExploreEntryPoint(method.Name, startIndex, isVerify);
+                if (_findings.AnalysisIncomplete)
+                    break;
+            }
+
+            return _findings;
+        }
+
+        private void ExploreEntryPoint(string entryPoint, int startIndex, bool isVerify)
+        {
+            Stack<SymbolicState> worklist = new();
+            worklist.Push(new SymbolicState(entryPoint, startIndex));
+
+            while (worklist.Count > 0)
+            {
+                if (_totalPaths >= MaxPaths)
+                {
+                    _findings.MarkIncomplete();
+                    return;
+                }
+
+                SymbolicState state = worklist.Pop();
+                bool pathEnded = false;
+
+                while (!pathEnded)
+                {
+                    if (_totalSteps >= MaxSteps)
+                    {
+                        _findings.MarkIncomplete();
+                        return;
+                    }
+                    _totalSteps++;
+
+                    if (state.BranchDepth > MaxDepth)
+                    {
+                        _findings.MarkIncomplete();
+                        break;
+                    }
+
+                    if (state.InstructionIndex < 0 || state.InstructionIndex >= _instructions.Length)
+                    {
+                        _findings.MarkIncomplete();
+                        break;
+                    }
+
+                    (int addr, VMInstruction instruction) = _instructions[state.InstructionIndex];
+                    OpCode opCode = instruction.OpCode;
+
+                    if (UnconditionalJumps.Contains(opCode) || opCode == OpCode.ENDTRY || opCode == OpCode.ENDTRY_L)
+                    {
+                        if (!TryJump(state, addr, instruction))
+                        {
+                            _findings.MarkIncomplete();
+                            break;
+                        }
+                        continue;
+                    }
+
+                    if (ConditionalJumps.Contains(opCode))
+                    {
+                        HandleConditionalJump(state, addr, instruction, worklist);
+                        continue;
+                    }
+
+                    switch (opCode)
+                    {
+                        case OpCode.CALL:
+                        case OpCode.CALL_L:
+                            if (!TryCall(state, addr, instruction))
+                            {
+                                _findings.MarkIncomplete();
+                                pathEnded = true;
+                            }
+                            break;
+                        case OpCode.CALLA:
+                            _findings.MarkIncomplete();
+                            pathEnded = true;
+                            break;
+                        case OpCode.CALLT:
+                            HandleCallT(state, addr, instruction);
+                            state.InstructionIndex++;
+                            break;
+                        case OpCode.SYSCALL:
+                            HandleSyscall(state, addr, instruction, isVerify);
+                            state.InstructionIndex++;
+                            break;
+                        case OpCode.RET:
+                            if (state.TryPopReturn(out int returnIndex))
+                            {
+                                state.InstructionIndex = returnIndex;
+                            }
+                            else
+                            {
+                                pathEnded = true;
+                            }
+                            break;
+                        case OpCode.THROW:
+                        case OpCode.ABORT:
+                        case OpCode.ABORTMSG:
+                            pathEnded = true;
+                            break;
+                        case OpCode.ASSERT:
+                            HandleAssert(state, consumeMessage: false);
+                            state.InstructionIndex++;
+                            break;
+                        case OpCode.ASSERTMSG:
+                            HandleAssert(state, consumeMessage: true);
+                            state.InstructionIndex++;
+                            break;
+                        case OpCode.ENDFINALLY:
+                            pathEnded = true;
+                            break;
+                        default:
+                            ApplyStackEffect(state, addr, instruction);
+                            state.InstructionIndex++;
+                            break;
+                    }
+                }
+
+                _totalPaths++;
+            }
+        }
+
+        private static void HandleAssert(SymbolicState state, bool consumeMessage)
+        {
+            if (consumeMessage)
+                state.Pop();
+            SymbolicValue condition = state.Pop();
+            if (condition.Kind == SymbolicValueKind.WitnessCheck)
+                state.HasWitnessGuard = true;
+        }
+
+        private void HandleConditionalJump(SymbolicState state, int addr, VMInstruction instruction, Stack<SymbolicState> worklist)
+        {
+            OpCode opCode = instruction.OpCode;
+            SymbolicValue condition;
+            if (opCode is OpCode.JMPEQ or OpCode.JMPNE or OpCode.JMPGT or OpCode.JMPGE or OpCode.JMPLT or OpCode.JMPLE
+                or OpCode.JMPEQ_L or OpCode.JMPNE_L or OpCode.JMPGT_L or OpCode.JMPGE_L or OpCode.JMPLT_L or OpCode.JMPLE_L)
+            {
+                state.Pop();
+                condition = state.Pop();
+            }
+            else
+            {
+                condition = state.Pop();
+            }
+
+            if (!TryGetJumpTarget(addr, instruction, out int targetIndex))
+            {
+                _findings.MarkIncomplete();
+                return;
+            }
+
+            SymbolicState jumpState = state.Clone();
+            SymbolicState fallthroughState = state.Clone();
+
+            bool isWitnessCondition = condition.Kind == SymbolicValueKind.WitnessCheck;
+            bool jumpIfTrue = opCode is OpCode.JMPIF or OpCode.JMPIF_L;
+            bool jumpIfFalse = opCode is OpCode.JMPIFNOT or OpCode.JMPIFNOT_L;
+
+            if (isWitnessCondition)
+            {
+                if (jumpIfTrue)
+                    jumpState.HasWitnessGuard = true;
+                if (jumpIfFalse)
+                    fallthroughState.HasWitnessGuard = true;
+            }
+
+            jumpState.InstructionIndex = targetIndex;
+            fallthroughState.InstructionIndex = state.InstructionIndex + 1;
+            jumpState.BranchDepth = state.BranchDepth + 1;
+            fallthroughState.BranchDepth = state.BranchDepth + 1;
+
+            worklist.Push(jumpState);
+            state.InstructionIndex = fallthroughState.InstructionIndex;
+            state.HasWitnessGuard = fallthroughState.HasWitnessGuard;
+            state.BranchDepth = fallthroughState.BranchDepth;
+        }
+
+        private bool TryJump(SymbolicState state, int addr, VMInstruction instruction)
+        {
+            if (!TryGetJumpTarget(addr, instruction, out int targetIndex))
+                return false;
+            state.InstructionIndex = targetIndex;
+            return true;
+        }
+
+        private bool TryGetJumpTarget(int addr, VMInstruction instruction, out int targetIndex)
+        {
+            targetIndex = -1;
+            int targetAddr;
+            try
+            {
+                targetAddr = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+            }
+            catch
+            {
+                return false;
+            }
+            return _addressToIndex.TryGetValue(targetAddr, out targetIndex);
+        }
+
+        private bool TryCall(SymbolicState state, int addr, VMInstruction instruction)
+        {
+            if (!TryGetJumpTarget(addr, instruction, out int targetIndex))
+                return false;
+            int returnIndex = state.InstructionIndex + 1;
+            state.PushReturn(returnIndex);
+            state.InstructionIndex = targetIndex;
+            if (state.CallStack.Count > MaxDepth)
+                return false;
+            return true;
+        }
+
+        private void HandleCallT(SymbolicState state, int addr, VMInstruction instruction)
+        {
+            if (instruction.TokenU16 >= _tokens.Length)
+                return;
+            MethodToken token = _tokens[instruction.TokenU16];
+            if (token.Hash == NativeContract.ContractManagement.Hash)
+            {
+                bool isUpdate = token.Method == "update";
+                bool isDestroy = token.Method == "destroy";
+                if ((isUpdate || isDestroy) && (token.CallFlags & CallFlags.WriteStates) != 0)
+                {
+                    if (!state.HasWitnessGuard)
+                        _findings.RecordUnguardedUpdate(state.EntryPoint, addr, isDestroy);
+                }
+            }
+            PopArgs(state, token.ParametersCount);
+            if (token.HasReturnValue)
+                state.Push(SymbolicValue.Unknown);
+        }
+
+        private void HandleSyscall(SymbolicState state, int addr, VMInstruction instruction, bool isVerify)
+        {
+            uint sysCall = instruction.TokenU32;
+            if (sysCall == ApplicationEngine.System_Runtime_CheckWitness.Hash)
+            {
+                SymbolicValue argument = state.Pop();
+                state.Push(SymbolicValue.WitnessCheck(argument));
+                return;
+            }
+
+            if (StorageWriteSyscalls.Contains(sysCall))
+            {
+                if (isVerify)
+                    _findings.RecordVerifyStorageWrite(state.EntryPoint, addr);
+                PopArgs(state, 3);
+                return;
+            }
+
+            if (sysCall == ApplicationEngine.System_Contract_Call.Hash)
+            {
+                SymbolicValue? hashValue = PeekStack(state, 3);
+                SymbolicValue? methodValue = PeekStack(state, 2);
+                if (hashValue != null && methodValue != null
+                    && hashValue.TryGetUInt160(out var hash)
+                    && methodValue.TryGetString(out string method)
+                    && hash == NativeContract.ContractManagement.Hash
+                    && (string.Equals(method, "update", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(method, "destroy", StringComparison.OrdinalIgnoreCase)))
+                {
+                    if (!state.HasWitnessGuard)
+                        _findings.RecordUnguardedUpdate(state.EntryPoint, addr, string.Equals(method, "destroy", StringComparison.OrdinalIgnoreCase));
+                }
+                PopArgs(state, 4);
+                state.Push(SymbolicValue.Unknown);
+                return;
+            }
+
+            // Default: conservatively drop one argument if present to avoid unbounded stack growth.
+            if (state.Stack.Count > 0)
+                state.Pop();
+        }
+
+        private static void ApplyStackEffect(SymbolicState state, int addr, VMInstruction instruction)
+        {
+            OpCode opCode = instruction.OpCode;
+            if (OpCodeTypes.pushConst.Contains(opCode))
+            {
+                state.Push(CreateConstant(addr, instruction));
+                return;
+            }
+
+            switch (opCode)
+            {
+                case OpCode.PUSHDATA1:
+                case OpCode.PUSHDATA2:
+                case OpCode.PUSHDATA4:
+                    state.Push(SymbolicValue.FromByteString(instruction.Operand.Span.ToArray()));
+                    break;
+                case OpCode.DUP:
+                    state.Push(state.Peek());
+                    break;
+                case OpCode.OVER:
+                    if (state.Stack.Count >= 2)
+                        state.Push(state.Stack[^2]);
+                    else
+                        state.Push(SymbolicValue.Unknown);
+                    break;
+                case OpCode.SWAP:
+                    if (state.Stack.Count >= 2)
+                    {
+                        int last = state.Stack.Count - 1;
+                        (state.Stack[last], state.Stack[last - 1]) = (state.Stack[last - 1], state.Stack[last]);
+                    }
+                    break;
+                case OpCode.DROP:
+                    state.Pop();
+                    break;
+                case OpCode.NIP:
+                    if (state.Stack.Count >= 2)
+                        state.Stack.RemoveAt(state.Stack.Count - 2);
+                    break;
+                case OpCode.ROT:
+                    if (state.Stack.Count >= 3)
+                    {
+                        int last = state.Stack.Count - 1;
+                        SymbolicValue a = state.Stack[last - 2];
+                        state.Stack[last - 2] = state.Stack[last - 1];
+                        state.Stack[last - 1] = state.Stack[last];
+                        state.Stack[last] = a;
+                    }
+                    break;
+                case OpCode.PICK:
+                case OpCode.ROLL:
+                    state.Pop();
+                    state.Push(SymbolicValue.Unknown);
+                    break;
+                case OpCode.NOT:
+                    state.Pop();
+                    state.Push(SymbolicValue.Unknown);
+                    break;
+                case OpCode.PUSHNULL:
+                    state.Push(SymbolicValue.Unknown);
+                    break;
+                case OpCode.PUSHT:
+                    state.Push(SymbolicValue.FromBoolean(true));
+                    break;
+                case OpCode.PUSHF:
+                    state.Push(SymbolicValue.FromBoolean(false));
+                    break;
+                case OpCode.PUSHM1:
+                    state.Push(SymbolicValue.FromInteger(-1));
+                    break;
+                case OpCode.PUSH0:
+                    state.Push(SymbolicValue.FromInteger(0));
+                    break;
+                case OpCode.PUSH1:
+                case OpCode.PUSH2:
+                case OpCode.PUSH3:
+                case OpCode.PUSH4:
+                case OpCode.PUSH5:
+                case OpCode.PUSH6:
+                case OpCode.PUSH7:
+                case OpCode.PUSH8:
+                case OpCode.PUSH9:
+                case OpCode.PUSH10:
+                case OpCode.PUSH11:
+                case OpCode.PUSH12:
+                case OpCode.PUSH13:
+                case OpCode.PUSH14:
+                case OpCode.PUSH15:
+                case OpCode.PUSH16:
+                    state.Push(SymbolicValue.FromInteger((int)opCode - (int)OpCode.PUSH0));
+                    break;
+                case OpCode.PUSHINT8:
+                case OpCode.PUSHINT16:
+                case OpCode.PUSHINT32:
+                case OpCode.PUSHINT64:
+                case OpCode.PUSHINT128:
+                case OpCode.PUSHINT256:
+                    state.Push(SymbolicValue.FromInteger(new BigInteger(instruction.Operand.Span)));
+                    break;
+                case OpCode.PUSHA:
+                    try
+                    {
+                        int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                        state.Push(SymbolicValue.FromInteger(target));
+                    }
+                    catch
+                    {
+                        state.Push(SymbolicValue.Unknown);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private static SymbolicValue CreateConstant(int addr, VMInstruction instruction)
+        {
+            OpCode opCode = instruction.OpCode;
+            if (opCode == OpCode.PUSHT)
+                return SymbolicValue.FromBoolean(true);
+            if (opCode == OpCode.PUSHF)
+                return SymbolicValue.FromBoolean(false);
+            if (opCode == OpCode.PUSHM1)
+                return SymbolicValue.FromInteger(-1);
+            if (opCode >= OpCode.PUSH0 && opCode <= OpCode.PUSH16)
+                return SymbolicValue.FromInteger((int)opCode - (int)OpCode.PUSH0);
+            if (opCode == OpCode.PUSHNULL)
+                return SymbolicValue.Unknown;
+            if (opCode == OpCode.PUSHA)
+            {
+                try
+                {
+                    int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                    return SymbolicValue.FromInteger(target);
+                }
+                catch
+                {
+                    return SymbolicValue.Unknown;
+                }
+            }
+            if (opCode == OpCode.PUSHINT8
+                || opCode == OpCode.PUSHINT16
+                || opCode == OpCode.PUSHINT32
+                || opCode == OpCode.PUSHINT64
+                || opCode == OpCode.PUSHINT128
+                || opCode == OpCode.PUSHINT256)
+                return SymbolicValue.FromInteger(new BigInteger(instruction.Operand.Span));
+
+            if (opCode == OpCode.PUSHDATA1 || opCode == OpCode.PUSHDATA2 || opCode == OpCode.PUSHDATA4)
+                return SymbolicValue.FromByteString(instruction.Operand.Span.ToArray());
+
+            return SymbolicValue.Unknown;
+        }
+
+        private static void PopArgs(SymbolicState state, int count)
+        {
+            for (int i = 0; i < count; i++)
+                state.Pop();
+        }
+
+        private static SymbolicValue? PeekStack(SymbolicState state, int indexFromTop)
+        {
+            int index = state.Stack.Count - 1 - indexFromTop;
+            if (index < 0 || index >= state.Stack.Count)
+                return null;
+            return state.Stack[index];
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicExecutor.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicExecutor.cs
@@ -371,8 +371,8 @@ namespace Neo.Compiler.SecurityAnalyzer.SymbolicExecution
 
             if (sysCall == ApplicationEngine.System_Contract_Call.Hash)
             {
-                SymbolicValue? hashValue = PeekStack(state, 3);
-                SymbolicValue? methodValue = PeekStack(state, 2);
+                SymbolicValue? hashValue = PeekStack(state, 0);
+                SymbolicValue? methodValue = PeekStack(state, 1);
                 if (hashValue != null && methodValue != null
                     && hashValue.TryGetUInt160(out var hash)
                     && methodValue.TryGetString(out string method)

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicState.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicState.cs
@@ -1,0 +1,88 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SymbolicState.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Generic;
+
+namespace Neo.Compiler.SecurityAnalyzer.SymbolicExecution
+{
+    internal sealed class SymbolicState
+    {
+        public string EntryPoint { get; }
+        public int InstructionIndex { get; set; }
+        public List<SymbolicValue> Stack { get; }
+        public List<int> CallStack { get; }
+        public bool HasWitnessGuard { get; set; }
+        public int BranchDepth { get; set; }
+
+        public SymbolicState(string entryPoint, int instructionIndex)
+        {
+            EntryPoint = entryPoint;
+            InstructionIndex = instructionIndex;
+            Stack = new List<SymbolicValue>();
+            CallStack = new List<int>();
+        }
+
+        private SymbolicState(string entryPoint, int instructionIndex, List<SymbolicValue> stack, List<int> callStack, bool hasWitnessGuard, int branchDepth)
+        {
+            EntryPoint = entryPoint;
+            InstructionIndex = instructionIndex;
+            Stack = stack;
+            CallStack = callStack;
+            HasWitnessGuard = hasWitnessGuard;
+            BranchDepth = branchDepth;
+        }
+
+        public SymbolicState Clone()
+        {
+            return new SymbolicState(
+                EntryPoint,
+                InstructionIndex,
+                new List<SymbolicValue>(Stack),
+                new List<int>(CallStack),
+                HasWitnessGuard,
+                BranchDepth);
+        }
+
+        public void Push(SymbolicValue value) => Stack.Add(value);
+
+        public SymbolicValue Pop()
+        {
+            if (Stack.Count == 0)
+                return SymbolicValue.Unknown;
+            int last = Stack.Count - 1;
+            SymbolicValue value = Stack[last];
+            Stack.RemoveAt(last);
+            return value;
+        }
+
+        public SymbolicValue Peek()
+        {
+            if (Stack.Count == 0)
+                return SymbolicValue.Unknown;
+            return Stack[^1];
+        }
+
+        public void PushReturn(int index) => CallStack.Add(index);
+
+        public bool TryPopReturn(out int index)
+        {
+            if (CallStack.Count == 0)
+            {
+                index = default;
+                return false;
+            }
+            int last = CallStack.Count - 1;
+            index = CallStack[last];
+            CallStack.RemoveAt(last);
+            return true;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicValue.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecution/SymbolicValue.cs
@@ -1,0 +1,104 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SymbolicValue.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo;
+using System;
+using System.Numerics;
+using System.Text;
+
+namespace Neo.Compiler.SecurityAnalyzer.SymbolicExecution
+{
+    internal enum SymbolicValueKind
+    {
+        Unknown,
+        Integer,
+        Boolean,
+        ByteString,
+        UInt160,
+        WitnessCheck,
+    }
+
+    internal sealed class SymbolicValue
+    {
+        public SymbolicValueKind Kind { get; }
+        public BigInteger? IntegerValue { get; }
+        public bool? BooleanValue { get; }
+        public byte[]? ByteStringValue { get; }
+        public UInt160? UInt160Value { get; }
+        public SymbolicValue? WitnessArgument { get; }
+
+        private SymbolicValue(
+            SymbolicValueKind kind,
+            BigInteger? integerValue = null,
+            bool? booleanValue = null,
+            byte[]? byteStringValue = null,
+            UInt160? uint160Value = null,
+            SymbolicValue? witnessArgument = null)
+        {
+            Kind = kind;
+            IntegerValue = integerValue;
+            BooleanValue = booleanValue;
+            ByteStringValue = byteStringValue;
+            UInt160Value = uint160Value;
+            WitnessArgument = witnessArgument;
+        }
+
+        public static SymbolicValue Unknown { get; } = new(SymbolicValueKind.Unknown);
+
+        public static SymbolicValue FromInteger(BigInteger value) => new(SymbolicValueKind.Integer, integerValue: value);
+
+        public static SymbolicValue FromBoolean(bool value) => new(SymbolicValueKind.Boolean, booleanValue: value);
+
+        public static SymbolicValue FromUInt160(UInt160 value) => new(SymbolicValueKind.UInt160, uint160Value: value);
+
+        public static SymbolicValue FromByteString(byte[] value)
+        {
+            if (value.Length == UInt160.Length)
+                return new SymbolicValue(SymbolicValueKind.ByteString, byteStringValue: value, uint160Value: new UInt160(value));
+            return new SymbolicValue(SymbolicValueKind.ByteString, byteStringValue: value);
+        }
+
+        public static SymbolicValue WitnessCheck(SymbolicValue? argument)
+            => new(SymbolicValueKind.WitnessCheck, witnessArgument: argument);
+
+        public bool TryGetString(out string text)
+        {
+            text = string.Empty;
+            if (Kind != SymbolicValueKind.ByteString || ByteStringValue is null)
+                return false;
+            try
+            {
+                text = Encoding.UTF8.GetString(ByteStringValue);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool TryGetUInt160(out UInt160 value)
+        {
+            if (Kind == SymbolicValueKind.UInt160 && UInt160Value is not null)
+            {
+                value = UInt160Value!;
+                return true;
+            }
+            if (Kind == SymbolicValueKind.ByteString && UInt160Value is not null)
+            {
+                value = UInt160Value!;
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecutionAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecutionAnalyzer.cs
@@ -13,9 +13,9 @@ using Neo.Compiler.SecurityAnalyzer.SymbolicExecution;
 using Neo.Json;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
-using Neo.SmartContract.Testing.Coverage;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Neo.Compiler.SecurityAnalyzer
@@ -88,7 +88,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                     {
                         if (neoDebugInfo != null)
                         {
-                            var location = neoDebugInfo.GetSourceLocation(warning.Address);
+                            var location = GetSourceLocation(warning.Address, neoDebugInfo);
                             if (location != null)
                             {
                                 result.AppendLine($"  At: {location.FileName}:{location.Line}:{location.Column}");
@@ -119,6 +119,39 @@ namespace Neo.Compiler.SecurityAnalyzer
             SymbolicExecutor executor = new();
             SymbolicFindings findings = executor.Analyze(nef, manifest, debugInfo);
             return new SymbolicExecutionWarnings(findings, debugInfo);
+        }
+
+        private static NeoDebugInfo.SourceLocation? GetSourceLocation(int instructionAddress, NeoDebugInfo debugInfo)
+        {
+            foreach (var method in debugInfo.Methods)
+            {
+                if (instructionAddress < method.Range.Start || instructionAddress > method.Range.End)
+                    continue;
+
+                var sequencePoints = method.SequencePoints
+                    .Where(sp => sp.Address <= instructionAddress)
+                    .OrderByDescending(sp => sp.Address)
+                    .ToList();
+
+                if (sequencePoints.Count == 0)
+                    continue;
+
+                var sequencePoint = sequencePoints.First();
+
+                if (sequencePoint.Document < 0 || sequencePoint.Document >= debugInfo.Documents.Count)
+                    continue;
+
+                string document = debugInfo.Documents[sequencePoint.Document];
+                return new NeoDebugInfo.SourceLocation
+                {
+                    FileName = document,
+                    Line = sequencePoint.Start.Line,
+                    Column = sequencePoint.Start.Column,
+                    CodeSnippet = null
+                };
+            }
+
+            return null;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecutionAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SymbolicExecutionAnalyzer.cs
@@ -1,0 +1,124 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SymbolicExecutionAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Compiler.SecurityAnalyzer.SymbolicExecution;
+using Neo.Json;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing.Coverage;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Neo.Compiler.SecurityAnalyzer
+{
+    public static class SymbolicExecutionAnalyzer
+    {
+        public sealed class SymbolicExecutionWarnings
+        {
+            private readonly IReadOnlyList<SymbolicWarning> warnings;
+            private readonly JToken? debugInfo;
+
+            public bool HasUnguardedUpdate { get; }
+            public bool HasUnguardedDestroy { get; }
+            public bool HasVerifyStorageWrite { get; }
+            public bool AnalysisIncomplete { get; }
+
+            internal SymbolicExecutionWarnings(SymbolicFindings findings, JToken? debugInfo)
+            {
+                warnings = findings.Warnings;
+                this.debugInfo = debugInfo;
+                HasUnguardedUpdate = findings.HasUnguardedUpdate;
+                HasUnguardedDestroy = findings.HasUnguardedDestroy;
+                HasVerifyStorageWrite = findings.HasVerifyStorageWrite;
+                AnalysisIncomplete = findings.AnalysisIncomplete;
+            }
+
+            public string GetWarningInfo(bool print = false)
+            {
+                if (warnings.Count == 0)
+                    return string.Empty;
+
+                NeoDebugInfo? neoDebugInfo = null;
+                if (debugInfo is JObject jObj)
+                {
+                    try
+                    {
+                        neoDebugInfo = NeoDebugInfo.FromDebugInfoJson(jObj);
+                    }
+                    catch
+                    {
+                        neoDebugInfo = null;
+                    }
+                }
+
+                StringBuilder result = new();
+                foreach (SymbolicWarning warning in warnings)
+                {
+                    switch (warning.Kind)
+                    {
+                        case SymbolicWarningKind.UnguardedUpdate:
+                            result.AppendLine($"[SEC] Symbolic execution detected unguarded contract update in method '{warning.EntryPoint}'.");
+                            result.AppendLine("  Recommendation: Guard update with Assert(CheckWitness(owner)) or an equivalent permission check.");
+                            break;
+                        case SymbolicWarningKind.UnguardedDestroy:
+                            result.AppendLine($"[SEC] Symbolic execution detected unguarded contract destroy in method '{warning.EntryPoint}'.");
+                            result.AppendLine("  Recommendation: Guard destroy with Assert(CheckWitness(owner)) or an equivalent permission check.");
+                            break;
+                        case SymbolicWarningKind.VerifyStorageWrite:
+                            result.AppendLine($"[SEC] Symbolic execution detected storage writes reachable from Verify in method '{warning.EntryPoint}'.");
+                            result.AppendLine("  Recommendation: Avoid storage writes in Verify or move them to runtime methods.");
+                            break;
+                        case SymbolicWarningKind.AnalysisIncomplete:
+                            result.AppendLine("[SEC][INFO] Symbolic execution analysis was incomplete due to path/step limits.");
+                            break;
+                        default:
+                            break;
+                    }
+
+                    if (warning.Address >= 0)
+                    {
+                        if (neoDebugInfo != null)
+                        {
+                            var location = neoDebugInfo.GetSourceLocation(warning.Address);
+                            if (location != null)
+                            {
+                                result.AppendLine($"  At: {location.FileName}:{location.Line}:{location.Column}");
+                            }
+                            else
+                            {
+                                result.AppendLine($"  At instruction address: {warning.Address}");
+                            }
+                        }
+                        else
+                        {
+                            result.AppendLine($"  At instruction address: {warning.Address}");
+                        }
+                    }
+
+                    result.AppendLine();
+                }
+
+                string output = result.ToString();
+                if (print)
+                    Console.Write(output);
+                return output;
+            }
+        }
+
+        public static SymbolicExecutionWarnings Analyze(NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
+        {
+            SymbolicExecutor executor = new();
+            SymbolicFindings findings = executor.Analyze(nef, manifest, debugInfo);
+            return new SymbolicExecutionWarnings(findings, debugInfo);
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_SymbolicSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_SecurityAnalyzer/Contract_SymbolicSecurity.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Contract_SymbolicSecurity.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+
+namespace Neo.Compiler.CSharp.TestContracts
+{
+    public class Contract_SymbolicSecurity : SmartContract.Framework.SmartContract
+    {
+        // Unguarded update should be flagged by symbolic execution analyzer.
+        public static void UnguardedUpdate(ByteString nefFile, string manifest)
+        {
+            ContractManagement.Update(nefFile, manifest, null);
+        }
+
+        // Verify entrypoint that writes storage should be flagged.
+        public static bool Verify()
+        {
+            Storage.Put("symbolic", "security");
+            return true;
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_SymbolicExecutionCore.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_SymbolicExecutionCore.cs
@@ -1,0 +1,292 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_SymbolicExecutionCore.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo;
+using Neo.Compiler.SecurityAnalyzer;
+using Neo.Compiler.SecurityAnalyzer.SymbolicExecution;
+using Neo.Json;
+using Neo.Optimizer;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+
+namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
+{
+    [TestClass]
+    public class UnitTest_SymbolicExecutionCore
+    {
+        [TestMethod]
+        public void Test_Conditional_Guarded_Update_Is_Not_Detected()
+        {
+            const string source = """
+                using Neo;
+                using Neo.SmartContract.Framework;
+                using Neo.SmartContract.Framework.Native;
+                using Neo.SmartContract.Framework.Services;
+
+                public class Contract : SmartContract
+                {
+                    public static void Main(UInt160 owner, ByteString nefFile, string manifest)
+                    {
+                        if (Runtime.CheckWitness(owner))
+                        {
+                            ContractManagement.Update(nefFile, manifest, null);
+                        }
+                    }
+                }
+                """;
+
+            var (context, warnings) = AnalyzeSource(source);
+
+            OpCode[] opcodes = ((Script)context.CreateExecutable().Script)
+                .EnumerateInstructions()
+                .Select(tuple => tuple.instruction.OpCode)
+                .ToArray();
+
+            Assert.IsTrue(opcodes.Any(opcode =>
+                opcode is OpCode.JMPIF or OpCode.JMPIFNOT or OpCode.JMPIF_L or OpCode.JMPIFNOT_L),
+                "Expected a conditional branch to exercise symbolic jump handling.");
+            Assert.IsFalse(warnings.HasUnguardedUpdate);
+            Assert.IsFalse(warnings.AnalysisIncomplete);
+        }
+
+        [TestMethod]
+        public void Test_Helper_Call_Unguarded_Destroy_Is_Detected()
+        {
+            const string source = """
+                using Neo.SmartContract.Framework;
+                using Neo.SmartContract.Framework.Native;
+
+                public class Contract : SmartContract
+                {
+                    public static void Main()
+                    {
+                        DestroyCore();
+                    }
+
+                    private static void DestroyCore()
+                    {
+                        ContractManagement.Destroy();
+                    }
+                }
+                """;
+
+            var (context, warnings) = AnalyzeSource(source);
+
+            OpCode[] opcodes = ((Script)context.CreateExecutable().Script)
+                .EnumerateInstructions()
+                .Select(tuple => tuple.instruction.OpCode)
+                .ToArray();
+
+            Assert.IsTrue(opcodes.Any(opcode => opcode is OpCode.CALL or OpCode.CALL_L),
+                "Expected a helper method call to exercise symbolic call/return tracking.");
+            Assert.IsTrue(warnings.HasUnguardedDestroy);
+        }
+
+        [TestMethod]
+        public void Test_AssertMessage_Guarded_Destroy_Is_Not_Detected()
+        {
+            const string source = """
+                using Neo;
+                using Neo.SmartContract.Framework;
+                using Neo.SmartContract.Framework.Native;
+                using Neo.SmartContract.Framework.Services;
+
+                public class Contract : SmartContract
+                {
+                    public static void Main(UInt160 owner)
+                    {
+                        ExecutionEngine.Assert(Runtime.CheckWitness(owner), "owner");
+                        ContractManagement.Destroy();
+                    }
+                }
+                """;
+
+            var (context, warnings) = AnalyzeSource(source);
+
+            OpCode[] opcodes = ((Script)context.CreateExecutable().Script)
+                .EnumerateInstructions()
+                .Select(tuple => tuple.instruction.OpCode)
+                .ToArray();
+
+            Assert.IsTrue(opcodes.Any(opcode => opcode is OpCode.JMPIF or OpCode.JMPIF_L));
+            Assert.IsTrue(opcodes.Contains(OpCode.ABORTMSG));
+            Assert.IsFalse(warnings.HasUnguardedDestroy);
+        }
+
+        [TestMethod]
+        public void Test_ContractCall_Update_And_Destroy_Are_Detected()
+        {
+            const string source = """
+                using Neo.SmartContract.Framework;
+                using Neo.SmartContract.Framework.Native;
+                using Neo.SmartContract.Framework.Services;
+
+                public class SymbolicContract : SmartContract
+                {
+                    public static void UpdateViaCall(ByteString nefFile, string manifest)
+                    {
+                        Neo.SmartContract.Framework.Services.Contract.Call(
+                            ContractManagement.Hash,
+                            "update",
+                            CallFlags.All,
+                            nefFile,
+                            manifest,
+                            null);
+                    }
+
+                    public static void DestroyViaCall()
+                    {
+                        Neo.SmartContract.Framework.Services.Contract.Call(
+                            ContractManagement.Hash,
+                            "destroy",
+                            CallFlags.All);
+                    }
+                }
+                """;
+
+            var (_, warnings) = AnalyzeSource(source);
+
+            Assert.IsTrue(warnings.HasUnguardedUpdate);
+            Assert.IsTrue(warnings.HasUnguardedDestroy);
+        }
+
+        [TestMethod]
+        public void Test_SymbolicValue_Conversions()
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes("update");
+            SymbolicValue textValue = SymbolicValue.FromByteString(utf8);
+
+            Assert.IsTrue(textValue.TryGetString(out string text));
+            Assert.AreEqual("update", text);
+            Assert.IsFalse(SymbolicValue.FromBoolean(true).TryGetString(out _));
+
+            byte[] hashBytes = Enumerable.Range(1, UInt160.Length).Select(i => (byte)i).ToArray();
+            SymbolicValue hashFromBytes = SymbolicValue.FromByteString(hashBytes);
+            Assert.IsTrue(hashFromBytes.TryGetUInt160(out UInt160 byteStringHash));
+            CollectionAssert.AreEqual(hashBytes, byteStringHash.GetSpan().ToArray());
+
+            SymbolicValue directHash = SymbolicValue.FromUInt160(UInt160.Zero);
+            Assert.IsTrue(directHash.TryGetUInt160(out UInt160 zeroHash));
+            Assert.AreEqual(UInt160.Zero, zeroHash);
+
+            SymbolicValue witnessArgument = SymbolicValue.FromInteger(BigInteger.One);
+            SymbolicValue witnessCheck = SymbolicValue.WitnessCheck(witnessArgument);
+            Assert.AreEqual(SymbolicValueKind.WitnessCheck, witnessCheck.Kind);
+            Assert.AreSame(witnessArgument, witnessCheck.WitnessArgument);
+
+            Assert.IsFalse(SymbolicValue.Unknown.TryGetUInt160(out _));
+        }
+
+        [TestMethod]
+        public void Test_SymbolicState_Clone_Is_Independent()
+        {
+            SymbolicState state = new("main", 5);
+
+            Assert.AreEqual(SymbolicValueKind.Unknown, state.Peek().Kind);
+            Assert.AreEqual(SymbolicValueKind.Unknown, state.Pop().Kind);
+
+            state.Push(SymbolicValue.FromBoolean(true));
+            state.PushReturn(9);
+            state.HasWitnessGuard = true;
+            state.BranchDepth = 2;
+
+            SymbolicState clone = state.Clone();
+            clone.Push(SymbolicValue.FromInteger(3));
+            clone.PushReturn(10);
+            clone.InstructionIndex = 7;
+            clone.HasWitnessGuard = false;
+            clone.BranchDepth = 4;
+
+            Assert.AreEqual(1, state.Stack.Count);
+            Assert.AreEqual(1, state.CallStack.Count);
+            Assert.AreEqual(5, state.InstructionIndex);
+            Assert.IsTrue(state.HasWitnessGuard);
+            Assert.AreEqual(2, state.BranchDepth);
+
+            Assert.IsTrue(state.TryPopReturn(out int returnIndex));
+            Assert.AreEqual(9, returnIndex);
+            Assert.IsFalse(state.TryPopReturn(out _));
+        }
+
+        [TestMethod]
+        public void Test_WarningInfo_Formats_Destroy_And_Incomplete_Warnings()
+        {
+            SymbolicFindings findings = new();
+            findings.RecordUnguardedUpdate("destroyNow", 42, isDestroy: true);
+            findings.MarkIncomplete();
+
+            var warnings = new SymbolicExecutionAnalyzer.SymbolicExecutionWarnings(findings, new JObject());
+            string output = warnings.GetWarningInfo();
+
+            Assert.IsTrue(output.Contains("unguarded contract destroy", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(output.Contains("At instruction address: 42", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(output.Contains("analysis was incomplete", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [TestMethod]
+        public void Test_WarningInfo_Without_Findings_Returns_Empty()
+        {
+            var warnings = new SymbolicExecutionAnalyzer.SymbolicExecutionWarnings(new SymbolicFindings(), null);
+            Assert.AreEqual(string.Empty, warnings.GetWarningInfo());
+        }
+
+        private static (CompilationContext Context, SymbolicExecutionAnalyzer.SymbolicExecutionWarnings Warnings) AnalyzeSource(string sourceCode)
+        {
+            CompilationContext context = CompileSingleContract(sourceCode);
+            var warnings = SymbolicExecutionAnalyzer.Analyze(
+                context.CreateExecutable(),
+                context.CreateManifest(),
+                debugInfo: null);
+            return (context, warnings);
+        }
+
+        private static CompilationContext CompileSingleContract(string sourceCode)
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+            File.WriteAllText(tempFile, sourceCode);
+
+            try
+            {
+                var options = new CompilationOptions
+                {
+                    Optimize = CompilationOptions.OptimizationType.None,
+                    Nullable = NullableContextOptions.Enable,
+                    SkipRestoreIfAssetsPresent = true
+                };
+
+                var engine = new CompilationEngine(options);
+                string repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+                string frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+                var contexts = engine.CompileSources(new CompilationSourceReferences
+                {
+                    Projects = new[] { frameworkProject }
+                }, tempFile);
+
+                Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+                Assert.IsTrue(contexts[0].Success, string.Join(Environment.NewLine, contexts[0].Diagnostics.Select(static d => d.ToString())));
+                return contexts[0];
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+            }
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_SymbolicSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_SymbolicSecurity.cs
@@ -11,7 +11,10 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.SecurityAnalyzer;
+using CompilerSecurityAnalyzer = Neo.Compiler.SecurityAnalyzer.SecurityAnalyzer;
 using Neo.SmartContract.Testing;
+using System;
+using System.IO;
 
 namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
 {
@@ -32,6 +35,35 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             var context = TestCleanup.EnsureArtifactUpToDateInternal(nameof(Contract_SymbolicSecurity));
             var warnings = SymbolicExecutionAnalyzer.Analyze(context.CreateExecutable(), context.CreateManifest(), context.CreateDebugInformation());
             Assert.IsTrue(warnings.HasVerifyStorageWrite);
+        }
+
+        [TestMethod]
+        public void Test_SecurityAnalyzer_Prints_Symbolic_Warnings()
+        {
+            var context = TestCleanup.EnsureArtifactUpToDateInternal(nameof(Contract_SymbolicSecurity));
+            string output = CaptureConsole(() => CompilerSecurityAnalyzer.AnalyzeWithPrint(
+                context.CreateExecutable(),
+                context.CreateManifest(),
+                context.CreateDebugInformation()));
+
+            Assert.IsTrue(output.Contains("Symbolic execution detected unguarded contract update", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(output.Contains("storage writes reachable from Verify", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string CaptureConsole(Action action)
+        {
+            var writer = new StringWriter();
+            TextWriter original = Console.Out;
+            try
+            {
+                Console.SetOut(writer);
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+            return writer.ToString();
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_SymbolicSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_SymbolicSecurity.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_SymbolicSecurity.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.SecurityAnalyzer;
+using Neo.SmartContract.Testing;
+
+namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
+{
+    [TestClass]
+    public class UnitTest_SymbolicSecurity
+    {
+        [TestMethod]
+        public void Test_Unguarded_Update_Is_Detected()
+        {
+            var context = TestCleanup.EnsureArtifactUpToDateInternal(nameof(Contract_SymbolicSecurity));
+            var warnings = SymbolicExecutionAnalyzer.Analyze(context.CreateExecutable(), context.CreateManifest(), context.CreateDebugInformation());
+            Assert.IsTrue(warnings.HasUnguardedUpdate);
+        }
+
+        [TestMethod]
+        public void Test_Verify_Write_Is_Detected()
+        {
+            var context = TestCleanup.EnsureArtifactUpToDateInternal(nameof(Contract_SymbolicSecurity));
+            var warnings = SymbolicExecutionAnalyzer.Analyze(context.CreateExecutable(), context.CreateManifest(), context.CreateDebugInformation());
+            Assert.IsTrue(warnings.HasVerifyStorageWrite);
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Abort.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Abort.cs
@@ -28,11 +28,12 @@ public abstract class Contract_Abort(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAEHA4
+    /// Script: VwEAEHA4VwEA
     /// INITSLOT 0100 [64 datoshi]
     /// PUSH0 [1 datoshi]
     /// STLOC0 [2 datoshi]
     /// ABORT [0 datoshi]
+    /// INITSLOT 0100 [64 datoshi]
     /// </remarks>
     [DisplayName("testAbort")]
     public abstract BigInteger? TestAbort();
@@ -41,7 +42,7 @@ public abstract class Contract_Abort(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIBEHA7ERkRcAwJZXhjZXB0aW9uOnF4JgQ0sDSoEnA/
+    /// Script: VwIBEHA7ERkRcAwJZXhjZXB0aW9uOnF4JgQ0sDSoEnA/VwIB
     /// INITSLOT 0201 [64 datoshi]
     /// PUSH0 [1 datoshi]
     /// STLOC0 [2 datoshi]
@@ -58,6 +59,7 @@ public abstract class Contract_Abort(Neo.SmartContract.Testing.SmartContractInit
     /// PUSH2 [1 datoshi]
     /// STLOC0 [2 datoshi]
     /// ENDFINALLY [4 datoshi]
+    /// INITSLOT 0201 [64 datoshi]
     /// </remarks>
     [DisplayName("testAbortInCatch")]
     public abstract BigInteger? TestAbortInCatch(bool? abortMsg);
@@ -90,7 +92,7 @@ public abstract class Contract_Abort(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBEHB4JgQ05zTf
+    /// Script: VwEBEHB4JgQ05zTfVwIB
     /// INITSLOT 0101 [64 datoshi]
     /// PUSH0 [1 datoshi]
     /// STLOC0 [2 datoshi]
@@ -98,6 +100,7 @@ public abstract class Contract_Abort(Neo.SmartContract.Testing.SmartContractInit
     /// JMPIFNOT 04 [2 datoshi]
     /// CALL E7 [512 datoshi]
     /// CALL DF [512 datoshi]
+    /// INITSLOT 0201 [64 datoshi]
     /// </remarks>
     [DisplayName("testAbortInFunction")]
     public abstract BigInteger? TestAbortInFunction(bool? abortMsg);
@@ -132,12 +135,13 @@ public abstract class Contract_Abort(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAEHAMCUFCT1JUIE1TR+A=
+    /// Script: VwEAEHAMCUFCT1JUIE1TR+BXAQE=
     /// INITSLOT 0100 [64 datoshi]
     /// PUSH0 [1 datoshi]
     /// STLOC0 [2 datoshi]
     /// PUSHDATA1 41424F5254204D5347 [8 datoshi]
     /// ABORTMSG [0 datoshi]
+    /// INITSLOT 0101 [64 datoshi]
     /// </remarks>
     [DisplayName("testAbortMsg")]
     public abstract BigInteger? TestAbortMsg();

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Enum.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Enum.cs
@@ -28,7 +28,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeEoRlyYMRQwGVmFsdWUxQEoSlyYMRQwGVmFsdWUyQEoTlyYMRQwGVmFsdWUzQEULQA==
+    /// Script: VwABeEoRlyYMRQwGVmFsdWUxQEoSlyYMRQwGVmFsdWUyQEoTlyYMRQwGVmFsdWUzQEULQFcAAQ==
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
@@ -55,6 +55,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// DROP [2 datoshi]
     /// PUSHNULL [1 datoshi]
     /// RET [0 datoshi]
+    /// INITSLOT 0001 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumGetName")]
     public abstract string? TestEnumGetName(BigInteger? value);
@@ -63,7 +64,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DAhUZXN0RW51bQwGVmFsdWUzDAZWYWx1ZTIMBlZhbHVlMRPAQA==
+    /// Script: DAhUZXN0RW51bQwGVmFsdWUzDAZWYWx1ZTIMBlZhbHVlMRPAQAwIVGVzdEVudW0=
     /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// PUSHDATA1 56616C756533 'Value3' [8 datoshi]
     /// PUSHDATA1 56616C756532 'Value2' [8 datoshi]
@@ -71,6 +72,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// PUSH3 [1 datoshi]
     /// PACK [2048 datoshi]
     /// RET [0 datoshi]
+    /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// </remarks>
     [DisplayName("testEnumGetNames")]
     public abstract IList<object>? TestEnumGetNames();
@@ -94,7 +96,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABDAhUZXN0RW51bXhKEZcmDUVFDAZWYWx1ZTFAShKXJg1FRQwGVmFsdWUyQEoTlyYNRUUMBlZhbHVlM0BFRQtA
+    /// Script: VwABDAhUZXN0RW51bXhKEZcmDUVFDAZWYWx1ZTFAShKXJg1FRQwGVmFsdWUyQEoTlyYNRUUMBlZhbHVlM0BFRQtAVwEC
     /// INITSLOT 0001 [64 datoshi]
     /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// LDARG0 [2 datoshi]
@@ -126,6 +128,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// DROP [2 datoshi]
     /// PUSHNULL [1 datoshi]
     /// RET [0 datoshi]
+    /// INITSLOT 0102 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumGetNameWithType")]
     public abstract string? TestEnumGetNameWithType(object? value = null);
@@ -134,7 +137,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DAhUZXN0RW51bRMSERPAQA==
+    /// Script: DAhUZXN0RW51bRMSERPAQFcAAQ==
     /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// PUSH3 [1 datoshi]
     /// PUSH2 [1 datoshi]
@@ -142,6 +145,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// PUSH3 [1 datoshi]
     /// PACK [2048 datoshi]
     /// RET [0 datoshi]
+    /// INITSLOT 0001 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumGetValues")]
     public abstract IList<object>? TestEnumGetValues();
@@ -263,7 +267,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABDAhUZXN0RW51bXhKDAZWYWx1ZTGXJgcRU0VFQEoMBlZhbHVlMpcmBxJTRUVASgwGVmFsdWUzlyYHE1NFRUBFDBJObyBzdWNoIGVudW0gdmFsdWU6
+    /// Script: VwABDAhUZXN0RW51bXhKDAZWYWx1ZTGXJgcRU0VFQEoMBlZhbHVlMpcmBxJTRUVASgwGVmFsdWUzlyYHE1NFRUBFDBJObyBzdWNoIGVudW0gdmFsdWU6VwAC
     /// INITSLOT 0001 [64 datoshi]
     /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// LDARG0 [2 datoshi]
@@ -297,6 +301,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// DROP [2 datoshi]
     /// PUSHDATA1 4E6F207375636820656E756D2076616C7565 [8 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0002 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumParse")]
     public abstract object? TestEnumParse(string? value);
@@ -305,7 +310,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBCXg0R3BoDAZWYWx1ZTGXJgQRQGgMBlZhbHVlMpcmBBJAaAwGVmFsdWUzlyYEE0AIJhcMEk5vIHN1Y2ggZW51bSB2YWx1ZTpoOg==
+    /// Script: VwEBCXg0R3BoDAZWYWx1ZTGXJgQRQGgMBlZhbHVlMpcmBBJAaAwGVmFsdWUzlyYEE0AIJhcMEk5vIHN1Y2ggZW51bSB2YWx1ZTpoOlcAAg==
     /// INITSLOT 0101 [64 datoshi]
     /// PUSHF [1 datoshi]
     /// LDARG0 [2 datoshi]
@@ -335,6 +340,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// THROW [512 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0002 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumParseGeneric")]
     public abstract BigInteger? TestEnumParseGeneric(string? value);
@@ -343,7 +349,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwICeXg0xnBocWkMBlZBTFVFMZcmBBFAaQwGVkFMVUUylyYEEkBpDAZWQUxVRTOXJgQTQGkMBlZhbHVlMZcmBBFAaQwGVmFsdWUylyYEEkBpDAZWYWx1ZTOXJgQTQAgmFwwSTm8gc3VjaCBlbnVtIHZhbHVlOmk6
+    /// Script: VwICeXg0xnBocWkMBlZBTFVFMZcmBBFAaQwGVkFMVUUylyYEEkBpDAZWQUxVRTOXJgQTQGkMBlZhbHVlMZcmBBFAaQwGVmFsdWUylyYEEkBpDAZWYWx1ZTOXJgQTQAgmFwwSTm8gc3VjaCBlbnVtIHZhbHVlOmk6VwEB
     /// INITSLOT 0202 [64 datoshi]
     /// LDARG1 [2 datoshi]
     /// LDARG0 [2 datoshi]
@@ -393,6 +399,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// THROW [512 datoshi]
     /// LDLOC1 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0101 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumParseGenericIgnoreCase")]
     public abstract BigInteger? TestEnumParseGenericIgnoreCase(string? value, bool? ignoreCase);
@@ -401,7 +408,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwACDAhUZXN0RW51bXh5Ji4MABBKeMq1JiJKeFDOSgBhAHu7JAlRUItQnCLpAGGfAEGeUVCLUJwi3EXbKEp5JjQMBlZBTFVFMZcmB0VFRRFASnkmIAwGVkFMVUUylyYHRUVFEkBKeSYMDAZWQUxVRTMiCgwGVmFsdWUzlyYHRUVFE0BFRQwSTm8gc3VjaCBlbnVtIHZhbHVlOg==
+    /// Script: VwACDAhUZXN0RW51bXh5Ji4MABBKeMq1JiJKeFDOSgBhAHu7JAlRUItQnCLpAGGfAEGeUVCLUJwi3EXbKEp5JjQMBlZBTFVFMZcmB0VFRRFASnkmIAwGVkFMVUUylyYHRUVFEkBKeSYMDAZWQUxVRTMiCgwGVmFsdWUzlyYHRUVFE0BFRQwSTm8gc3VjaCBlbnVtIHZhbHVlOlcAAQ==
     /// INITSLOT 0002 [64 datoshi]
     /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// LDARG0 [2 datoshi]
@@ -480,6 +487,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// DROP [2 datoshi]
     /// PUSHDATA1 4E6F207375636820656E756D2076616C7565 [8 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0001 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumParseIgnoreCase")]
     public abstract object? TestEnumParseIgnoreCase(string? value, bool? ignoreCase);
@@ -608,7 +616,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBCXg1Tv///3BoDAZWYWx1ZTGXJgQIQGgMBlZhbHVlMpcmBAhAaAwGVmFsdWUzlyYECEAIJgQJQGg6
+    /// Script: VwEBCXg1Tv///3BoDAZWYWx1ZTGXJgQIQGgMBlZhbHVlMpcmBAhAaAwGVmFsdWUzlyYECEAIJgQJQGg6VwIC
     /// INITSLOT 0101 [64 datoshi]
     /// PUSHF [1 datoshi]
     /// LDARG0 [2 datoshi]
@@ -638,6 +646,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// RET [0 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0202 [64 datoshi]
     /// </remarks>
     [DisplayName("testEnumTryParseGeneric")]
     public abstract bool? TestEnumTryParseGeneric(string? value);
@@ -646,7 +655,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwICeXg1Ev///3BocWkMBlZBTFVFMZcmBAhAaQwGVkFMVUUylyYECEBpDAZWQUxVRTOXJgQIQGkMBlZhbHVlMZcmBAhAaQwGVmFsdWUylyYECEBpDAZWYWx1ZTOXJgQIQAgmBAlAaTo=
+    /// Script: VwICeXg1Ev///3BocWkMBlZBTFVFMZcmBAhAaQwGVkFMVUUylyYECEBpDAZWQUxVRTOXJgQIQGkMBlZhbHVlMZcmBAhAaQwGVmFsdWUylyYECEBpDAZWYWx1ZTOXJgQIQAgmBAlAaToT
     /// INITSLOT 0202 [64 datoshi]
     /// LDARG1 [2 datoshi]
     /// LDARG0 [2 datoshi]
@@ -696,6 +705,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// RET [0 datoshi]
     /// LDLOC1 [2 datoshi]
     /// THROW [512 datoshi]
+    /// PUSH3 [1 datoshi]
     /// </remarks>
     [DisplayName("testEnumTryParseGenericIgnoreCase")]
     public abstract bool? TestEnumTryParseGenericIgnoreCase(string? value, bool? ignoreCase);
@@ -704,7 +714,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwACDAhUZXN0RW51bXh5C2MmMFBFDAAQSnjKtSYiSnhQzkoAYQB7uyQJUVCLUJwi6QBhnwBBnlFQi1CcItxF2yhKeSY2DAZWQUxVRTGXJghFRRFiCEBKeSYhDAZWQUxVRTKXJghFRRJiCEBKeSYMDAZWQUxVRTMiCgwGVmFsdWUzlyYIRUUTYghARUUQYglA
+    /// Script: VwACDAhUZXN0RW51bXh5C2MmMFBFDAAQSnjKtSYiSnhQzkoAYQB7uyQJUVCLUJwi6QBhnwBBnlFQi1CcItxF2yhKeSY2DAZWQUxVRTGXJghFRRFiCEBKeSYhDAZWQUxVRTKXJghFRRJiCEBKeSYMDAZWQUxVRTMiCgwGVmFsdWUzlyYIRUUTYghARUUQYglADAhUZXN0RW51bQ==
     /// INITSLOT 0002 [64 datoshi]
     /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// LDARG0 [2 datoshi]
@@ -792,6 +802,7 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// STSFLD2 [2 datoshi]
     /// PUSHF [1 datoshi]
     /// RET [0 datoshi]
+    /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// </remarks>
     [DisplayName("testEnumTryParseIgnoreCase")]
     public abstract bool? TestEnumTryParseIgnoreCase(string? value, bool? ignoreCase);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_GoTo.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_GoTo.cs
@@ -28,7 +28,7 @@ public abstract class Contract_GoTo(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAEXBoSpxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcEVoE5cmymhA
+    /// Script: VwEAEXBoSpxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcEVoE5cmymhAVwIA
     /// INITSLOT 0100 [64 datoshi]
     /// PUSH1 [1 datoshi]
     /// STLOC0 [2 datoshi]
@@ -57,6 +57,7 @@ public abstract class Contract_GoTo(Neo.SmartContract.Testing.SmartContractIniti
     /// JMPIFNOT CA [2 datoshi]
     /// LDLOC0 [2 datoshi]
     /// RET [0 datoshi]
+    /// INITSLOT 0200 [64 datoshi]
     /// </remarks>
     [DisplayName("test")]
     public abstract BigInteger? Test();

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Inline.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Inline.cs
@@ -68,7 +68,7 @@ public abstract class Contract_Inline(Neo.SmartContract.Testing.SmartContractIni
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeHBoDAZpbmxpbmWXJgQRQGgMGmlubGluZV93aXRoX29uZV9wYXJhbWV0ZXJzlyYEE0BoDBxpbmxpbmVfd2l0aF9tdWx0aV9wYXJhbWV0ZXJzlyY0E5ycSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BoDApub3RfaW5saW5llyYFNHRAaAwebm90X2lubGluZV93aXRoX29uZV9wYXJhbWV0ZXJzlyYGEzROQGgMIG5vdF9pbmxpbmVfd2l0aF9tdWx0aV9wYXJhbWV0ZXJzlyYHExI0KEBoDA1pbmxpbmVfbmVzdGVklyYFNEdACCYFAGNAaDo=
+    /// Script: VwEBeHBoDAZpbmxpbmWXJgQRQGgMGmlubGluZV93aXRoX29uZV9wYXJhbWV0ZXJzlyYEE0BoDBxpbmxpbmVfd2l0aF9tdWx0aV9wYXJhbWV0ZXJzlyY0E5ycSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BoDApub3RfaW5saW5llyYFNHRAaAwebm90X2lubGluZV93aXRoX29uZV9wYXJhbWV0ZXJzlyYGEzROQGgMIG5vdF9pbmxpbmVfd2l0aF9tdWx0aV9wYXJhbWV0ZXJzlyYHExI0KEBoDA1pbmxpbmVfbmVzdGVklyYFNEdACCYFAGNAaDoR
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// STLOC0 [2 datoshi]
@@ -139,6 +139,7 @@ public abstract class Contract_Inline(Neo.SmartContract.Testing.SmartContractIni
     /// RET [0 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// PUSH1 [1 datoshi]
     /// </remarks>
     [DisplayName("testInline")]
     public abstract BigInteger? TestInline(string? method);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Pattern.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Pattern.cs
@@ -72,7 +72,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeHBoEbckBQkiBmgAMrUmBAhAaAAyuCQFCSIGaABktSYECEAIJgQJQGg6
+    /// Script: VwEBeHBoEbckBQkiBmgAMrUmBAhAaAAyuCQFCSIGaABktSYECEAIJgQJQGg6VwIA
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// STLOC0 [2 datoshi]
@@ -106,6 +106,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// RET [0 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0200 [64 datoshi]
     /// </remarks>
     [DisplayName("between3")]
     public abstract bool? Between3(BigInteger? value);
@@ -130,7 +131,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeHBoANi1JgwMB1RvbyBsb3dAaADYuCQFCSIFaBC1JggMA0xvd0BoELgkBQkiBWgatSYPDApBY2NlcHRhYmxlQGgauCQFCSIGaAAUtSYJDARIaWdoQGgAFLgmDQwIVG9vIGhpZ2hAaDo=
+    /// Script: VwEBeHBoANi1JgwMB1RvbyBsb3dAaADYuCQFCSIFaBC1JggMA0xvd0BoELgkBQkiBWgatSYPDApBY2NlcHRhYmxlQGgauCQFCSIGaAAUtSYJDARIaWdoQGgAFLgmDQwIVG9vIGhpZ2hAaDpXAQE=
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// STLOC0 [2 datoshi]
@@ -184,6 +185,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// RET [0 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0101 [64 datoshi]
     /// </remarks>
     [DisplayName("classify")]
     public abstract string? Classify(BigInteger? measurement);
@@ -192,7 +194,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeHBoE5cmBQgiBWgUlyYFCCIFaBWXJgsMBnNwcmluZ0BoFpcmBQgiBWgXlyYFCCIFaBiXJgsMBnN1bW1lckBoGZcmBQgiBWgalyYFCCIFaBuXJgsMBmF1dHVtbkBoHJcmBQgiBWgRlyYFCCIFaBKXJgsMBndpbnRlckAIJiIMElVuZXhwZWN0ZWQgbW9udGg6IHg3AACLDAEui9soOmg6
+    /// Script: VwEBeHBoE5cmBQgiBWgUlyYFCCIFaBWXJgsMBnNwcmluZ0BoFpcmBQgiBWgXlyYFCCIFaBiXJgsMBnN1bW1lckBoGZcmBQgiBWgalyYFCCIFaBuXJgsMBmF1dHVtbkBoHJcmBQgiBWgRlyYFCCIFaBKXJgsMBndpbnRlckAIJiIMElVuZXhwZWN0ZWQgbW9udGg6IHg3AACLDAEui9soOmg6VwQA
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// STLOC0 [2 datoshi]
@@ -280,6 +282,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// THROW [512 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0400 [64 datoshi]
     /// </remarks>
     [DisplayName("getCalendarSeason")]
     public abstract string? GetCalendarSeason(BigInteger? month);
@@ -337,7 +340,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIADBQAAAAAAAAAAAAAAAAAAAAAAAAAAHBocWlK2SgkBkUJIgbKABSzCJckBQkiB2mxqgiXJgQIQAgmBAlAaTo=
+    /// Script: VwIADBQAAAAAAAAAAAAAAAAAAAAAAAAAAHBocWlK2SgkBkUJIgbKABSzCJckBQkiB2mxqgiXJgQIQAgmBAlAaTpXAgA=
     /// INITSLOT 0200 [64 datoshi]
     /// PUSHDATA1 0000000000000000000000000000000000000000 [8 datoshi]
     /// STLOC0 [2 datoshi]
@@ -372,6 +375,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// RET [0 datoshi]
     /// LDLOC1 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0200 [64 datoshi]
     /// </remarks>
     [DisplayName("testRecursivePattern")]
     public abstract bool? TestRecursivePattern();
@@ -380,7 +384,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIACQkSwAkIEk00H3BocWkQzgiXJAUJIgdpEc4JlyYECEAIJgQJQGk6
+    /// Script: VwIACQkSwAkIEk00H3BocWkQzgiXJAUJIgdpEc4JlyYECEAIJgQJQGk6VwAD
     /// INITSLOT 0200 [64 datoshi]
     /// PUSHF [1 datoshi]
     /// PUSHF [1 datoshi]
@@ -416,6 +420,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// RET [0 datoshi]
     /// LDLOC1 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0003 [64 datoshi]
     /// </remarks>
     [DisplayName("testRecursivePatternAllMatch")]
     public abstract bool? TestRecursivePatternAllMatch();
@@ -468,7 +473,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIACQkSwAgIEk0043BocWkQzgiXJAUJIgdpEc4JlyYECEAIJgQJQGk6
+    /// Script: VwIACQkSwAgIEk0043BocWkQzgiXJAUJIgdpEc4JlyYECEAIJgQJQGk6VwIA
     /// INITSLOT 0200 [64 datoshi]
     /// PUSHF [1 datoshi]
     /// PUSHF [1 datoshi]
@@ -504,6 +509,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// RET [0 datoshi]
     /// LDLOC1 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0200 [64 datoshi]
     /// </remarks>
     [DisplayName("testRecursivePatternSecondMismatch")]
     public abstract bool? TestRecursivePatternSecondMismatch();
@@ -512,7 +518,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIAwnBocWk0FwiXJAUJIgVpNBImBAhACCYECUBpOg==
+    /// Script: VwIAwnBocWk0FwiXJAUJIgVpNBImBAhACCYECUBpOlcAAQ==
     /// INITSLOT 0200 [64 datoshi]
     /// NEWARRAY0 [16 datoshi]
     /// STLOC0 [2 datoshi]
@@ -536,6 +542,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// RET [0 datoshi]
     /// LDLOC1 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0001 [64 datoshi]
     /// </remarks>
     [DisplayName("testRecursivePatternShortCircuitOnFirstMismatch")]
     public abstract bool? TestRecursivePatternShortCircuitOnFirstMismatch();
@@ -544,7 +551,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeHBo2TAmA0Bo2SgmA0Bo2SBFQA==
+    /// Script: VwEBeHBo2TAmA0Bo2SgmA0Bo2SBFQFcBAQ==
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// STLOC0 [2 datoshi]
@@ -560,6 +567,7 @@ public abstract class Contract_Pattern(Neo.SmartContract.Testing.SmartContractIn
     /// ISTYPE 20 'Boolean' [2 datoshi]
     /// DROP [2 datoshi]
     /// RET [0 datoshi]
+    /// INITSLOT 0101 [64 datoshi]
     /// </remarks>
     [DisplayName("testTypePattern")]
     public abstract void TestTypePattern(object? o1 = null);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Switch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Switch.cs
@@ -79,7 +79,7 @@ public abstract class Contract_Switch(Neo.SmartContract.Testing.SmartContractIni
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeHBoDAEwlyYEEUBoDAExlyYEEkBoDAEylyYEE0BoDAEzlyYEFEBoDAE0lyYEFUBoDAE1lyYEFkAIJgUAY0BoOg==
+    /// Script: VwEBeHBoDAEwlyYEEUBoDAExlyYEEkBoDAEylyYEE0BoDAEzlyYEFEBoDAE0lyYEFUBoDAE1lyYEFkAIJgUAY0BoOlcCAQ==
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// STLOC0 [2 datoshi]
@@ -125,6 +125,7 @@ public abstract class Contract_Switch(Neo.SmartContract.Testing.SmartContractIni
     /// RET [0 datoshi]
     /// LDLOC0 [2 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0201 [64 datoshi]
     /// </remarks>
     [DisplayName("switch6Inline")]
     public abstract object? Switch6Inline(string? method);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_SymbolicSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_SymbolicSecurity.cs
@@ -1,10 +1,57 @@
-using Neo.SmartContract.Manifest;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Numerics;
+
+#pragma warning disable CS0067
 
 namespace Neo.SmartContract.Testing;
 
 public abstract class Contract_SymbolicSecurity(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), IContractInfo
 {
-    public static Neo.SmartContract.NefFile Nef => throw new NotImplementedException();
-    public static ContractManifest Manifest => throw new NotImplementedException();
+    #region Compiled data
+
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_SymbolicSecurity"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unguardedUpdate"",""parameters"":[{""name"":""nefFile"",""type"":""ByteArray""},{""name"":""manifest"",""type"":""String""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""verify"",""parameters"":[],""returntype"":""Boolean"",""offset"":10,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xfffdc93764dbaddd97c48f252a53ea4643faa3fd"",""methods"":[""update""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+
+    /// <summary>
+    /// Optimization: "All"
+    /// </summary>
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH9o/pDRupTKiWPxJfdrdtkN8n9/wZ1cGRhdGUDAAAPAAAlVwACC3l4NwAAQAwIc2VjdXJpdHkMCHN5bWJvbGljQTkM4woIQB117b4=").AsSerializable<Neo.SmartContract.NefFile>();
+
+    #endregion
+
+    #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACC3l4NwAAQA==
+    /// INITSLOT 0002 [64 datoshi]
+    /// PUSHNULL [1 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALLT 0000 [32768 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("unguardedUpdate")]
+    public abstract void UnguardedUpdate(byte[]? nefFile, string? manifest);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: DAhzZWN1cml0eQwIc3ltYm9saWNBOQzjCghA
+    /// PUSHDATA1 7365637572697479 'security' [8 datoshi]
+    /// PUSHDATA1 73796D626F6C6963 'symbolic' [8 datoshi]
+    /// SYSCALL 390CE30A 'System.Storage.Local.Put' [32768 datoshi]
+    /// PUSHT [1 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("verify")]
+    public abstract bool? Verify();
+
+    #endregion
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_SymbolicSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_SymbolicSecurity.cs
@@ -1,0 +1,10 @@
+using Neo.SmartContract.Manifest;
+using System;
+
+namespace Neo.SmartContract.Testing;
+
+public abstract class Contract_SymbolicSecurity(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), IContractInfo
+{
+    public static Neo.SmartContract.NefFile Nef => throw new NotImplementedException();
+    public static ContractManifest Manifest => throw new NotImplementedException();
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_TryCatch.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_TryCatch.cs
@@ -52,9 +52,10 @@ public abstract class Contract_TryCatch(Neo.SmartContract.Testing.SmartContractI
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DAlleGNlcHRpb246
+    /// Script: DAlleGNlcHRpb246VwIE
     /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
     /// THROW [512 datoshi]
+    /// INITSLOT 0204 [64 datoshi]
     /// </remarks>
     [DisplayName("throwCall")]
     public abstract object? ThrowCall();

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_WriteInTry.cs
@@ -149,7 +149,7 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwIAOxw2OwoNNdL+//89AHA9AAwJZXhjZXB0aW9uOnA7Cg01uP7//z0AcT0ADAlleGNlcHRpb246OA==
+    /// Script: VwIAOxw2OwoNNdL+//89AHA9AAwJZXhjZXB0aW9uOnA7Cg01uP7//z0AcT0ADAlleGNlcHRpb246OFcBAQ==
     /// INITSLOT 0200 [64 datoshi]
     /// TRY 1C36 [4 datoshi]
     /// TRY 0A0D [4 datoshi]
@@ -168,6 +168,7 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
     /// THROW [512 datoshi]
     /// ABORT [0 datoshi]
+    /// INITSLOT 0101 [64 datoshi]
     /// </remarks>
     [DisplayName("safeTryWithCatchWithThrowInFinally")]
     public abstract void SafeTryWithCatchWithThrowInFinally();
@@ -176,7 +177,7 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAOx0ANOcMFXRocm93IGluIFRyeVdyaXRlIHRyeTpwOwAfNNMMF3Rocm93IGluIFRyeVdyaXRlIGNhdGNoOj8=
+    /// Script: VwEAOx0ANOcMFXRocm93IGluIFRyeVdyaXRlIHRyeTpwOwAfNNMMF3Rocm93IGluIFRyeVdyaXRlIGNhdGNoOj9XAQA=
     /// INITSLOT 0100 [64 datoshi]
     /// TRY 1D00 [4 datoshi]
     /// CALL E7 [512 datoshi]
@@ -188,6 +189,7 @@ public abstract class Contract_WriteInTry(Neo.SmartContract.Testing.SmartContrac
     /// PUSHDATA1 7468726F7720696E205472795772697465206361746368 [8 datoshi]
     /// THROW [512 datoshi]
     /// ENDFINALLY [4 datoshi]
+    /// INITSLOT 0100 [64 datoshi]
     /// </remarks>
     [DisplayName("tryWrite")]
     public abstract void TryWrite();

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_GuardHelpers_Inline.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_GuardHelpers_Inline.cs
@@ -209,9 +209,10 @@ public abstract class Contract_GuardHelpers_Inline(Neo.SmartContract.Testing.Sma
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DAhSRVZFUlRFRDU//v//
+    /// Script: DAhSRVZFUlRFRDU//v//VwAD
     /// PUSHDATA1 5245564552544544 'REVERTED' [8 datoshi]
     /// CALL_L 3FFEFFFF [512 datoshi]
+    /// INITSLOT 0003 [64 datoshi]
     /// </remarks>
     [DisplayName("testRevert")]
     public abstract void TestRevert();


### PR DESCRIPTION
## Summary
- add a NeoVM-level symbolic execution analyzer to the compiler security pipeline
- flag unguarded contract update and destroy paths plus storage writes reachable from `Verify`
- add dedicated symbolic security contracts, unit tests, and refreshed testing artifact output for the new analyzer

## Context
- first implementation slice for the `Security: CheckWitness data-flow analysis` roadmap item from #1514
- based on the latest `master-n3`

## Test Plan
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_SymbolicSecurity
