### PR TITLE
fix(analyzer): detect contract destroy paths

### DIFF
--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
@@ -25,8 +25,14 @@ namespace Neo.Compiler.SecurityAnalyzer
             CheckWitnessAnalyzer.AnalyzeCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
             MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
             UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(nef, manifest, debugInfo).GetWarningInfo(print: true);
-            if (!UpdateAnalyzer.AnalyzeUpdate(nef, manifest, debugInfo))
-                Console.WriteLine("[SECURITY] This contract cannot be updated, or maybe you used abstract code styles to update it.");
+            bool canUpdate = UpdateAnalyzer.AnalyzeUpdate(nef, manifest, debugInfo);
+            bool canDestroy = UpdateAnalyzer.AnalyzeDestroy(nef, manifest, debugInfo);
+            if (canUpdate)
+                Console.WriteLine("[SECURITY] This contract can be updated.");
+            if (canDestroy)
+                Console.WriteLine("[SECURITY] This contract can be destroyed.");
+            if (!canUpdate && !canDestroy)
+                Console.WriteLine("[SECURITY] This contract cannot be updated or destroyed, or maybe you used abstract code styles to do so.");
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
@@ -35,6 +35,7 @@ namespace Neo.Compiler.SecurityAnalyzer
             (nef, manifest, _) = Reachability.RemoveUncoveredInstructions(nef, manifest, null);
             (int addr, VM.Instruction instruction)[] instructions = ((Script)nef.Script).EnumerateInstructions().ToArray();
             byte[] update = System.Text.Encoding.UTF8.GetBytes("update");
