### PR TITLE
refactor(compiler): extract temporary project workspace from CompilationEngine

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -41,11 +41,7 @@ namespace Neo.Compiler
         private string? ProjectVersionSuffix;
         internal readonly ConcurrentDictionary<INamedTypeSymbol, CompilationContext> Contexts = new(SymbolEqualityComparer.Default);
         private readonly Lock tempProjectLock = new();
-        private string? tempProjectDirectory;
-        private string? tempProjectPath;
-        private string? tempProjectNuGetConfig;
-        private string? tempProjectReferencesKey;
-        private bool tempProjectCleanupRegistered;
+        private readonly TemporaryProjectWorkspace _temporaryProjectWorkspace = new();
 
         /// <summary>
         /// Gets the version that was extracted from the project
@@ -169,211 +165,31 @@ namespace Neo.Compiler
 
             lock (tempProjectLock)
             {
-                var referencesKey = BuildReferencesKey(references);
                 if (Options.SkipRestoreIfAssetsPresent)
                 {
-                    EnsurePersistentTempProject(referencesKey);
+                    _temporaryProjectWorkspace.EnsurePersistent(TemporaryProjectWorkspace.BuildReferencesKey(references));
                 }
                 else
                 {
-                    PrepareTransientTempProject();
+                    _temporaryProjectWorkspace.PrepareTransient();
                 }
 
-                WriteTempProject(references, sourceFiles);
+                _temporaryProjectWorkspace.WriteProject(references, sourceFiles);
 
                 Compilation = null;
                 try
                 {
-                    return CompileProject(tempProjectPath!);
+                    return CompileProject(_temporaryProjectWorkspace.ProjectPath);
                 }
                 finally
                 {
                     if (!Options.SkipRestoreIfAssetsPresent)
                     {
-                        CleanupTempProjectDirectory();
+                        _temporaryProjectWorkspace.Cleanup();
                     }
                 }
             }
         }
