### PR TITLE
fix(compiler): support BigInteger.TryParse out handling

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
@@ -221,7 +221,10 @@ partial class MethodConvert
         methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
         if (!methodConvert._context.TryGetCapturedStaticField(symbol.Parameters[1], out var index)) throw new CompilationException(symbol, DiagnosticId.SyntaxNotSupported, "Out parameter must be captured in a static field.");
 
-        JumpTarget endTarget = new();
+        // Drop the out parameter since it's not needed.
+        // We use the captured static field to hold the parsed value.
+        methodConvert.Swap();
+        methodConvert.Drop();
 
         // Convert string to BigInteger
         methodConvert.CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
@@ -229,18 +232,23 @@ partial class MethodConvert
         // Check if the parsing was successful
         methodConvert.Dup();                                       // Duplicate result for null check
         methodConvert.IsNull();                                    // Check if null (parse failed)
-        methodConvert.JumpIfTrueLong(endTarget);             // Jump to end if null
+        JumpTarget failTarget = new();
+        methodConvert.JumpIfTrueLong(failTarget);            // Jump to fail if null
 
         // If successful, store the value and push true
-        methodConvert.Dup();                                       // Duplicate result for storage
         methodConvert.AccessSlot(OpCode.STSFLD, index);            // Store value in static field
         methodConvert.Push(true);                                  // Push success flag
+        JumpTarget endTarget = new();
         methodConvert.JumpAlwaysLong(endTarget);               // Jump to end
 
-        // End target: clean up stack and push false if parsing failed
-        endTarget.Instruction = methodConvert.Nop();               // End target
-        methodConvert.Drop();                                      // Drop the failed value
+        // Fail target: clear parsed value, set out parameter default, then push false
+        failTarget.Instruction = methodConvert.Drop();             // Drop the failed value
+        methodConvert.PushDefault(symbol.Parameters[1].Type);      // Default out value on parse failure
+        methodConvert.AccessSlot(OpCode.STSFLD, index);            // Store default in out parameter capture
         methodConvert.Push(false);                                 // Push failure flag
+
+        // End target
+        endTarget.Instruction = methodConvert.Nop();               // End target
     }
 
     /// <summary>

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
@@ -613,6 +613,7 @@ internal partial class MethodConvert
         RegisterHandler((string? s, uint result) => uint.TryParse(s, out result), HandleUIntTryParseWithOut);
         RegisterHandler((string? s, long result) => long.TryParse(s, out result), HandleLongTryParseWithOut);
         RegisterHandler((string? s, ulong result) => ulong.TryParse(s, out result), HandleULongTryParseWithOut);
+        RegisterHandler((string? s, BigInteger result) => BigInteger.TryParse(s, out result), HandleBigIntegerTryParseWithOut);
 
         // Bool
         RegisterHandler((string? value, bool result) => bool.TryParse(value, out result), HandleBoolTryParseWithOut);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigIntegerTryParse.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigIntegerTryParse.cs
@@ -1,0 +1,101 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using Neo.SmartContract.Testing;
+using Neo.VM.Types;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_BigIntegerTryParse
+{
+    [TestMethod]
+    public void BigIntegerTryParse_ReturnsTrue_And_AssignsParsedValue()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using System.ComponentModel;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    [DisplayName(""test"")]
+    public static (bool, BigInteger) Test(string s)
+    {
+        bool success = BigInteger.TryParse(s, out BigInteger result);
+        return (success, result);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<BigIntegerTryParseContract>(context.CreateExecutable(), context.CreateManifest());
+
+        var result = contract.Test("123");
+        Assert.IsNotNull(result);
+        var tuple = result!;
+
+        bool success = tuple[0] switch
+        {
+            StackItem stackItem => stackItem.GetBoolean(),
+            bool value => value,
+            _ => throw new AssertFailedException($"Unexpected success result type: {tuple[0]?.GetType().Name ?? "null"}")
+        };
+
+        System.Numerics.BigInteger parsed = tuple[1] switch
+        {
+            System.Numerics.BigInteger value => value,
+            StackItem stackItem => stackItem.GetInteger(),
+            _ => throw new AssertFailedException($"Unexpected parsed value type: {tuple[1]?.GetType().Name ?? "null"}")
+        };
+
+        Assert.IsTrue(success, "BigInteger.TryParse should report success for a valid integer string.");
+        Assert.AreEqual((System.Numerics.BigInteger)123, parsed);
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            return contexts[0];
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public abstract class BigIntegerTryParseContract(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("test")]
+        public abstract object?[]? Test(string s);
+    }
+}


### PR DESCRIPTION
## Summary
- register `BigInteger.TryParse(string, out BigInteger)` in the system call handler table
- fix the out-parameter stack flow so the BigInteger handler matches the existing numeric `TryParse` pattern
- add a temp-contract regression test that compiles and executes `BigInteger.TryParse`

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_BigIntegerTryParse.BigIntegerTryParse_ReturnsTrue_And_AssignsParsedValue`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_SystemCall_Out|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_BigIntegerTryParse"`

Related checklist item: issue #1556, Issue 1.