+            byte[] destroy = System.Text.Encoding.UTF8.GetBytes("destroy");
             for (int i = 0; i < instructions.Length; ++i)
             {
                 VM.Instruction instruction = instructions[i].instruction;
@@ -42,14 +43,18 @@ namespace Neo.Compiler.SecurityAnalyzer
                 {
                     uint tokenId = instruction.TokenU16;
                     MethodToken token = nef.Tokens[tokenId];
-                    if (token.Hash == NativeContract.ContractManagement.Hash && token.Method == "update" && ((token.CallFlags & CallFlags.WriteStates) != 0))
+                    if (token.Hash == NativeContract.ContractManagement.Hash
+                        && (token.Method == "update" || token.Method == "destroy")
+                        && ((token.CallFlags & CallFlags.WriteStates) != 0))
                         return true;
                 }
                 if (i + 2 >= instructions.Length)
                     continue;  // Do not break or return. There can be a CALLT following.
                 VM.Instruction instruction1 = instructions[i + 1].instruction;
                 VM.Instruction instruction2 = instructions[i + 2].instruction;
-                if (instruction.OpCode == OpCode.PUSHDATA1 && instruction.Operand.ToArray().SequenceEqual(update)
+                if (instruction.OpCode == OpCode.PUSHDATA1
+                 && (instruction.Operand.ToArray().SequenceEqual(update)
+                  || instruction.Operand.ToArray().SequenceEqual(destroy))
                  && instruction1.OpCode == OpCode.PUSHDATA1 && instruction1.Operand.Span.SequenceEqual(NativeContract.ContractManagement.Hash.GetSpan())
                  && instruction2.OpCode == OpCode.SYSCALL && instruction2.TokenU32 == ApplicationEngine.System_Contract_Call.Hash)
                     return true;

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
@@ -32,10 +32,24 @@ namespace Neo.Compiler.SecurityAnalyzer
         public static bool AnalyzeUpdate
             (NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
         {
+            return AnalyzeContractManagementMethod(nef, manifest, "update", debugInfo);
+        }
+
+        public static bool AnalyzeDestroy
+            (NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
+        {
+            return AnalyzeContractManagementMethod(nef, manifest, "destroy", debugInfo);
+        }
+
+        private static bool AnalyzeContractManagementMethod(
+            NefFile nef,
+            ContractManifest manifest,
+            string methodName,
+            JToken? debugInfo = null)
+        {
             (nef, manifest, _) = Reachability.RemoveUncoveredInstructions(nef, manifest, null);
             (int addr, VM.Instruction instruction)[] instructions = ((Script)nef.Script).EnumerateInstructions().ToArray();
-            byte[] update = System.Text.Encoding.UTF8.GetBytes("update");
-            byte[] destroy = System.Text.Encoding.UTF8.GetBytes("destroy");
+            byte[] methodBytes = System.Text.Encoding.UTF8.GetBytes(methodName);
             for (int i = 0; i < instructions.Length; ++i)
             {
                 VM.Instruction instruction = instructions[i].instruction;
@@ -43,9 +57,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                 {
                     uint tokenId = instruction.TokenU16;
                     MethodToken token = nef.Tokens[tokenId];
-                    if (token.Hash == NativeContract.ContractManagement.Hash
-                        && (token.Method == "update" || token.Method == "destroy")
-                        && ((token.CallFlags & CallFlags.WriteStates) != 0))
+                    if (token.Hash == NativeContract.ContractManagement.Hash && token.Method == methodName && ((token.CallFlags & CallFlags.WriteStates) != 0))
                         return true;
                 }
                 if (i + 2 >= instructions.Length)
@@ -53,8 +65,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                 VM.Instruction instruction1 = instructions[i + 1].instruction;
                 VM.Instruction instruction2 = instructions[i + 2].instruction;
                 if (instruction.OpCode == OpCode.PUSHDATA1
-                 && (instruction.Operand.ToArray().SequenceEqual(update)
-                  || instruction.Operand.ToArray().SequenceEqual(destroy))
+                 && instruction.Operand.ToArray().SequenceEqual(methodBytes)
                  && instruction1.OpCode == OpCode.PUSHDATA1 && instruction1.Operand.Span.SequenceEqual(NativeContract.ContractManagement.Hash.GetSpan())
                  && instruction2.OpCode == OpCode.SYSCALL && instruction2.TokenU32 == ApplicationEngine.System_Contract_Call.Hash)
                     return true;

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
@@ -110,7 +110,35 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             NefFile nef = CreateNefFile(script, tokens);
             var manifest = CreateManifest();
 
-            Assert.IsTrue(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "CALLT destroy with WriteStates should be detected");
+            Assert.IsFalse(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Destroy should not be reported as update");
+            Assert.IsTrue(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "CALLT destroy with WriteStates should be detected");
+        }
+
+        [TestMethod]
+        public void Test_UpdateAnalyzer_CallT_Destroy_WithoutWriteStates_NotDetected()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.CALLT, 0x00, 0x00,
+                (byte)OpCode.RET
+            ];
+
+            MethodToken[] tokens =
+            [
+                new MethodToken
+                {
+                    Hash = NativeContract.ContractManagement.Hash,
+                    Method = "destroy",
+                    ParametersCount = 0,
+                    HasReturnValue = false,
+                    CallFlags = CallFlags.AllowCall
+                }
+            ];
+
+            NefFile nef = CreateNefFile(script, tokens);
+            var manifest = CreateManifest();
+
+            Assert.IsFalse(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "CALLT destroy without WriteStates should not be detected");
         }
 
         /// <summary>
@@ -254,7 +282,34 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             NefFile nef = CreateNefFile(script.ToArray(), Array.Empty<MethodToken>());
             var manifest = CreateManifest();
 
-            Assert.IsTrue(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Syscall destroy pattern should be detected");
+            Assert.IsFalse(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Destroy should not be reported as update");
+            Assert.IsTrue(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "Syscall destroy pattern should be detected");
+        }
+
+        [TestMethod]
+        public void Test_UpdateAnalyzer_SyscallDestroyPattern_WithWrongHash_NotDetected()
+        {
+            byte[] destroyBytes = Encoding.UTF8.GetBytes("destroy");
+            byte[] hashBytes = UInt160.Zero.GetSpan().ToArray();
+            uint syscall = ApplicationEngine.System_Contract_Call.Hash;
+
+            var script = new List<byte>();
+            script.Add((byte)OpCode.PUSHDATA1);
+            script.Add((byte)destroyBytes.Length);
+            script.AddRange(destroyBytes);
+
+            script.Add((byte)OpCode.PUSHDATA1);
+            script.Add((byte)hashBytes.Length);
+            script.AddRange(hashBytes);
+
+            script.Add((byte)OpCode.SYSCALL);
+            script.AddRange(BitConverter.GetBytes(syscall));
+            script.Add((byte)OpCode.RET);
+
+            NefFile nef = CreateNefFile(script.ToArray(), Array.Empty<MethodToken>());
+            var manifest = CreateManifest();
+
+            Assert.IsFalse(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "Wrong target hash should not be detected as destroy");
         }
 
         [TestMethod]
@@ -293,6 +348,7 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
                 Console.SetOut(originalOut);
             }
 
+            Assert.IsTrue(stdout.ToString().Contains("can be destroyed", StringComparison.OrdinalIgnoreCase));
             Assert.IsFalse(stdout.ToString().Contains("cannot be updated", StringComparison.OrdinalIgnoreCase));
         }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
@@ -85,6 +85,33 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.IsFalse(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "CALLT without WriteStates should not be detected");
         }
 
+        [TestMethod]
+        public void Test_UpdateAnalyzer_CallT_Destroy_WithWriteStates()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.CALLT, 0x00, 0x00,
+                (byte)OpCode.RET
+            ];
+
+            MethodToken[] tokens =
+            [
+                new MethodToken
+                {
+                    Hash = NativeContract.ContractManagement.Hash,
+                    Method = "destroy",
+                    ParametersCount = 0,
+                    HasReturnValue = false,
+                    CallFlags = CallFlags.WriteStates
+                }
+            ];
+
+            NefFile nef = CreateNefFile(script, tokens);
+            var manifest = CreateManifest();
+
+            Assert.IsTrue(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "CALLT destroy with WriteStates should be detected");
+        }
+
         /// <summary>
         /// Test that the bitwise operator fix correctly identifies WriteStates flag.
         /// </summary>