-
-        private void PrepareTransientTempProject()
-        {
-            CleanupTempProjectDirectory();
-            tempProjectDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(tempProjectDirectory);
-            tempProjectPath = Path.Combine(tempProjectDirectory, "TempProject.csproj");
-            tempProjectNuGetConfig = Path.Combine(tempProjectDirectory, "nuget.config");
-            WriteNuGetConfig(tempProjectNuGetConfig);
-            tempProjectReferencesKey = null;
-        }
-
-        private void EnsurePersistentTempProject(string referencesKey)
-        {
-            var directoryExists = tempProjectDirectory is not null && Directory.Exists(tempProjectDirectory);
-            if (!directoryExists || tempProjectReferencesKey != referencesKey)
-            {
-                CleanupTempProjectDirectory();
-                tempProjectDirectory = Path.Combine(Path.GetTempPath(), "Neo.Compiler", "CompileSources", Guid.NewGuid().ToString("N"));
-                Directory.CreateDirectory(tempProjectDirectory);
-                tempProjectPath = Path.Combine(tempProjectDirectory, "TempProject.csproj");
-                tempProjectNuGetConfig = Path.Combine(tempProjectDirectory, "nuget.config");
-                WriteNuGetConfig(tempProjectNuGetConfig);
-                tempProjectReferencesKey = referencesKey;
-                RegisterTempProjectCleanup();
-            }
-        }
-
-        private void WriteTempProject(CompilationSourceReferences references, string[] sourceFiles)
-        {
-            if (tempProjectDirectory is null)
-            {
-                throw new InvalidOperationException("Temporary project directory must be initialized before writing the project file.");
-            }
-
-            tempProjectPath ??= Path.Combine(tempProjectDirectory, "TempProject.csproj");
-            tempProjectNuGetConfig ??= Path.Combine(tempProjectDirectory, "nuget.config");
-
-            var csproj = BuildTempProjectContent(references, sourceFiles);
-            File.WriteAllText(tempProjectPath, csproj);
-
-            if (!File.Exists(tempProjectNuGetConfig))
-            {
-                WriteNuGetConfig(tempProjectNuGetConfig);
-            }
-        }
-
-        private static string BuildTempProjectContent(CompilationSourceReferences references, string[] sourceFiles)
-        {
-            var packages = references.Packages;
-            var packageGroup = packages is null || packages.Length == 0
-                ? string.Empty
-                : $@"
-    <ItemGroup>
-        {string.Join(Environment.NewLine, packages.Select(u => $" <PackageReference Include =\"{u.packageName}\" Version=\"{u.packageVersion}\" />"))}
-    </ItemGroup>";
-
-            var projects = references.Projects;
-            var projectsGroup = projects is null || projects.Length == 0
-                ? string.Empty
-                : $@"
-    <ItemGroup>
-        {string.Join(Environment.NewLine, projects.Select(u => $" <ProjectReference Include =\"{u}\"/>"))}
-    </ItemGroup>";
-
-            return $@"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-    <PropertyGroup>
-        <TargetFramework>{GetTargetFrameworkMoniker()}</TargetFramework>
-        <LangVersion>preview</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
-
-    <!-- Remove all Compile items from compilation -->
-    <ItemGroup>
-        <Compile Remove=""*.cs"" />
-    </ItemGroup>
-
-    <!-- Add specific files for compilation -->
-    <ItemGroup>
-        {string.Join(Environment.NewLine, sourceFiles.Select(u => $"<Compile Include=\"{Path.GetFullPath(u)}\" />"))}
-    </ItemGroup>
-
-    {packageGroup}
-    {projectsGroup}
-
-</Project>";
-        }
-
-        private void WriteNuGetConfig(string nugetConfigPath)
-        {
-            const string nugetConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
-  </packageSources>
-</configuration>";
-
-            File.WriteAllText(nugetConfigPath, nugetConfigContent);
-        }
-
-        private static string BuildReferencesKey(CompilationSourceReferences references)
-        {
-            var builder = new StringBuilder();
-
-            if (references.Packages is { Length: > 0 })
-            {
-                foreach (var (packageName, packageVersion) in references.Packages
-                             .OrderBy(p => p.packageName, StringComparer.Ordinal))
-                {
-                    builder.Append("pkg:")
-                        .Append(packageName)
-                        .Append('@')
-                        .Append(packageVersion)
-                        .Append(';');
-                }
-            }
-
-            builder.Append('|');
-
-            if (references.Projects is { Length: > 0 })
-            {
-                foreach (var project in references.Projects
-                             .Select(p => Path.GetFullPath(p))
-                             .OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
-                {
-                    builder.Append("proj:")
-                        .Append(project)
-                        .Append(';');
-                }
-            }
-
-            return builder.ToString();
-        }
-
-        private void RegisterTempProjectCleanup()
-        {
-            if (tempProjectCleanupRegistered)
-            {
-                return;
-            }
-
-            tempProjectCleanupRegistered = true;
-            AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupTempProjectDirectory();
-        }
-
-        private void CleanupTempProjectDirectory()
-        {
-            if (tempProjectDirectory is null)
-            {
-                return;
-            }
-
-            try
-            {
-                if (Directory.Exists(tempProjectDirectory))
-                {
-                    Directory.Delete(tempProjectDirectory, true);
-                }
-            }
-            catch (IOException)
-            {
-                // Best-effort cleanup; ignore IO failures.
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // Best-effort cleanup; ignore permission failures.
-            }
-
-            tempProjectDirectory = null;
-            tempProjectPath = null;
-            tempProjectNuGetConfig = null;
-            tempProjectReferencesKey = null;
-        }
-
-        private static string GetTargetFrameworkMoniker() => RuntimeAssemblyResolver.CompilerTargetFrameworkMoniker;
 
         public List<CompilationContext> CompileProject(string csproj)
         {

--- a/src/Neo.Compiler.CSharp/CompilationEngine/TemporaryProjectWorkspace.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/TemporaryProjectWorkspace.cs
@@ -1,0 +1,196 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TemporaryProjectWorkspace.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Neo.Compiler
+{
+    internal sealed class TemporaryProjectWorkspace
+    {
+        private string? _directory;
+        private string? _projectPath;
+        private string? _nugetConfigPath;
+        private string? _referencesKey;
+        private bool _cleanupRegistered;
+
+        internal string ProjectPath =>
+            _projectPath ?? throw new InvalidOperationException("Temporary project path has not been initialized.");
+
+        internal void PrepareTransient()
+        {
+            Cleanup();
+            _directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_directory);
+            _projectPath = Path.Combine(_directory, "TempProject.csproj");
+            _nugetConfigPath = Path.Combine(_directory, "nuget.config");
+            WriteNuGetConfig(_nugetConfigPath);
+            _referencesKey = null;
+        }
+
+        internal void EnsurePersistent(string referencesKey)
+        {
+            var directoryExists = _directory is not null && Directory.Exists(_directory);
+            if (!directoryExists || _referencesKey != referencesKey)
+            {
+                Cleanup();
+                _directory = Path.Combine(Path.GetTempPath(), "Neo.Compiler", "CompileSources", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(_directory);
+                _projectPath = Path.Combine(_directory, "TempProject.csproj");
+                _nugetConfigPath = Path.Combine(_directory, "nuget.config");
+                WriteNuGetConfig(_nugetConfigPath);
+                _referencesKey = referencesKey;
+                RegisterCleanup();
+            }
+        }
+
+        internal void WriteProject(CompilationSourceReferences references, string[] sourceFiles)
+        {
+            if (_directory is null)
+                throw new InvalidOperationException("Temporary project directory must be initialized before writing the project file.");
+
+            _projectPath ??= Path.Combine(_directory, "TempProject.csproj");
+            _nugetConfigPath ??= Path.Combine(_directory, "nuget.config");
+
+            File.WriteAllText(_projectPath, BuildTempProjectContent(references, sourceFiles));
+
+            if (!File.Exists(_nugetConfigPath))
+                WriteNuGetConfig(_nugetConfigPath);
+        }
+
+        internal void Cleanup()
+        {
+            if (_directory is null)
+                return;
+
+            try
+            {
+                if (Directory.Exists(_directory))
+                    Directory.Delete(_directory, true);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; ignore IO failures.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best-effort cleanup; ignore permission failures.
+            }
+
+            _directory = null;
+            _projectPath = null;
+            _nugetConfigPath = null;
+            _referencesKey = null;
+        }
+
+        internal static string BuildTempProjectContent(CompilationSourceReferences references, string[] sourceFiles)
+        {
+            var packages = references.Packages;
+            var packageGroup = packages is null || packages.Length == 0
+                ? string.Empty
+                : $@"
+    <ItemGroup>
+        {string.Join(Environment.NewLine, packages.Select(u => $" <PackageReference Include =\"{u.packageName}\" Version=\"{u.packageVersion}\" />"))}
+    </ItemGroup>";
+
+            var projects = references.Projects;
+            var projectsGroup = projects is null || projects.Length == 0
+                ? string.Empty
+                : $@"
+    <ItemGroup>
+        {string.Join(Environment.NewLine, projects.Select(u => $" <ProjectReference Include =\"{u}\"/>"))}
+    </ItemGroup>";
+
+            return $@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+    <PropertyGroup>
+        <TargetFramework>{RuntimeAssemblyResolver.CompilerTargetFrameworkMoniker}</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <!-- Remove all Compile items from compilation -->
+    <ItemGroup>
+        <Compile Remove=""*.cs"" />
+    </ItemGroup>
+
+    <!-- Add specific files for compilation -->
+    <ItemGroup>
+        {string.Join(Environment.NewLine, sourceFiles.Select(u => $"<Compile Include=\"{Path.GetFullPath(u)}\" />"))}
+    </ItemGroup>
+
+    {packageGroup}
+    {projectsGroup}
+
+</Project>";
+        }
+
+        internal static string BuildReferencesKey(CompilationSourceReferences references)
+        {
+            var builder = new StringBuilder();
+
+            if (references.Packages is { Length: > 0 })
+            {
+                foreach (var (packageName, packageVersion) in references.Packages
+                             .OrderBy(p => p.packageName, StringComparer.Ordinal))
+                {
+                    builder.Append("pkg:")
+                        .Append(packageName)
+                        .Append('@')
+                        .Append(packageVersion)
+                        .Append(';');
+                }
+            }
+
+            builder.Append('|');
+
+            if (references.Projects is { Length: > 0 })
+            {
+                foreach (var project in references.Projects
+                             .Select(Path.GetFullPath)
+                             .OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+                {
+                    builder.Append("proj:")
+                        .Append(project)
+                        .Append(';');
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static void WriteNuGetConfig(string nugetConfigPath)
+        {
+            const string nugetConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
+  </packageSources>
+</configuration>";
+
+            File.WriteAllText(nugetConfigPath, nugetConfigContent);
+        }
+
+        private void RegisterCleanup()
+        {
+            if (_cleanupRegistered)
+                return;
+
+            _cleanupRegistered = true;
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => Cleanup();
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TempProjectGeneration.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TempProjectGeneration.cs
@@ -32,12 +32,63 @@ namespace Neo.Compiler.CSharp.UnitTests
             }
         }
 
+        [TestMethod]
+        public void BuildReferencesKeyIsStableAcrossOrdering()
+        {
+            var first = new CompilationSourceReferences
+            {
+                Packages =
+                [
+                    ("Neo.SmartContract.Framework", "3.9.0"),
+                    ("Neo.Json", "3.9.0")
+                ],
+                Projects =
+                [
+                    Path.Combine(Path.GetTempPath(), "b", "ProjectB.csproj"),
+                    Path.Combine(Path.GetTempPath(), "a", "ProjectA.csproj")
+                ]
+            };
+
+            var second = new CompilationSourceReferences
+            {
+                Packages =
+                [
+                    ("Neo.Json", "3.9.0"),
+                    ("Neo.SmartContract.Framework", "3.9.0")
+                ],
+                Projects =
+                [
+                    Path.Combine(Path.GetTempPath(), "a", "ProjectA.csproj"),
+                    Path.Combine(Path.GetTempPath(), "b", "ProjectB.csproj")
+                ]
+            };
+
+            var firstKey = InvokeBuildReferencesKey(first);
+            var secondKey = InvokeBuildReferencesKey(second);
+
+            Assert.AreEqual(firstKey, secondKey);
+        }
+
         private static string InvokeBuildTempProjectContent(CompilationSourceReferences references, string[] sourceFiles)
         {
-            var method = typeof(CompilationEngine).GetMethod("BuildTempProjectContent", BindingFlags.NonPublic | BindingFlags.Static)
+            var workspaceType = typeof(CompilationEngine).Assembly.GetType("Neo.Compiler.TemporaryProjectWorkspace")
+                ?? throw new InvalidOperationException("Unable to locate TemporaryProjectWorkspace type via reflection.");
+
+            var method = workspaceType.GetMethod("BuildTempProjectContent", BindingFlags.NonPublic | BindingFlags.Static)
                 ?? throw new InvalidOperationException("Unable to locate BuildTempProjectContent method via reflection.");
 
             return (string)method.Invoke(null, new object[] { references, sourceFiles })!;
+        }
+
+        private static string InvokeBuildReferencesKey(CompilationSourceReferences references)
+        {
+            var workspaceType = typeof(CompilationEngine).Assembly.GetType("Neo.Compiler.TemporaryProjectWorkspace")
+                ?? throw new InvalidOperationException("Unable to locate TemporaryProjectWorkspace type via reflection.");
+
+            var method = workspaceType.GetMethod("BuildReferencesKey", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException("Unable to locate BuildReferencesKey method via reflection.");
+
+            return (string)method.Invoke(null, new object[] { references })!;
         }
     }
 }


### PR DESCRIPTION
## Summary
- extract temporary project lifecycle, NuGet config generation, and temp csproj generation out of `CompilationEngine`
- keep `CompileSources(...)` behavior unchanged while shrinking the `CompilationEngine` responsibility surface
- add focused unit coverage for the extracted workspace helper and stable reference-key generation

## Context
- first refactor slice for `Architecture: Decompose CompilationContext/CompilationEngine God Classes` from #1514
- based on the latest `master-n3`

## Test Plan
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_TempProjectGeneration
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_OutAlias
