### PR TITLE
fix(compiler): assign recursive pattern designations

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RecursivePattern.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Pattern/RecursivePattern.cs
@@ -59,6 +59,25 @@ internal partial class MethodConvert
             AddInstruction(OpCode.ISNULL);
             AddInstruction(OpCode.NOT);
         }
+
+        switch (pattern.Designation)
+        {
+            case null:
+            case DiscardDesignationSyntax:
+                break;
+            case SingleVariableDesignationSyntax variable:
+                ILocalSymbol local = (ILocalSymbol)model.GetDeclaredSymbol(variable)!;
+                byte index = AddLocalVariable(local);
+                AddInstruction(OpCode.DUP);
+                JumpTarget skipAssignment = new();
+                Jump(OpCode.JMPIFNOT, skipAssignment);
+                AccessSlot(OpCode.LDLOC, localIndex);
+                AccessSlot(OpCode.STLOC, index);
+                skipAssignment.Instruction = AddInstruction(OpCode.NOP);
+                break;
+            default:
+                throw CompilationException.UnsupportedSyntax(pattern, $"Recursive pattern designation type '{pattern.Designation.GetType().Name}' is not supported. Only single variable and discard designations are allowed.");
+        }
     }
 
     private void EmitRecursivePropertyConstantPatternCheck(SemanticModel model, SubpatternSyntax subpattern, ConstantPatternSyntax constantPattern, byte localIndex)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_RecursivePatternDesignation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_RecursivePatternDesignation.cs
@@ -1,0 +1,80 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using Neo.SmartContract.Testing;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_RecursivePatternDesignation
+{
+    [TestMethod]
+    public void RecursivePattern_Designation_AssignsCapturedValue()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using System.ComponentModel;
+
+public class Contract : SmartContract
+{
+    [DisplayName(""test"")]
+    public static bool Test()
+    {
+        object value = ""A"";
+        return value is string { Length: 1 } matched && matched == ""A"";
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<RecursivePatternDesignationContract>(context.CreateExecutable(), context.CreateManifest());
+
+        Assert.IsTrue(contract.Test()!.Value);
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            return contexts[0];
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public abstract class RecursivePatternDesignationContract(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("test")]
+        public abstract bool? Test();
+    }
+}


### PR DESCRIPTION
## Summary
- assign recursive-pattern designation variables only when the recursive pattern matches
- mirror the declaration-pattern "assign on success" flow for recursive designations
- add a runtime regression covering recursive pattern designations in an `&&` chain

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_RecursivePatternDesignation.RecursivePattern_Designation_AssignsCapturedValue`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_RecursivePatternDesignation|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.UnitTest_Pattern|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.Syntax.UnitTest_PatternTypeSupport"`

Related checklist item: issue #1556, Issue 7.
