### PR TITLE
fix(analyzer): trace dropped CheckWitness results

### DIFF
--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/CheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/CheckWitnessAnalyzer.cs
@@ -69,7 +69,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                 if (instruction.OpCode == OpCode.SYSCALL && instruction.TokenU32 == ApplicationEngine.System_Runtime_CheckWitness.Hash)
                 {
                     if (IsDroppedCheckWitnessResult(instructions, i))
-                        result.Add(i);
+                        result.Add(instructions[i].addr);
                 }
             }
             return new CheckWitnessVulnerability(result);

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/CheckWitnessAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/CheckWitnessAnalyzer.cs
@@ -68,13 +68,84 @@ namespace Neo.Compiler.SecurityAnalyzer
                 VM.Instruction instruction = instructions[i].instruction;
                 if (instruction.OpCode == OpCode.SYSCALL && instruction.TokenU32 == ApplicationEngine.System_Runtime_CheckWitness.Hash)
                 {
-                    if (i + 1 >= instructions.Length)
-                        return new CheckWitnessVulnerability(result);
-                    if (instructions[i + 1].instruction.OpCode == OpCode.DROP)
+                    if (IsDroppedCheckWitnessResult(instructions, i))
                         result.Add(i);
                 }
             }
             return new CheckWitnessVulnerability(result);
