### PR TITLE
fix(compiler): reject slot count overflow

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/ConvertHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/ConvertHelpers.cs
@@ -25,6 +25,13 @@ extern alias scfx;
 
 internal partial class MethodConvert
 {
+    private static byte RequireByteSizedSlotCount(ISymbol symbol, int count, string description)
+    {
+        if ((uint)count > byte.MaxValue)
+            throw new CompilationException(symbol, DiagnosticId.SyntaxNotSupported, $"Methods with more than {byte.MaxValue} {description} are not supported.");
+        return (byte)count;
+    }
+
     private bool TryProcessInlineMethods(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<SyntaxNode>? arguments)
     {
         SyntaxNode? syntaxNode = null;
@@ -113,9 +120,9 @@ internal partial class MethodConvert
 
         if (_initSlot)
         {
-            byte pc = (byte)Symbol.Parameters.Length;
-            byte lc = (byte)_localsCount;
-            if (NeedInstanceConstructor(Symbol)) pc++;
+            int parameterSlotCount = Symbol.Parameters.Length + (NeedInstanceConstructor(Symbol) ? 1 : 0);
+            byte pc = RequireByteSizedSlotCount(Symbol, parameterSlotCount, "parameters");
+            byte lc = RequireByteSizedSlotCount(Symbol, _localsCount, "local slots");
             if (pc > 0 || lc > 0)
             {
                 _instructions.Insert(0, new Instruction

--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/SlotHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/SlotHelpers.cs
@@ -36,7 +36,9 @@ internal partial class MethodConvert
     /// <returns>The index of the newly added local variable.</returns>
     private byte AddLocalVariable(ILocalSymbol symbol)
     {
-        var index = (byte)(_localVariables.Count + _anonymousVariables.Count);
+        int indexValue = _localVariables.Count + _anonymousVariables.Count;
+        RequireByteSizedSlotCount(Symbol, indexValue + 1, "local slots");
+        var index = (byte)indexValue;
         _variableSymbols.Add((symbol, index));
         _localVariables.Add(symbol, index);
         if (_localsCount < index + 1)
@@ -47,7 +49,9 @@ internal partial class MethodConvert
 
     private byte AddAnonymousVariable()
     {
-        var index = (byte)(_localVariables.Count + _anonymousVariables.Count);
+        int indexValue = _localVariables.Count + _anonymousVariables.Count;
+        RequireByteSizedSlotCount(Symbol, indexValue + 1, "local slots");
+        var index = (byte)indexValue;
         _anonymousVariables.Add(index);
         if (_localsCount < index + 1)
             _localsCount = index + 1;

--- a/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
@@ -33,11 +33,14 @@ internal partial class MethodConvert
         if (_parameters.Count > 0)
             return;
 
-        for (byte i = 0; i < Symbol.Parameters.Length; i++)
+        int parameterSlotCount = Symbol.Parameters.Length + (NeedInstanceConstructor(Symbol) ? 1 : 0);
+        RequireByteSizedSlotCount(Symbol, parameterSlotCount, "parameters");
+
+        for (int i = 0; i < Symbol.Parameters.Length; i++)
         {
             IParameterSymbol parameter = Symbol.Parameters[i];
             IParameterSymbol original = parameter.OriginalDefinition;
-            byte index = i;
+            byte index = (byte)i;
             if (NeedInstanceConstructor(Symbol)) index++;
 
             _parameters.TryAdd(parameter, index);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SlotLimits.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SlotLimits.cs
@@ -1,0 +1,111 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_SlotLimits
+{
+    [TestMethod]
+    public void Methods_WithMoreThan255Parameters_FailCompilationCleanly()
+    {
+        var context = CompileSingleContract(BuildParameterOverflowSource(256), TimeSpan.FromSeconds(10));
+
+        Assert.IsFalse(context.Success, "Compilation should fail cleanly when parameter count exceeds the VM slot limit.");
+        StringAssert.Contains(string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())), "255 parameters");
+    }
+
+    [TestMethod]
+    public void Methods_WithMoreThan255Locals_FailCompilationCleanly()
+    {
+        var context = CompileSingleContract(BuildLocalOverflowSource(256), TimeSpan.FromSeconds(10));
+
+        Assert.IsFalse(context.Success, "Compilation should fail cleanly when local count exceeds the VM slot limit.");
+        StringAssert.Contains(string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())), "255 local");
+    }
+
+    private static string BuildParameterOverflowSource(int parameterCount)
+    {
+        var parameters = string.Join(", ", Enumerable.Range(0, parameterCount).Select(i => $"int p{i}"));
+        return $$"""
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main({{parameters}})
+    {
+        return 0;
+    }
+}
+""";
+    }
+
+    private static string BuildLocalOverflowSource(int localCount)
+    {
+        var body = new StringBuilder();
+        for (var i = 0; i < localCount; i++)
+        {
+            body.Append("        int v").Append(i).Append(" = ").Append(i).AppendLine(";");
+        }
+
+        return $$"""
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main()
+    {
+{{body}}        return 0;
+    }
+}
+""";
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode, TimeSpan timeout)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var task = Task.Run(() =>
+            {
+                var options = new CompilationOptions
+                {
+                    Optimize = CompilationOptions.OptimizationType.All,
+                    Nullable = NullableContextOptions.Enable,
+                    SkipRestoreIfAssetsPresent = true
+                };
+
+                var engine = new CompilationEngine(options);
+                var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+                var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+                var contexts = engine.CompileSources(new CompilationSourceReferences
+                {
+                    Projects = new[] { frameworkProject }
+                }, tempFile);
+
+                Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+                return contexts[0];
+            });
+
+            if (!task.Wait(timeout))
+                Assert.Fail($"Compilation timed out after {timeout.TotalSeconds:0} seconds. Parameter/local overflow should fail cleanly instead of hanging.");
+
+            return task.GetAwaiter().GetResult();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- reject parameter-slot counts above the byte-sized `INITSLOT` limit before registration starts
- reject local-slot growth beyond the same limit before slot indices wrap
- add compiler regression tests for >255 parameters and >255 locals

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_SlotLimits`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_SlotLimits|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_OutAlias|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_RefLocals|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_RefSupport"`

Related checklist item: issue #1556, Issue 4.
