### PR TITLE
fix(analyzer): track local storage in reentrancy

### DIFF
--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/ReEntrancyAnalyzer.cs
@@ -173,7 +173,9 @@ namespace Neo.Compiler.SecurityAnalyzer
                         if (instruction.TokenU32 == ApplicationEngine.System_Contract_Call.Hash)
                             callOtherContractInstructions[b].Add(addr);
                         if (instruction.TokenU32 == ApplicationEngine.System_Storage_Put.Hash
-                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Delete.Hash)
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Delete.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Put.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Delete.Hash)
                         {
                             writeStorageInstructions[b].Add(addr);
                             if (callOtherContractInstructions[b].Count > 0)

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
@@ -13,7 +13,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.SecurityAnalyzer;
 using Neo.Json;
 using Neo.Optimizer;
+using Neo.SmartContract;
 using Neo.SmartContract.Testing;
+using Neo.VM;
+using System;
+using System.Linq;
 
 namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
 {
@@ -53,6 +57,62 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
 
             // Message should be more detailed than just addresses
             Assert.IsTrue(warningInfo.Length > 300, "Enhanced diagnostic message should be more detailed than simple address listing");
+        }
+
+        [TestMethod]
+        public void Test_ReentrancyAnalyzer_Treats_LocalStorageWrites_As_StateWrites()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Contract_Call.Hash),
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Storage_Local_Put.Hash),
+                (byte)OpCode.RET
+            ];
+
+            var nef = CreateNefFile(script);
+            var manifest = CreateManifest();
+
+            var result = ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(nef, manifest);
+            Assert.AreEqual(1, result.vulnerabilityPairs.Count, "Local storage writes after external calls should be tracked as reentrancy-relevant writes.");
+        }
+
+        private static NefFile CreateNefFile(byte[] script)
+        {
+            return new NefFile
+            {
+                Compiler = "test",
+                Source = "test.cs",
+                Tokens = Array.Empty<MethodToken>(),
+                Script = script
+            };
+        }
+
+        private static SmartContract.Manifest.ContractManifest CreateManifest()
+        {
+            return new SmartContract.Manifest.ContractManifest
+            {
+                Name = "TestContract",
+                Groups = Array.Empty<SmartContract.Manifest.ContractGroup>(),
+                SupportedStandards = Array.Empty<string>(),
+                Abi = new SmartContract.Manifest.ContractAbi
+                {
+                    Methods =
+                    [
+                        new SmartContract.Manifest.ContractMethodDescriptor
+                        {
+                            Name = "main",
+                            Offset = 0,
+                            Parameters = Array.Empty<SmartContract.Manifest.ContractParameterDefinition>(),
+                            ReturnType = ContractParameterType.Void,
+                            Safe = false
+                        }
+                    ],
+                    Events = Array.Empty<SmartContract.Manifest.ContractEventDescriptor>()
+                },
+                Permissions = Array.Empty<SmartContract.Manifest.ContractPermission>(),
+                Trusts = SmartContract.Manifest.WildcardContainer<SmartContract.Manifest.ContractPermissionDescriptor>.Create(),
+                Extra = null
+            };
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
@@ -76,6 +76,34 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.AreEqual(1, result.vulnerabilityPairs.Count, "Local storage writes after external calls should be tracked as reentrancy-relevant writes.");
         }
 
+        [TestMethod]
+        public void Test_ReentrancyAnalyzer_Treats_LocalStorageDelete_As_StateWrite()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Contract_Call.Hash),
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Storage_Local_Delete.Hash),
+                (byte)OpCode.RET
+            ];
+
+            var result = ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(1, result.vulnerabilityPairs.Count);
+        }
+
+        [TestMethod]
+        public void Test_ReentrancyAnalyzer_DoesNotTreat_LocalStorageGet_As_StateWrite()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Contract_Call.Hash),
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Storage_Local_Get.Hash),
+                (byte)OpCode.RET
+            ];
+
+            var result = ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.vulnerabilityPairs.Count);
+        }
+
         private static NefFile CreateNefFile(byte[] script)
         {
             return new NefFile

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_Reentrancy.cs
@@ -91,6 +91,32 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         }
 
         [TestMethod]
+        public void Test_ReentrancyAnalyzer_DoesNotWarn_On_LocalStoragePut_Without_ExternalCall()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Storage_Local_Put.Hash),
+                (byte)OpCode.RET
+            ];
+
+            var result = ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.vulnerabilityPairs.Count);
+        }
+
+        [TestMethod]
+        public void Test_ReentrancyAnalyzer_DoesNotWarn_On_LocalStorageDelete_Without_ExternalCall()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Storage_Local_Delete.Hash),
+                (byte)OpCode.RET
+            ];
+
+            var result = ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.vulnerabilityPairs.Count);
+        }
+
+        [TestMethod]
         public void Test_ReentrancyAnalyzer_DoesNotTreat_LocalStorageGet_As_StateWrite()
         {
             byte[] script =


### PR DESCRIPTION
## Summary
- treat `System.Storage.Local.Put/Delete` as state writes in `ReEntrancyAnalyzer`
- add a focused analyzer regression for external calls followed by local storage writes
- preserve the existing syscall-based external call detection unchanged

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.ReentrancyTests.Test_ReentrancyAnalyzer_Treats_LocalStorageWrites_As_StateWrites|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.ReentrancyTests.Test_HasReentrancy|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.ReentrancyTests.Test_ReentrancyWithEnhancedDiagnostics"`

Related checklist item: issue #1556, Issue 10.
