### PR TITLE
feat(analyzer): warn on unvalidated token callbacks

### DIFF
--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/SecurityAnalyzer.cs
@@ -22,6 +22,7 @@ namespace Neo.Compiler.SecurityAnalyzer
         {
             ReEntrancyAnalyzer.AnalyzeSingleContractReEntrancy(nef, manifest, debugInfo).GetWarningInfo(print: true);
             WriteInTryAnalyzer.AnalyzeWriteInTry(nef, manifest, debugInfo).GetWarningInfo(print: true);
+            TokenCallbackAuthorizationAnalyzer.AnalyzeTokenCallbacks(nef, manifest, debugInfo).GetWarningInfo(print: true);
             CheckWitnessAnalyzer.AnalyzeCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
             MissingCheckWitnessAnalyzer.AnalyzeMissingCheckWitness(nef, manifest, debugInfo).GetWarningInfo(print: true);
             UnboundedOperationAnalyzer.AnalyzeUnboundedOperations(nef, manifest, debugInfo).GetWarningInfo(print: true);

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/TokenCallbackAuthorizationAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/TokenCallbackAuthorizationAnalyzer.cs
@@ -1,0 +1,155 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TokenCallbackAuthorizationAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Json;
+using Neo.Optimizer;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo.Compiler.SecurityAnalyzer
+{
+    public static class TokenCallbackAuthorizationAnalyzer
+    {
+        public class TokenCallbackAuthorizationVulnerability
+        {
+            public readonly IReadOnlyList<string> vulnerableMethodNames;
+            public readonly JToken? debugInfo;
+
+            public TokenCallbackAuthorizationVulnerability(
+                IReadOnlyList<string> vulnerableMethodNames,
+                JToken? debugInfo = null)
+            {
+                this.vulnerableMethodNames = vulnerableMethodNames;
+                this.debugInfo = debugInfo;
+            }
+
+            public string GetWarningInfo(bool print = false)
+            {
+                if (vulnerableMethodNames.Count == 0)
+                    return "";
+
+                string result = $"[SECURITY] The following token payment callbacks write storage without validating Runtime.CallingScriptHash:{Environment.NewLine}" +
+                    $"\t{string.Join(", ", vulnerableMethodNames)}{Environment.NewLine}" +
+                    $"Validate the calling token contract hash in NEP-17/NEP-11 payment callbacks before mutating state.{Environment.NewLine}";
+                if (print)
+                    Console.Write(result);
+                return result;
+            }
+        }
+
+        public static TokenCallbackAuthorizationVulnerability AnalyzeTokenCallbacks(
+            NefFile nef, ContractManifest manifest, JToken? debugInfo = null)
+        {
+            (int addr, VM.Instruction instruction)[] instructions =
+                ((Script)nef.Script).EnumerateInstructions().ToArray();
+
+            ContractMethodDescriptor[] methods = manifest.Abi.Methods;
+            HashSet<int> methodStartOffsets = methods.Select(m => m.Offset).ToHashSet();
+            foreach ((int addr, VM.Instruction instruction) in instructions)
+            {
+                if (instruction.OpCode != VM.OpCode.CALL && instruction.OpCode != VM.OpCode.CALL_L)
+                    continue;
+
+                int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                if (target >= 0)
+                    methodStartOffsets.Add(target);
+            }
+            int[] sortedOffsets = methodStartOffsets.OrderBy(o => o).ToArray();
+
+            var callbackMethods = methods.Where(m =>
+                string.Equals(m.Name, "onNEP17Payment", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(m.Name, "onNEP11Payment", StringComparison.OrdinalIgnoreCase));
+
+            List<string> vulnerableMethods = new();
+            foreach (ContractMethodDescriptor method in callbackMethods)
+            {
+                (bool hasStorageWrite, bool hasCallingScriptHashValidation) = AnalyzeMethodAndStaticHelpers(
+                    method.Offset,
+                    instructions,
+                    sortedOffsets,
+                    methodStartOffsets);
+
+                if (hasStorageWrite && !hasCallingScriptHashValidation)
+                    vulnerableMethods.Add(method.Name);
+            }
+
+            return new TokenCallbackAuthorizationVulnerability(vulnerableMethods, debugInfo);
+        }
+
+        private static (bool hasStorageWrite, bool hasCallingScriptHashValidation) AnalyzeMethodAndStaticHelpers(
+            int methodStart,
+            (int addr, VM.Instruction instruction)[] instructions,
+            int[] sortedOffsets,
+            HashSet<int> methodStartOffsets)
+        {
+            bool hasStorageWrite = false;
+            bool hasCallingScriptHashValidation = false;
+
+            Stack<int> pendingMethodStarts = new();
+            HashSet<int> visitedMethodStarts = new();
+            pendingMethodStarts.Push(methodStart);
+
+            while (pendingMethodStarts.Count > 0)
+            {
+                int currentStart = pendingMethodStarts.Pop();
+                if (!visitedMethodStarts.Add(currentStart))
+                    continue;
+
+                int currentEnd = GetMethodEnd(currentStart, sortedOffsets);
+                foreach ((int addr, VM.Instruction instruction) in instructions)
+                {
+                    if (addr < currentStart)
+                        continue;
+                    if (addr >= currentEnd)
+                        break;
+
+                    if (instruction.OpCode == VM.OpCode.SYSCALL)
+                    {
+                        if (instruction.TokenU32 == ApplicationEngine.System_Storage_Put.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Delete.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Put.Hash
+                            || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Delete.Hash)
+                            hasStorageWrite = true;
+
+                        if (instruction.TokenU32 == ApplicationEngine.System_Runtime_GetCallingScriptHash.Hash)
+                            hasCallingScriptHashValidation = true;
+
+                        continue;
+                    }
+
+                    if (instruction.OpCode == VM.OpCode.CALL || instruction.OpCode == VM.OpCode.CALL_L)
+                    {
+                        int target = Neo.Optimizer.JumpTarget.ComputeJumpTarget(addr, instruction);
+                        if (methodStartOffsets.Contains(target))
+                            pendingMethodStarts.Push(target);
+                    }
+                }
+            }
+
+            return (hasStorageWrite, hasCallingScriptHashValidation);
+        }
+
+        private static int GetMethodEnd(int methodStart, int[] sortedOffsets)
+        {
+            int methodIndex = Array.BinarySearch(sortedOffsets, methodStart);
+            if (methodIndex < 0)
+                methodIndex = ~methodIndex;
+
+            return methodIndex + 1 < sortedOffsets.Length
+                ? sortedOffsets[methodIndex + 1]
+                : int.MaxValue;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/TokenCallbackAuthorizationAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/TokenCallbackAuthorizationAnalyzer.cs
@@ -69,8 +69,8 @@ namespace Neo.Compiler.SecurityAnalyzer
             int[] sortedOffsets = methodStartOffsets.OrderBy(o => o).ToArray();
 
             var callbackMethods = methods.Where(m =>
-                string.Equals(m.Name, "onNEP17Payment", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(m.Name, "onNEP11Payment", StringComparison.OrdinalIgnoreCase));
+                string.Equals(m.Name, "onNEP17Payment", StringComparison.Ordinal) ||
+                string.Equals(m.Name, "onNEP11Payment", StringComparison.Ordinal));
 
             List<string> vulnerableMethods = new();
             foreach (ContractMethodDescriptor method in callbackMethods)
@@ -123,7 +123,8 @@ namespace Neo.Compiler.SecurityAnalyzer
                             || instruction.TokenU32 == ApplicationEngine.System_Storage_Local_Delete.Hash)
                             hasStorageWrite = true;
 
-                        if (instruction.TokenU32 == ApplicationEngine.System_Runtime_GetCallingScriptHash.Hash)
+                        if (instruction.TokenU32 == ApplicationEngine.System_Runtime_GetCallingScriptHash.Hash
+                            && IsCallingScriptHashUsedDefensively(instructions, addr, currentEnd))
                             hasCallingScriptHashValidation = true;
 
                         continue;
@@ -141,11 +142,47 @@ namespace Neo.Compiler.SecurityAnalyzer
             return (hasStorageWrite, hasCallingScriptHashValidation);
         }
 
+        private static bool IsCallingScriptHashUsedDefensively(
+            (int addr, VM.Instruction instruction)[] instructions,
+            int callingScriptHashAddr,
+            int methodEnd)
+        {
+            int startIndex = Array.FindIndex(instructions, item => item.addr == callingScriptHashAddr);
+            if (startIndex < 0)
+                return false;
+
+            int inspected = 0;
+            for (int i = startIndex + 1; i < instructions.Length && instructions[i].addr < methodEnd && inspected < 6; i++)
+            {
+                VM.Instruction instruction = instructions[i].instruction;
+                if (instruction.OpCode == VM.OpCode.NOP)
+                    continue;
+
+                inspected++;
+
+                if (instruction.OpCode == VM.OpCode.DROP)
+                    return false;
+
+                if (instruction.OpCode is VM.OpCode.EQUAL
+                    or VM.OpCode.NOTEQUAL
+                    or VM.OpCode.JMPEQ
+                    or VM.OpCode.JMPEQ_L
+                    or VM.OpCode.JMPNE
+                    or VM.OpCode.JMPNE_L
+                    or VM.OpCode.JMPIF
+                    or VM.OpCode.JMPIF_L
+                    or VM.OpCode.JMPIFNOT
+                    or VM.OpCode.JMPIFNOT_L
+                    or VM.OpCode.ASSERT)
+                    return true;
+            }
+
+            return false;
+        }
+
         private static int GetMethodEnd(int methodStart, int[] sortedOffsets)
         {
             int methodIndex = Array.BinarySearch(sortedOffsets, methodStart);
-            if (methodIndex < 0)
-                methodIndex = ~methodIndex;
 
             return methodIndex + 1 < sortedOffsets.Length
                 ? sortedOffsets[methodIndex + 1]

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_TokenCallbackAuthorizationAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_TokenCallbackAuthorizationAnalyzer.cs
@@ -74,6 +74,61 @@ public class Contract : SmartContract
     }
 
     [TestMethod]
+    public void TokenCallbacks_FetchedAndDroppedCallingScriptHash_AreStillFlagged()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    public static void onNEP17Payment(UInt160 from, BigInteger amount, object data)
+    {
+        _ = Runtime.CallingScriptHash;
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, amount);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var result = TokenCallbackAuthorizationAnalyzer.AnalyzeTokenCallbacks(
+            context.CreateExecutable(),
+            context.CreateManifest(),
+            null);
+
+        CollectionAssert.AreEquivalent(new[] { "onNEP17Payment" }, result.vulnerableMethodNames.ToArray());
+    }
+
+    [TestMethod]
+    public void TokenCallbacks_RequireExactCallbackCasing()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    [DisplayName(""OnNEP17Payment"")]
+    public static void Payment(UInt160 from, BigInteger amount, object data)
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, amount);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var result = TokenCallbackAuthorizationAnalyzer.AnalyzeTokenCallbacks(
+            context.CreateExecutable(),
+            context.CreateManifest(),
+            null);
+
+        Assert.AreEqual(0, result.vulnerableMethodNames.Count);
+    }
+
+    [TestMethod]
     public void SecurityAnalyzer_AnalyzeWithPrint_IncludesTokenCallbackWarnings()
     {
         const string source = @"using Neo.SmartContract.Framework;

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_TokenCallbackAuthorizationAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_TokenCallbackAuthorizationAnalyzer.cs
@@ -1,0 +1,145 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using Neo.Compiler.SecurityAnalyzer;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer;
+
+[TestClass]
+public class TokenCallbackAuthorizationAnalyzerTests
+{
+    [TestMethod]
+    public void TokenCallbacks_WritingStorageWithoutCallingScriptHashValidation_AreFlagged()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    public static void onNEP17Payment(UInt160 from, BigInteger amount, object data)
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, amount);
+    }
+
+    public static void onNEP11Payment(UInt160 from, BigInteger amount, ByteString tokenId, object data)
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x02 }, amount);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var result = TokenCallbackAuthorizationAnalyzer.AnalyzeTokenCallbacks(
+            context.CreateExecutable(),
+            context.CreateManifest(),
+            null);
+
+        CollectionAssert.AreEquivalent(
+            new[] { "onNEP17Payment", "onNEP11Payment" },
+            result.vulnerableMethodNames.ToArray());
+    }
+
+    [TestMethod]
+    public void TokenCallbacks_WithCallingScriptHashValidation_AreNotFlagged()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    public static void onNEP17Payment(UInt160 from, BigInteger amount, object data)
+    {
+        if (Runtime.CallingScriptHash != NEO.Hash) throw new Exception();
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, amount);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var result = TokenCallbackAuthorizationAnalyzer.AnalyzeTokenCallbacks(
+            context.CreateExecutable(),
+            context.CreateManifest(),
+            null);
+
+        Assert.AreEqual(0, result.vulnerableMethodNames.Count);
+    }
+
+    [TestMethod]
+    public void SecurityAnalyzer_AnalyzeWithPrint_IncludesTokenCallbackWarnings()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    public static void onNEP17Payment(UInt160 from, BigInteger amount, object data)
+    {
+        Storage.Put(Storage.CurrentContext, new byte[] { 0x01 }, amount);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        using var stdout = new StringWriter();
+        TextWriter originalOut = Console.Out;
+        try
+        {
+            Console.SetOut(stdout);
+            Neo.Compiler.SecurityAnalyzer.SecurityAnalyzer.AnalyzeWithPrint(
+                context.CreateExecutable(),
+                context.CreateManifest(),
+                null);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        StringAssert.Contains(stdout.ToString(), "onNEP17Payment");
+        StringAssert.Contains(stdout.ToString(), "Runtime.CallingScriptHash");
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            return contexts[0];
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add analyzer coverage for `onNEP17Payment` and `onNEP11Payment` methods that write storage without reading `Runtime.CallingScriptHash`
- integrate the new callback warning into `SecurityAnalyzer.AnalyzeWithPrint`
- add focused tests for unsafe callbacks, validated callbacks, and default analyzer output

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.TokenCallbackAuthorizationAnalyzerTests|FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.SecurityAnalyzerTests"`

Related checklist item: issue #1556, Issue 13.
