### PR TITLE
fix(compiler): enforce recursive pattern type checks

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RecursivePattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RecursivePattern.cs
@@ -26,7 +26,15 @@ internal partial class MethodConvert
             throw CompilationException.UnsupportedSyntax(pattern, "Recursive patterns must include a property pattern clause. Use syntax like 'Type { Property: value }' or '{ Property: value }'.");
         }
 
-        bool hasSubpattern = false;
+        bool hasPredicate = false;
+        if (pattern.Type is not null)
+        {
+            ITypeSymbol type = model.GetTypeInfo(pattern.Type).Type!;
+            AccessSlot(OpCode.LDLOC, localIndex);
+            IsType(type.GetPatternType());
+            hasPredicate = true;
+        }
+
         foreach (var subpattern in propertyClause.Subpatterns)
         {
             if (subpattern is not { Pattern: ConstantPatternSyntax constantPattern })
@@ -34,7 +42,7 @@ internal partial class MethodConvert
                 throw CompilationException.UnsupportedSyntax(subpattern, $"Recursive patterns currently only support constant pattern matching. Found: {subpattern.Pattern?.GetType().Name ?? "null"}. Use syntax like '{{ PropertyName: constantValue }}'.");
             }
 
-            if (hasSubpattern)
+            if (hasPredicate)
             {
                 JumpTarget evaluateNextPattern = new();
                 JumpTarget endPattern = new();
@@ -48,11 +56,12 @@ internal partial class MethodConvert
             else
             {
                 EmitRecursivePropertyConstantPatternCheck(model, subpattern, constantPattern, localIndex);
-                hasSubpattern = true;
             }
+
+            hasPredicate = true;
         }
 
-        if (!hasSubpattern)
+        if (!hasPredicate)
         {
             // `{ }` should match any non-null value.
             AccessSlot(OpCode.LDLOC, localIndex);

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_RecursivePatternType.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_RecursivePatternType.cs
@@ -1,0 +1,80 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using Neo.SmartContract.Testing;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_RecursivePatternType
+{
+    [TestMethod]
+    public void RecursivePattern_WithTypeClause_DoesNotMatchDifferentTypeWithSamePropertyShape()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using System.ComponentModel;
+
+public class Contract : SmartContract
+{
+    [DisplayName(""test"")]
+    public static bool Test()
+    {
+        object value = new byte[] { 0x2A };
+        return value is string { Length: 1 };
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<RecursivePatternTypeContract>(context.CreateExecutable(), context.CreateManifest());
+
+        Assert.IsFalse(contract.Test()!.Value);
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            return contexts[0];
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public abstract class RecursivePatternTypeContract(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("test")]
+        public abstract bool? Test();
+    }
+}


### PR DESCRIPTION
## Summary
- apply the recursive-pattern type clause before property subpattern evaluation
- short-circuit property checks when the runtime type does not match the declared recursive pattern type
- add a runtime regression using `string` versus `byte[]` with the same `Length` property shape

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_RecursivePatternType.RecursivePattern_WithTypeClause_DoesNotMatchDifferentTypeWithSamePropertyShape`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_RecursivePatternType|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_Pattern|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.Syntax.UnitTest_PatternTypeSupport"`

Related checklist item: issue #1556, Issue 6.