@@ -201,6 +228,32 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             var manifest = CreateManifest();
 
             Assert.IsFalse(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Wrong target hash should not be detected as update");
+        }
+
+        [TestMethod]
+        public void Test_UpdateAnalyzer_SyscallDestroyPattern_Detected()
+        {
+            byte[] destroyBytes = Encoding.UTF8.GetBytes("destroy");
+            byte[] hashBytes = NativeContract.ContractManagement.Hash.GetSpan().ToArray();
+            uint syscall = ApplicationEngine.System_Contract_Call.Hash;
+
+            var script = new List<byte>();
+            script.Add((byte)OpCode.PUSHDATA1);
+            script.Add((byte)destroyBytes.Length);
+            script.AddRange(destroyBytes);
+
+            script.Add((byte)OpCode.PUSHDATA1);
+            script.Add((byte)hashBytes.Length);
+            script.AddRange(hashBytes);
+
+            script.Add((byte)OpCode.SYSCALL);
+            script.AddRange(BitConverter.GetBytes(syscall));
+            script.Add((byte)OpCode.RET);
+
+            NefFile nef = CreateNefFile(script.ToArray(), Array.Empty<MethodToken>());
+            var manifest = CreateManifest();
+
+            Assert.IsTrue(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Syscall destroy pattern should be detected");
         }
 
         private static NefFile CreateNefFile(byte[] script, MethodToken[] tokens)

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
@@ -16,6 +16,7 @@ using Neo.SmartContract.Native;
 using Neo.VM;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -254,6 +255,45 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             var manifest = CreateManifest();
 
             Assert.IsTrue(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Syscall destroy pattern should be detected");
+        }
+
+        [TestMethod]
+        public void Test_SecurityAnalyzer_DoesNotReportDestroyOnlyContractAsNonUpdatable()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.CALLT, 0x00, 0x00,
+                (byte)OpCode.RET
+            ];
+
+            MethodToken[] tokens =
+            [
+                new MethodToken
+                {
+                    Hash = NativeContract.ContractManagement.Hash,
+                    Method = "destroy",
+                    ParametersCount = 0,
+                    HasReturnValue = false,
+                    CallFlags = CallFlags.WriteStates
+                }
+            ];
+
+            NefFile nef = CreateNefFile(script, tokens);
+            var manifest = CreateManifest();
+
+            var stdout = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            try
+            {
+                Console.SetOut(stdout);
+                Neo.Compiler.SecurityAnalyzer.SecurityAnalyzer.AnalyzeWithPrint(nef, manifest, null);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            Assert.IsFalse(stdout.ToString().Contains("cannot be updated", StringComparison.OrdinalIgnoreCase));
         }
 
         private static NefFile CreateNefFile(byte[] script, MethodToken[] tokens)


### PR DESCRIPTION
## Summary
- extend `UpdateAnalyzer` to detect `ContractManagement.Destroy` with the same rules used for `Update`
- cover both `CALLT`-based and syscall-style destroy paths
- verify that `AnalyzeWithPrint` no longer reports a destroy-capable contract as non-updatable

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.UpdateAnalyzerTests"`

Related checklist item: issue #1556, Issue 11.
