### PR TITLE
feat(analyzer): detect direct recursive gas paths

### DIFF
--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
@@ -29,23 +29,36 @@ namespace Neo.Compiler.SecurityAnalyzer
         public class UnboundedOperationVulnerability
         {
             public readonly IReadOnlyList<int> backwardJumpAddresses;
+            public readonly IReadOnlyList<int> recursiveCallAddresses;
             public readonly JToken? debugInfo;
 
             public UnboundedOperationVulnerability(
                 IReadOnlyList<int> backwardJumpAddresses,
+                IReadOnlyList<int> recursiveCallAddresses,
                 JToken? debugInfo = null)
             {
                 this.backwardJumpAddresses = backwardJumpAddresses;
+                this.recursiveCallAddresses = recursiveCallAddresses;
                 this.debugInfo = debugInfo;
             }
 
             public string GetWarningInfo(bool print = false)
             {
-                if (backwardJumpAddresses.Count == 0)
+                if (backwardJumpAddresses.Count == 0 && recursiveCallAddresses.Count == 0)
                     return "";
-                string result = $"[SECURITY] Potential unbounded operations (backward jumps) detected at instruction addresses:{Environment.NewLine}" +
-                    $"\t{string.Join(", ", backwardJumpAddresses)}{Environment.NewLine}" +
-                    $"Unbounded loops can lead to excessive GAS consumption (DoS). Consider adding iteration limits.{Environment.NewLine}";
+
+                string result = "[SECURITY] Potential unbounded operations detected";
+                if (backwardJumpAddresses.Count > 0)
+                {
+                    result += $"{Environment.NewLine}Backward jumps at instruction addresses:{Environment.NewLine}" +
+                        $"\t{string.Join(", ", backwardJumpAddresses)}";
+                }
+                if (recursiveCallAddresses.Count > 0)
+                {
+                    result += $"{Environment.NewLine}Direct recursive calls at instruction addresses:{Environment.NewLine}" +
+                        $"\t{string.Join(", ", recursiveCallAddresses)}";
+                }
+                result += $"{Environment.NewLine}Unbounded loops or recursion can lead to excessive GAS consumption (DoS). Consider adding iteration limits or recursion guards.{Environment.NewLine}";
                 if (print)
                     Console.Write(result);
                 return result;
@@ -65,6 +78,19 @@ namespace Neo.Compiler.SecurityAnalyzer
                 ((Script)nef.Script).EnumerateInstructions().ToArray();
 
             List<int> backwardJumps = new();
+            List<int> recursiveCalls = new();
+
+            HashSet<int> methodStartOffsets = manifest.Abi.Methods.Select(m => m.Offset).ToHashSet();
+            foreach ((int addr, VM.Instruction instruction) in instructions)
+            {
+                if (instruction.OpCode != OpCode.CALL && instruction.OpCode != OpCode.CALL_L)
+                    continue;
+
+                int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                if (target >= 0)
+                    methodStartOffsets.Add(target);
+            }
+            int[] sortedOffsets = methodStartOffsets.OrderBy(o => o).ToArray();
 
             foreach ((int addr, VM.Instruction instruction) in instructions)
             {
@@ -76,7 +102,37 @@ namespace Neo.Compiler.SecurityAnalyzer
                     backwardJumps.Add(addr);
             }
 
-            return new UnboundedOperationVulnerability(backwardJumps, debugInfo);
+            foreach (int methodStart in sortedOffsets)
+            {
+                int methodEnd = GetMethodEnd(methodStart, sortedOffsets);
+                foreach ((int addr, VM.Instruction instruction) in instructions)
+                {
+                    if (addr < methodStart)
+                        continue;
+                    if (addr >= methodEnd)
+                        break;
+
+                    if (instruction.OpCode != OpCode.CALL && instruction.OpCode != OpCode.CALL_L)
+                        continue;
+
+                    int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                    if (target == methodStart)
+                        recursiveCalls.Add(addr);
+                }
+            }
+
+            return new UnboundedOperationVulnerability(backwardJumps, recursiveCalls, debugInfo);
+        }
+
+        private static int GetMethodEnd(int methodStart, int[] sortedOffsets)
+        {
+            int methodIndex = Array.BinarySearch(sortedOffsets, methodStart);
+            if (methodIndex < 0)
+                methodIndex = ~methodIndex;
+
+            return methodIndex + 1 < sortedOffsets.Length
+                ? sortedOffsets[methodIndex + 1]
+                : int.MaxValue;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UnboundedOperationAnalyzer.cs
@@ -42,6 +42,13 @@ namespace Neo.Compiler.SecurityAnalyzer
                 this.debugInfo = debugInfo;
             }
 
+            public UnboundedOperationVulnerability(
+                IReadOnlyList<int> backwardJumpAddresses,
+                JToken? debugInfo = null)
+                : this(backwardJumpAddresses, Array.Empty<int>(), debugInfo)
+            {
+            }
+
             public string GetWarningInfo(bool print = false)
             {
                 if (backwardJumpAddresses.Count == 0 && recursiveCallAddresses.Count == 0)

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
@@ -11,7 +11,10 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.SecurityAnalyzer;
+using Neo.SmartContract;
 using Neo.SmartContract.Testing;
+using Neo.VM;
+using System;
 
 namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
 {
@@ -33,7 +36,60 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             var result = UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(NefFile, Manifest, null);
             string warning = result.GetWarningInfo(print: false);
             Assert.IsTrue(warning.Contains("[SECURITY]"));
-            Assert.IsTrue(warning.Contains("backward jump"));
+            Assert.IsTrue(warning.Contains("Backward jumps"));
+        }
+
+        [TestMethod]
+        public void Test_UnboundedOperation_DetectsDirectRecursiveCall()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.CALL_L, 0x00, 0x00, 0x00, 0x00,
+                (byte)OpCode.RET
+            ];
+
+            var result = UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(1, result.recursiveCallAddresses.Count);
+            Assert.AreEqual(0, result.recursiveCallAddresses[0]);
+        }
+
+        private static NefFile CreateNefFile(byte[] script)
+        {
+            return new NefFile
+            {
+                Compiler = "test",
+                Source = "test.cs",
+                Tokens = Array.Empty<MethodToken>(),
+                Script = script
+            };
+        }
+
+        private static SmartContract.Manifest.ContractManifest CreateManifest()
+        {
+            return new SmartContract.Manifest.ContractManifest
+            {
+                Name = "TestContract",
+                Groups = Array.Empty<SmartContract.Manifest.ContractGroup>(),
+                SupportedStandards = Array.Empty<string>(),
+                Abi = new SmartContract.Manifest.ContractAbi
+                {
+                    Methods =
+                    [
+                        new SmartContract.Manifest.ContractMethodDescriptor
+                        {
+                            Name = "main",
+                            Offset = 0,
+                            Parameters = Array.Empty<SmartContract.Manifest.ContractParameterDefinition>(),
+                            ReturnType = ContractParameterType.Void,
+                            Safe = false
+                        }
+                    ],
+                    Events = Array.Empty<SmartContract.Manifest.ContractEventDescriptor>()
+                },
+                Permissions = Array.Empty<SmartContract.Manifest.ContractPermission>(),
+                Trusts = SmartContract.Manifest.WildcardContainer<SmartContract.Manifest.ContractPermissionDescriptor>.Create(),
+                Extra = null
+            };
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UnboundedOperation.cs
@@ -53,6 +53,14 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.AreEqual(0, result.recursiveCallAddresses[0]);
         }
 
+        [TestMethod]
+        public void Test_UnboundedOperationVulnerability_BackwardJumpOnlyCtor_RemainsCompatible()
+        {
+            var result = new UnboundedOperationAnalyzer.UnboundedOperationVulnerability(new[] { 7 }, null);
+            Assert.AreEqual(1, result.backwardJumpAddresses.Count);
+            Assert.AreEqual(0, result.recursiveCallAddresses.Count);
+        }
+
         private static NefFile CreateNefFile(byte[] script)
         {
             return new NefFile


### PR DESCRIPTION
## Summary
- extend `UnboundedOperationAnalyzer` beyond backward jumps to cover direct recursive calls
- keep backward jump reporting intact and add a separate recursive-call channel
- update warning text to mention recursion and add a focused recursive-call regression

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.UnboundedOperationTests"`

Related checklist item: issue #1556, Issue 15.