+        }
+
+        private static bool IsDroppedCheckWitnessResult((int addr, VM.Instruction instruction)[] instructions, int checkWitnessIndex)
+        {
+            int i = checkWitnessIndex + 1;
+            while (i < instructions.Length && instructions[i].instruction.OpCode == OpCode.NOP)
+                i++;
+
+            if (i >= instructions.Length)
+                return false;
+
+            if (instructions[i].instruction.OpCode == OpCode.DROP)
+                return true;
+
+            if (!TryGetLocalStoreSlot(instructions[i].instruction, out byte slot))
+                return false;
+
+            i++;
+            while (i < instructions.Length && instructions[i].instruction.OpCode == OpCode.NOP)
+                i++;
+
+            if (i >= instructions.Length || !TryGetLocalLoadSlot(instructions[i].instruction, out byte loadedSlot) || loadedSlot != slot)
+                return false;
+
+            i++;
+            while (i < instructions.Length && instructions[i].instruction.OpCode == OpCode.NOP)
+                i++;
+
+            return i < instructions.Length && instructions[i].instruction.OpCode == OpCode.DROP;
+        }
+
+        private static bool TryGetLocalStoreSlot(VM.Instruction instruction, out byte slot)
+        {
+            switch (instruction.OpCode)
+            {
+                case OpCode.STLOC0:
+                case OpCode.STLOC1:
+                case OpCode.STLOC2:
+                case OpCode.STLOC3:
+                case OpCode.STLOC4:
+                case OpCode.STLOC5:
+                case OpCode.STLOC6:
+                    slot = (byte)(instruction.OpCode - OpCode.STLOC0);
+                    return true;
+                case OpCode.STLOC:
+                    slot = instruction.TokenU8;
+                    return true;
+                default:
+                    slot = 0;
+                    return false;
+            }
+        }
+
+        private static bool TryGetLocalLoadSlot(VM.Instruction instruction, out byte slot)
+        {
+            switch (instruction.OpCode)
+            {
+                case OpCode.LDLOC0:
+                case OpCode.LDLOC1:
+                case OpCode.LDLOC2:
+                case OpCode.LDLOC3:
+                case OpCode.LDLOC4:
+                case OpCode.LDLOC5:
+                case OpCode.LDLOC6:
+                    slot = (byte)(instruction.OpCode - OpCode.LDLOC0);
+                    return true;
+                case OpCode.LDLOC:
+                    slot = instruction.TokenU8;
+                    return true;
+                default:
+                    slot = 0;
+                    return false;
+            }
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_CheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_CheckWitness.cs
@@ -11,7 +11,10 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler.SecurityAnalyzer;
+using Neo.SmartContract;
 using Neo.SmartContract.Testing;
+using Neo.VM;
+using System;
 
 namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
 {
@@ -23,6 +26,77 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         {
             var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(NefFile, Manifest, null);
             Assert.AreEqual(result.droppedCheckWitnessResults.Count, 1);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_DetectsDropAfterNop()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.NOP,
+                (byte)OpCode.DROP,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(1, result.droppedCheckWitnessResults.Count);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_DetectsDropAfterSimpleLocalRoundTrip()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.INITSLOT, 0x01, 0x00,
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.STLOC0,
+                (byte)OpCode.LDLOC0,
+                (byte)OpCode.DROP,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(1, result.droppedCheckWitnessResults.Count);
+        }
+
+        private static NefFile CreateNefFile(byte[] script)
+        {
+            return new NefFile
+            {
+                Compiler = "test",
+                Source = "test.cs",
+                Tokens = Array.Empty<MethodToken>(),
+                Script = script
+            };
+        }
+
+        private static SmartContract.Manifest.ContractManifest CreateManifest()
+        {
+            return new SmartContract.Manifest.ContractManifest
+            {
+                Name = "TestContract",
+                Groups = Array.Empty<SmartContract.Manifest.ContractGroup>(),
+                SupportedStandards = Array.Empty<string>(),
+                Abi = new SmartContract.Manifest.ContractAbi
+                {
+                    Methods =
+                    [
+                        new SmartContract.Manifest.ContractMethodDescriptor
+                        {
+                            Name = "main",
+                            Offset = 0,
+                            Parameters = Array.Empty<SmartContract.Manifest.ContractParameterDefinition>(),
+                            ReturnType = ContractParameterType.Void,
+                            Safe = false
+                        }
+                    ],
+                    Events = Array.Empty<SmartContract.Manifest.ContractEventDescriptor>()
+                },
+                Permissions = Array.Empty<SmartContract.Manifest.ContractPermission>(),
+                Trusts = SmartContract.Manifest.WildcardContainer<SmartContract.Manifest.ContractPermissionDescriptor>.Create(),
+                Extra = null
+            };
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_CheckWitness.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_CheckWitness.cs
@@ -60,6 +60,100 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.AreEqual(1, result.droppedCheckWitnessResults.Count);
         }
 
+        [TestMethod]
+        public void Test_CheckWitness_DetectsDropAfterGenericLocalRoundTrip()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.INITSLOT, 0x08, 0x00,
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.STLOC, 0x07,
+                (byte)OpCode.NOP,
+                (byte)OpCode.LDLOC, 0x07,
+                (byte)OpCode.NOP,
+                (byte)OpCode.DROP,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(1, result.droppedCheckWitnessResults.Count);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_IgnoresTrailingNopWithoutConsumer()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.NOP
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.droppedCheckWitnessResults.Count);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_IgnoresNonDroppedStoredResult()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.INITSLOT, 0x01, 0x00,
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.STLOC0,
+                (byte)OpCode.LDLOC0,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.droppedCheckWitnessResults.Count);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_IgnoresStoreWithoutReload()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.INITSLOT, 0x01, 0x00,
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.STLOC0,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.droppedCheckWitnessResults.Count);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_IgnoresMismatchedLocalRoundTrip()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.INITSLOT, 0x02, 0x00,
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.STLOC0,
+                (byte)OpCode.LDLOC1,
+                (byte)OpCode.DROP,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.droppedCheckWitnessResults.Count);
+        }
+
+        [TestMethod]
+        public void Test_CheckWitness_IgnoresNonLocalConsumer()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.SYSCALL, .. BitConverter.GetBytes(ApplicationEngine.System_Runtime_CheckWitness.Hash),
+                (byte)OpCode.NZ,
+                (byte)OpCode.RET
+            ];
+
+            var result = CheckWitnessAnalyzer.AnalyzeCheckWitness(CreateNefFile(script), CreateManifest(), null);
+            Assert.AreEqual(0, result.droppedCheckWitnessResults.Count);
+        }
+
         private static NefFile CreateNefFile(byte[] script)
         {
             return new NefFile


### PR DESCRIPTION
## Summary
- improve `CheckWitnessAnalyzer` beyond the immediate `DROP` pattern
- catch dropped results after harmless `NOP`s and after a simple `STLOC`/`LDLOC` round-trip
- add focused synthetic-script regressions for those two cases

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer.CheckWitnessTests"`

Related checklist item: issue #1556, Issue 14.
