### PR TITLE
feat(analyzer): detect duplicate storage map prefixes

### DIFF
--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -50,3 +50,4 @@ NC4051  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (UTF-8 string literals
 NC4053  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (file-local types)
 NC4054  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (ref readonly parameters)
 NC4055  | Usage    | Warning  | InitialValueAnalyzer (Parse enforcement)
+NC4056  | Security | Warning  | StorageKeyCollisionAnalyzer

--- a/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
@@ -59,18 +59,22 @@ namespace Neo.SmartContract.Analyzer
                 if (field.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken) is not VariableDeclaratorSyntax declarator)
                     continue;
 
-                if (declarator.Initializer?.Value is not BaseObjectCreationExpressionSyntax creation)
-                    continue;
-
-                SemanticModel semanticModel = context.Compilation.GetSemanticModel(creation.SyntaxTree);
                 if (!IsStorageNamespaceType(field.Type))
                     continue;
 
-                ExpressionSyntax? prefixExpression = GetPrefixExpression(creation);
-                if (prefixExpression is null)
+                if (!TryGetPrefixExpression(
+                        declarator.Initializer?.Value,
+                        field.Type,
+                        context.Compilation,
+                        context.CancellationToken,
+                        new HashSet<ISymbol>(SymbolEqualityComparer.Default),
+                        out ExpressionSyntax? prefixExpression,
+                        out SemanticModel? prefixSemanticModel))
+                {
                     continue;
+                }
 
-                if (!TryNormalizePrefix(prefixExpression, semanticModel, context.CancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out string normalizedPrefix))
+                if (!TryNormalizePrefix(prefixExpression, prefixSemanticModel, context.CancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out string normalizedPrefix))
                     continue;
 
                 if (seenPrefixes.TryGetValue(normalizedPrefix, out PrefixUsage existing))
@@ -99,15 +103,77 @@ namespace Neo.SmartContract.Analyzer
                 or "global::Neo.SmartContract.Framework.Services.LocalStorageMap";
         }
 
