### PR TITLE
docs(compiler): define bool.TryParse compatibility policy

### DIFF
--- a/docs/csharp-syntax/SemanticDifferences.md
+++ b/docs/csharp-syntax/SemanticDifferences.md
@@ -1,0 +1,35 @@
+# Semantic Differences
+
+This page records intentional or currently accepted behavior differences between Neo C# contract compilation and standard .NET semantics.
+
+## `bool.TryParse`
+
+The compiler currently preserves an extended NeoVM-oriented bool parsing policy.
+
+Accepted true literals:
+- `"true"`
+- `"TRUE"`
+- `"True"`
+- `"t"`
+- `"T"`
+- `"1"`
+- `"yes"`
+- `"YES"`
+- `"y"`
+- `"Y"`
+
+Accepted false literals:
+- `"false"`
+- `"FALSE"`
+- `"False"`
+- `"f"`
+- `"F"`
+- `"0"`
+- `"no"`
+- `"NO"`
+- `"n"`
+- `"N"`
+
+Notes:
+- This intentionally diverges from .NET `bool.TryParse`, which only accepts `true` and `false` case-insensitively.
+- Whitespace-padded inputs such as `" true "` are still rejected.

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
@@ -260,7 +260,9 @@ partial class MethodConvert
     /// <param name="instanceExpression">The instance expression (if any)</param>
     /// <param name="arguments">The method arguments</param>
     /// <remarks>
-    /// Algorithm: Checks input string against various true/false representations, stores result in static field
+    /// Algorithm: Checks input string against NeoVM-oriented true/false representations, stores result in static field.
+    /// This intentionally diverges from .NET bool.TryParse by accepting additional literals such as
+    /// "1"/"0", "yes"/"no", "y"/"n", and "t"/"f".
     /// </remarks>
     private static void HandleBoolTryParseWithOut(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SystemCall_Out.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SystemCall_Out.cs
@@ -313,7 +313,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         [TestMethod]
-        public void TestBoolTryParse()
+        public void TestBoolTryParse_DotNetStyleLiterals()
         {
             var res = Contract.TestBoolTryParse("true");
             Assert.IsNotNull(res);
@@ -334,8 +334,12 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsNotNull(res);
             Assert.IsTrue((bool)res[0]);
             Assert.IsFalse((bool)res[1]);
+        }
 
-            res = Contract.TestBoolTryParse("1");
+        [TestMethod]
+        public void TestBoolTryParse_ExtendedNeoVmLiterals()
+        {
+            var res = Contract.TestBoolTryParse("1");
             Assert.IsNotNull(res);
             Assert.IsTrue((bool)res[0]);
             Assert.IsTrue((bool)res[1]);
@@ -354,11 +358,6 @@ namespace Neo.Compiler.CSharp.UnitTests
             res = Contract.TestBoolTryParse("FALSE");
             Assert.IsNotNull(res);
             Assert.IsTrue((bool)res[0]);
-            Assert.IsFalse((bool)res[1]);
-
-            res = Contract.TestBoolTryParse(" true ");
-            Assert.IsNotNull(res);
-            Assert.IsFalse((bool)res[0]);
             Assert.IsFalse((bool)res[1]);
 
             res = Contract.TestBoolTryParse("yes");
@@ -389,6 +388,15 @@ namespace Neo.Compiler.CSharp.UnitTests
             res = Contract.TestBoolTryParse("N");
             Assert.IsNotNull(res);
             Assert.IsTrue((bool)res[0]);
+            Assert.IsFalse((bool)res[1]);
+        }
+
+        [TestMethod]
+        public void TestBoolTryParse_InvalidInputsRemainRejected()
+        {
+            var res = Contract.TestBoolTryParse(" true ");
+            Assert.IsNotNull(res);
+            Assert.IsFalse((bool)res[0]);
             Assert.IsFalse((bool)res[1]);
 
             res = Contract.TestBoolTryParse("invalid");


### PR DESCRIPTION
## Summary
- document that the compiler intentionally accepts NeoVM-oriented extended literals for `bool.TryParse`
- split the bool `TryParse` unit test into standard, extended, and invalid-input coverage
- add a user-facing semantic-differences document for the behavior

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_SystemCall_Out`

Related checklist item: issue #1556, Issue 8.
