### PR TITLE
fix(analyzer): inspect underscore ABI methods

### DIFF
--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
@@ -84,6 +84,9 @@ namespace Neo.Compiler.SecurityAnalyzer
 
             foreach (ContractMethodDescriptor method in methods)
             {
+                if (method.Name is "_deploy" or "_initialize")
+                    continue;
+
                 (bool hasStorageWrite, bool hasCheckWitness) = AnalyzeMethodAndStaticHelpers(
                     method.Offset,
                     instructions,

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/MissingCheckWitnessAnalyzer.cs
@@ -84,10 +84,6 @@ namespace Neo.Compiler.SecurityAnalyzer
 
             foreach (ContractMethodDescriptor method in methods)
             {
-                // Skip internal methods
-                if (method.Name.StartsWith("_"))
-                    continue;
-
                 (bool hasStorageWrite, bool hasCheckWitness) = AnalyzeMethodAndStaticHelpers(
                     method.Offset,
                     instructions,

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
@@ -74,6 +74,37 @@ public class Contract : SmartContract
             Assert.IsTrue(result.vulnerableMethodNames.Contains("_admin_transfer"));
         }
 
+        [TestMethod]
+        public void Test_MissingCheckWitness_Skips_Deploy_And_Initialize_Callbacks()
+        {
+            const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+
+public class Contract : SmartContract
+{
+    public static void _deploy(object data, bool update)
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, 1);
+    }
+
+    public static void _initialize()
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x02 }, 1);
+    }
+}";
+
+            var context = CompileSingleContract(source);
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+            var result = MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(
+                context.CreateExecutable(),
+                context.CreateManifest(),
+                null);
+
+            Assert.IsFalse(result.vulnerableMethodNames.Contains("_deploy"));
+            Assert.IsFalse(result.vulnerableMethodNames.Contains("_initialize"));
+        }
+
         private static CompilationContext CompileSingleContract(string sourceCode)
         {
             var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_MissingCheckWitness.cs
@@ -11,7 +11,11 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.SecurityAnalyzer;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
 using Neo.SmartContract.Testing;
+using System;
+using System.ComponentModel;
+using System.IO;
 using System.Linq;
 
 namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
@@ -41,6 +45,66 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.IsTrue(warning.Contains("[SECURITY]"));
             Assert.IsTrue(warning.Contains("unsafeUpdate"));
             Assert.IsTrue(warning.Contains("unsafeLocalUpdate"));
+        }
+
+        [TestMethod]
+        public void Test_MissingCheckWitness_DoesNotSkip_UnderscorePrefixedPublicAbiMethods()
+        {
+            const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+
+public class Contract : SmartContract
+{
+    [DisplayName(""_admin_transfer"")]
+    public static void AdminTransfer()
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, 1);
+    }
+}";
+
+            var context = CompileSingleContract(source);
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+            var result = MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(
+                context.CreateExecutable(),
+                context.CreateManifest(),
+                null);
+
+            Assert.IsTrue(result.vulnerableMethodNames.Contains("_admin_transfer"));
+        }
+
+        private static CompilationContext CompileSingleContract(string sourceCode)
+        {
+            var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+            File.WriteAllText(tempFile, sourceCode);
+
+            try
+            {
+                var options = new CompilationOptions
+                {
+                    Optimize = CompilationOptions.OptimizationType.All,
+                    Nullable = Microsoft.CodeAnalysis.NullableContextOptions.Enable,
+                    SkipRestoreIfAssetsPresent = true
+                };
+
+                var engine = new CompilationEngine(options);
+                var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+                var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+                var contexts = engine.CompileSources(new CompilationSourceReferences
+                {
+                    Projects = new[] { frameworkProject }
+                }, tempFile);
+
+                Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+                return contexts[0];
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop skipping underscore-prefixed public ABI methods in `MissingCheckWitnessAnalyzer`
- add a focused regression for a public ABI method exposed as `_admin_transfer`
- preserve the existing missing-check-witness warnings for current test contracts

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.MissingCheckWitnessTests.Test_MissingCheckWitness_DoesNotSkip_UnderscorePrefixedPublicAbiMethods|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.MissingCheckWitnessTests.Test_MissingCheckWitness|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.MissingCheckWitnessTests.Test_MissingCheckWitness_WarningInfo"`

Related checklist item: issue #1556, Issue 12.