-        private static ExpressionSyntax? GetPrefixExpression(BaseObjectCreationExpressionSyntax creation)
+        private static bool TryGetPrefixExpression(
+            ExpressionSyntax? initializerValue,
+            ITypeSymbol expectedType,
+            Compilation compilation,
+            CancellationToken cancellationToken,
+            HashSet<ISymbol> visitedSymbols,
+            out ExpressionSyntax? prefixExpression,
+            out SemanticModel? prefixSemanticModel)
         {
-            if (creation.ArgumentList is null)
-                return null;
+            prefixExpression = null;
+            prefixSemanticModel = null;
 
-            if (creation.ArgumentList.Arguments.Count == 0)
-                return null;
+            if (initializerValue is null)
+                return false;
 
-            return creation.ArgumentList.Arguments[creation.ArgumentList.Arguments.Count - 1].Expression;
+            if (initializerValue is BaseObjectCreationExpressionSyntax creation)
+            {
+                if (creation.ArgumentList is null || creation.ArgumentList.Arguments.Count == 0)
+                    return false;
+
+                prefixExpression = creation.ArgumentList.Arguments[creation.ArgumentList.Arguments.Count - 1].Expression;
+                prefixSemanticModel = compilation.GetSemanticModel(creation.SyntaxTree);
+                return true;
+            }
+
+            if (initializerValue is not InvocationExpressionSyntax invocation)
+                return false;
+
+            SemanticModel invocationSemanticModel = compilation.GetSemanticModel(invocation.SyntaxTree);
+            if (invocationSemanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol methodSymbol)
+                return false;
+
+            if (!IsStorageNamespaceType(methodSymbol.ReturnType))
+                return false;
+
+            if (methodSymbol.Parameters.Length != 0)
+                return false;
+
+            if (!visitedSymbols.Add(methodSymbol))
+                return false;
+
+            foreach (SyntaxReference syntaxReference in methodSymbol.DeclaringSyntaxReferences)
+            {
+                if (syntaxReference.GetSyntax(cancellationToken) is not MethodDeclarationSyntax methodDeclaration)
+                    continue;
+
+                ExpressionSyntax? returnedExpression = methodDeclaration.ExpressionBody?.Expression;
+                if (returnedExpression is null &&
+                    methodDeclaration.Body?.Statements.Count == 1 &&
+                    methodDeclaration.Body.Statements[0] is ReturnStatementSyntax returnStatement)
+                {
+                    returnedExpression = returnStatement.Expression;
+                }
+
+                if (returnedExpression is null)
+                    continue;
+
+                if (TryGetPrefixExpression(
+                        returnedExpression,
+                        methodSymbol.ReturnType,
+                        compilation,
+                        cancellationToken,
+                        visitedSymbols,
+                        out prefixExpression,
+                        out prefixSemanticModel))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool TryNormalizePrefix(

--- a/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
@@ -1,0 +1,257 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StorageKeyCollisionAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Neo.SmartContract.Analyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class StorageKeyCollisionAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "NC4056";
+        private const string Category = "Security";
+
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Duplicate storage prefix may collide",
+            "Storage prefix '{0}' used by '{1}' collides with '{2}'",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Duplicate constant StorageMap/LocalStorageMap prefixes in the same contract can cause storage namespace collisions.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            if (context.Symbol is not INamedTypeSymbol typeSymbol || typeSymbol.TypeKind != TypeKind.Class)
+                return;
+
+            Dictionary<string, PrefixUsage> seenPrefixes = new(StringComparer.Ordinal);
+            foreach (IFieldSymbol field in typeSymbol.GetMembers().OfType<IFieldSymbol>())
+            {
+                if (field.DeclaringSyntaxReferences.Length == 0)
+                    continue;
+
+                if (field.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken) is not VariableDeclaratorSyntax declarator)
+                    continue;
+
+                if (declarator.Initializer?.Value is not BaseObjectCreationExpressionSyntax creation)
+                    continue;
+
+                SemanticModel semanticModel = context.Compilation.GetSemanticModel(creation.SyntaxTree);
+                if (!IsStorageNamespaceType(field.Type))
+                    continue;
+
+                ExpressionSyntax? prefixExpression = GetPrefixExpression(creation);
+                if (prefixExpression is null)
+                    continue;
+
+                if (!TryNormalizePrefix(prefixExpression, semanticModel, context.CancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out string normalizedPrefix))
+                    continue;
+
+                if (seenPrefixes.TryGetValue(normalizedPrefix, out PrefixUsage existing))
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(existing.Field, field))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            Rule,
+                            declarator.Identifier.GetLocation(),
+                            normalizedPrefix,
+                            field.Name,
+                            existing.Field.Name));
+                    }
+
+                    continue;
+                }
+
+                seenPrefixes[normalizedPrefix] = new PrefixUsage(field);
+            }
+        }
+
+        private static bool IsStorageNamespaceType(ITypeSymbol typeSymbol)
+        {
+            string fullName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return fullName is "global::Neo.SmartContract.Framework.Services.StorageMap"
+                or "global::Neo.SmartContract.Framework.Services.LocalStorageMap";
+        }
+
+        private static ExpressionSyntax? GetPrefixExpression(BaseObjectCreationExpressionSyntax creation)
+        {
+            if (creation.ArgumentList is null)
+                return null;
+
+            if (creation.ArgumentList.Arguments.Count == 0)
+                return null;
+
+            return creation.ArgumentList.Arguments[creation.ArgumentList.Arguments.Count - 1].Expression;
+        }
+
+        private static bool TryNormalizePrefix(
+            ExpressionSyntax expression,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            HashSet<ISymbol> visitedSymbols,
+            out string normalizedPrefix)
+        {
+            normalizedPrefix = string.Empty;
+
+            if (TryGetByteSequence(expression, semanticModel, cancellationToken, visitedSymbols, out byte[] bytes))
+            {
+                normalizedPrefix = BitConverter.ToString(bytes).Replace("-", string.Empty);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetByteSequence(
+            ExpressionSyntax expression,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            HashSet<ISymbol> visitedSymbols,
+            out byte[] bytes)
+        {
+            bytes = Array.Empty<byte>();
+
+            switch (expression)
+            {
+                case LiteralExpressionSyntax literal:
+                    return TryGetLiteralBytes(literal.Token.Value, out bytes);
+                case CastExpressionSyntax castExpression:
+                    return TryGetByteSequence(castExpression.Expression, semanticModel, cancellationToken, visitedSymbols, out bytes);
+                case PrefixUnaryExpressionSyntax unaryExpression:
+                    return TryGetByteSequence(unaryExpression.Operand, semanticModel, cancellationToken, visitedSymbols, out bytes);
+                case ArrayCreationExpressionSyntax arrayCreation when arrayCreation.Initializer is not null:
+                    return TryGetByteArray(arrayCreation.Initializer.Expressions, semanticModel, cancellationToken, visitedSymbols, out bytes);
+                case ImplicitArrayCreationExpressionSyntax implicitArray when implicitArray.Initializer is not null:
+                    return TryGetByteArray(implicitArray.Initializer.Expressions, semanticModel, cancellationToken, visitedSymbols, out bytes);
+            }
+
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+            if (symbolInfo.Symbol is null && semanticModel.GetConstantValue(expression, cancellationToken) is { HasValue: true } constantValue)
+            {
+                return TryGetLiteralBytes(constantValue.Value, out bytes);
+            }
+
+            if (symbolInfo.Symbol is IFieldSymbol fieldSymbol)
+            {
+                if (!visitedSymbols.Add(fieldSymbol))
+                    return false;
+
+                if (fieldSymbol.HasConstantValue && TryGetLiteralBytes(fieldSymbol.ConstantValue, out bytes))
+                    return true;
+
+                if (fieldSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken) is VariableDeclaratorSyntax declarator &&
+                    declarator.Initializer is not null)
+                {
+                    return TryGetByteSequence(declarator.Initializer.Value, semanticModel, cancellationToken, visitedSymbols, out bytes);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetByteArray(
+            SeparatedSyntaxList<ExpressionSyntax> expressions,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            HashSet<ISymbol> visitedSymbols,
+            out byte[] bytes)
+        {
+            List<byte> values = new(expressions.Count);
+            foreach (ExpressionSyntax expression in expressions)
+            {
+                if (!TryGetByteSequence(expression, semanticModel, cancellationToken, visitedSymbols, out byte[] elementBytes))
+                {
+                    bytes = Array.Empty<byte>();
+                    return false;
+                }
+
+                if (elementBytes.Length != 1)
+                {
+                    bytes = Array.Empty<byte>();
+                    return false;
+                }
+
+                values.Add(elementBytes[0]);
+            }
+
+            bytes = values.ToArray();
+            return true;
+        }
+
+        private static bool TryGetLiteralBytes(object? value, out byte[] bytes)
+        {
+            switch (value)
+            {
+                case null:
+                    bytes = Array.Empty<byte>();
+                    return false;
+                case string text:
+                    bytes = Encoding.UTF8.GetBytes(text);
+                    return true;
+                case byte byteValue:
+                    bytes = [byteValue];
+                    return true;
+                case sbyte sbyteValue:
+                    bytes = [unchecked((byte)sbyteValue)];
+                    return true;
+                case short shortValue when shortValue >= byte.MinValue && shortValue <= byte.MaxValue:
+                    bytes = [(byte)shortValue];
+                    return true;
+                case ushort ushortValue when ushortValue <= byte.MaxValue:
+                    bytes = [(byte)ushortValue];
+                    return true;
+                case int intValue when intValue >= byte.MinValue && intValue <= byte.MaxValue:
+                    bytes = [(byte)intValue];
+                    return true;
+                case uint uintValue when uintValue <= byte.MaxValue:
+                    bytes = [(byte)uintValue];
+                    return true;
+                case long longValue when longValue >= byte.MinValue && longValue <= byte.MaxValue:
+                    bytes = [(byte)longValue];
+                    return true;
+                case ulong ulongValue when ulongValue <= byte.MaxValue:
+                    bytes = [(byte)ulongValue];
+                    return true;
+                default:
+                    bytes = Array.Empty<byte>();
+                    return false;
+            }
+        }
+
+        private sealed class PrefixUsage
+        {
+            public PrefixUsage(IFieldSymbol field)
+            {
+                Field = field;
+            }
+
+            public IFieldSymbol Field { get; }
+        }
+    }
+}

--- a/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
@@ -74,6 +74,9 @@ namespace Neo.SmartContract.Analyzer
                     continue;
                 }
 
+                if (prefixExpression is null || prefixSemanticModel is null)
+                    continue;
+
                 if (!TryNormalizePrefix(prefixExpression, prefixSemanticModel, context.CancellationToken, new HashSet<ISymbol>(SymbolEqualityComparer.Default), out string normalizedPrefix))
                     continue;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
@@ -154,5 +154,93 @@ namespace Neo.SmartContract.Analyzer.UnitTests
 
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
+
+        [TestMethod]
+        public async Task DifferentFactoryCreatedPrefixes_DoNotReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractF
+                {
+                    private const byte PrefixOwners = 0x2A;
+                    private const byte PrefixAdmins = 0x2B;
+
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Owners = CreateOwners();
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap Admins = CreateAdmins();
+
+                    private static Neo.SmartContract.Framework.Services.StorageMap CreateOwners() =>
+                        new Neo.SmartContract.Framework.Services.StorageMap(
+                            Neo.SmartContract.Framework.Services.Storage.CurrentContext,
+                            PrefixOwners);
+
+                    private static Neo.SmartContract.Framework.Services.LocalStorageMap CreateAdmins()
+                    {
+                        return new Neo.SmartContract.Framework.Services.LocalStorageMap(PrefixAdmins);
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task DuplicateNestedFactoryCreatedPrefixes_ReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractG
+                {
+                    private const byte PrefixShared = 0x3C;
+
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Owners = CreateOwners();
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap Admins = CreateAdmins();
+
+                    private static Neo.SmartContract.Framework.Services.StorageMap CreateOwners() => CreateOwnersCore();
+
+                    private static Neo.SmartContract.Framework.Services.StorageMap CreateOwnersCore()
+                    {
+                        return new Neo.SmartContract.Framework.Services.StorageMap(
+                            Neo.SmartContract.Framework.Services.Storage.CurrentContext,
+                            PrefixShared);
+                    }
+
+                    private static Neo.SmartContract.Framework.Services.LocalStorageMap CreateAdmins()
+                    {
+                        return CreateAdminsCore();
+                    }
+
+                    private static Neo.SmartContract.Framework.Services.LocalStorageMap CreateAdminsCore() =>
+                        new Neo.SmartContract.Framework.Services.LocalStorageMap(PrefixShared);
+                }
+                """;
+
+            var expected = VerifyCS.Diagnostic(StorageKeyCollisionAnalyzer.DiagnosticId)
+                .WithSpan(27, 82, 27, 88)
+                .WithArguments("3C", "Admins", "Owners");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task ParameterizedFactoryCreatedPrefixes_DoNotReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractH
+                {
+                    private const byte PrefixShared = 0x4D;
+
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Owners = CreateOwners(PrefixShared);
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap Admins = CreateAdmins(PrefixShared);
+
+                    private static Neo.SmartContract.Framework.Services.StorageMap CreateOwners(byte prefix) =>
+                        new Neo.SmartContract.Framework.Services.StorageMap(
+                            Neo.SmartContract.Framework.Services.Storage.CurrentContext,
+                            prefix);
+
+                    private static Neo.SmartContract.Framework.Services.LocalStorageMap CreateAdmins(byte prefix) =>
+                        new Neo.SmartContract.Framework.Services.LocalStorageMap(prefix);
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
@@ -1,0 +1,128 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StorageKeyCollisionAnalyzerUnitTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.StorageKeyCollisionAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class StorageKeyCollisionAnalyzerUnitTests
+    {
+        private const string StorageStubs = """
+            namespace Neo.SmartContract.Framework.Services
+            {
+                public class StorageContext { }
+                public static class Storage
+                {
+                    public static StorageContext CurrentContext { get; } = new StorageContext();
+                }
+
+                public class StorageMap
+                {
+                    public StorageMap(StorageContext context, byte prefix) { }
+                    public StorageMap(StorageContext context, byte[] prefix) { }
+                    public StorageMap(StorageContext context, string prefix) { }
+                }
+
+                public class LocalStorageMap
+                {
+                    public LocalStorageMap(byte prefix) { }
+                    public LocalStorageMap(byte[] prefix) { }
+                    public LocalStorageMap(string prefix) { }
+                }
+            }
+            """;
+
+        [TestMethod]
+        public async Task DuplicateBytePrefixFields_ReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractA
+                {
+                    private const byte PrefixBalances = 0x01;
+                    private const byte PrefixAllowances = 0x01;
+
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Balances =
+                        new(Neo.SmartContract.Framework.Services.Storage.CurrentContext, PrefixBalances);
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap Allowances =
+                        new(PrefixAllowances);
+                }
+                """;
+
+            var expected = VerifyCS.Diagnostic(StorageKeyCollisionAnalyzer.DiagnosticId)
+                .WithSpan(29, 82, 29, 92)
+                .WithArguments("01", "Allowances", "Balances");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task DuplicateStringPrefixFields_ReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractB
+                {
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Owners =
+                        new(Neo.SmartContract.Framework.Services.Storage.CurrentContext, "owner");
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Admins =
+                        new(Neo.SmartContract.Framework.Services.Storage.CurrentContext, "owner");
+                }
+                """;
+
+            var expected = VerifyCS.Diagnostic(StorageKeyCollisionAnalyzer.DiagnosticId)
+                .WithSpan(26, 77, 26, 83)
+                .WithArguments("6F776E6572", "Admins", "Owners");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task DifferentPrefixes_DoNotReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractC
+                {
+                    private const byte PrefixBalances = 0x01;
+                    private const byte PrefixAllowances = 0x02;
+
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Balances =
+                        new(Neo.SmartContract.Framework.Services.Storage.CurrentContext, PrefixBalances);
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap Allowances =
+                        new(PrefixAllowances);
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task MethodLocalReuse_DoesNotReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractD
+                {
+                    public void Put()
+                    {
+                        var balances = new Neo.SmartContract.Framework.Services.StorageMap(
+                            Neo.SmartContract.Framework.Services.Storage.CurrentContext, (byte)0x01);
+                        var balancesAgain = new Neo.SmartContract.Framework.Services.StorageMap(
+                            Neo.SmartContract.Framework.Services.Storage.CurrentContext, (byte)0x01);
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
@@ -124,5 +124,35 @@ namespace Neo.SmartContract.Analyzer.UnitTests
 
             await VerifyCS.VerifyAnalyzerAsync(test);
         }
+
+        [TestMethod]
+        public async Task DuplicateFactoryCreatedPrefixes_ReportDiagnostic()
+        {
+            var test = StorageStubs + """
+                public class ContractE
+                {
+                    private const byte PrefixShared = 0x2A;
+
+                    private static readonly Neo.SmartContract.Framework.Services.StorageMap Owners = CreateOwners();
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap Admins = CreateAdmins();
+
+                    private static Neo.SmartContract.Framework.Services.StorageMap CreateOwners()
+                    {
+                        return new Neo.SmartContract.Framework.Services.StorageMap(
+                            Neo.SmartContract.Framework.Services.Storage.CurrentContext,
+                            PrefixShared);
+                    }
+
+                    private static Neo.SmartContract.Framework.Services.LocalStorageMap CreateAdmins() =>
+                        new Neo.SmartContract.Framework.Services.LocalStorageMap(PrefixShared);
+                }
+                """;
+
+            var expected = VerifyCS.Diagnostic(StorageKeyCollisionAnalyzer.DiagnosticId)
+                .WithSpan(27, 82, 27, 88)
+                .WithArguments("2A", "Admins", "Owners");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a Roslyn analyzer that flags duplicate constant `StorageMap` / `LocalStorageMap` prefixes declared in the same contract type
- normalize byte, string, and byte-array prefixes so obvious namespace collisions are surfaced early
- add focused analyzer unit tests for duplicate byte and string prefixes plus non-collision cases

## Context
- first implementation slice for `Security: Storage key collision detection` from #1514
- based on the latest `master-n3`

## Test Plan
- dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter FullyQualifiedName~StorageKeyCollisionAnalyzerUnitTests
