### PR TITLE
fix(compiler): avoid faulting on invalid BigInteger.TryParse

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
@@ -213,7 +213,7 @@ partial class MethodConvert
     /// <param name="instanceExpression">The instance expression (if any)</param>
     /// <param name="arguments">The method arguments</param>
     /// <remarks>
-    /// Algorithm: Uses StdLib.atoi to parse string to BigInteger, stores result in static field, returns success flag
+    /// Algorithm: Validates the decimal string shape before calling StdLib.atoi so invalid input returns false instead of faulting.
     /// </remarks>
     private static void HandleBigIntegerTryParseWithOut(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
@@ -226,24 +226,83 @@ partial class MethodConvert
         methodConvert.Swap();
         methodConvert.Drop();
 
+        byte strSlot = methodConvert.AddAnonymousVariable();
+        byte lengthSlot = methodConvert.AddAnonymousVariable();
+        byte indexSlot = methodConvert.AddAnonymousVariable();
+
+        JumpTarget failTarget = new();
+        JumpTarget signTarget = new();
+        JumpTarget loopTarget = new();
+        JumpTarget parseTarget = new();
+        JumpTarget endTarget = new();
+
+        methodConvert.AccessSlot(OpCode.STLOC, strSlot);
+
+        methodConvert.AccessSlot(OpCode.LDLOC, strSlot);
+        methodConvert.IsNull();
+        methodConvert.JumpIfTrueLong(failTarget);
+
+        methodConvert.AccessSlot(OpCode.LDLOC, strSlot);
+        methodConvert.Size();
+        methodConvert.AccessSlot(OpCode.STLOC, lengthSlot);
+
+        methodConvert.AccessSlot(OpCode.LDLOC, lengthSlot);
+        methodConvert.Nz();
+        methodConvert.JumpIfFalseLong(failTarget);
+
+        methodConvert.Push0();
+        methodConvert.AccessSlot(OpCode.STLOC, indexSlot);
+
+        methodConvert.AccessSlot(OpCode.LDLOC, strSlot);
+        methodConvert.Push0();
+        methodConvert.PickItem();
+        methodConvert.Dup();
+        methodConvert.Push((ushort)'-');
+        methodConvert.NumEqual();
+        methodConvert.JumpIfTrueLong(signTarget);
+        methodConvert.Push((ushort)'+');
+        methodConvert.NumEqual();
+        methodConvert.JumpIfTrueLong(signTarget);
+        methodConvert.JumpAlwaysLong(loopTarget);
+
+        signTarget.Instruction = methodConvert.Nop();
+        methodConvert.AccessSlot(OpCode.LDLOC, lengthSlot);
+        methodConvert.Push1();
+        methodConvert.NumEqual();
+        methodConvert.JumpIfTrueLong(failTarget);
+        methodConvert.Push1();
+        methodConvert.AccessSlot(OpCode.STLOC, indexSlot);
+
+        loopTarget.Instruction = methodConvert.Nop();
+        methodConvert.AccessSlot(OpCode.LDLOC, indexSlot);
+        methodConvert.AccessSlot(OpCode.LDLOC, lengthSlot);
+        methodConvert.Ge();
+        methodConvert.JumpIfTrueLong(parseTarget);
+
+        methodConvert.AccessSlot(OpCode.LDLOC, strSlot);
+        methodConvert.AccessSlot(OpCode.LDLOC, indexSlot);
+        methodConvert.PickItem();
+        methodConvert.Within('0', '9');
+        methodConvert.JumpIfFalseLong(failTarget);
+
+        methodConvert.AccessSlot(OpCode.LDLOC, indexSlot);
+        methodConvert.Inc();
+        methodConvert.AccessSlot(OpCode.STLOC, indexSlot);
+        methodConvert.JumpAlwaysLong(loopTarget);
+
+        parseTarget.Instruction = methodConvert.Nop();
+        methodConvert.AccessSlot(OpCode.LDLOC, strSlot);
+
         // Convert string to BigInteger
         methodConvert.CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
-
-        // Check if the parsing was successful
-        methodConvert.Dup();                                       // Duplicate result for null check
-        methodConvert.IsNull();                                    // Check if null (parse failed)
-        JumpTarget failTarget = new();
-        methodConvert.JumpIfTrueLong(failTarget);            // Jump to fail if null
 
         // If successful, store the value and push true
         methodConvert.AccessSlot(OpCode.STSFLD, index);            // Store value in static field
         methodConvert.Push(true);                                  // Push success flag
-        JumpTarget endTarget = new();
-        methodConvert.JumpAlwaysLong(endTarget);               // Jump to end
+        methodConvert.JumpAlwaysLong(endTarget);
 
-        // Fail target: clear parsed value, set out parameter default, then push false
-        failTarget.Instruction = methodConvert.Drop();             // Drop the failed value
-        methodConvert.PushDefault(symbol.Parameters[1].Type);      // Default out value on parse failure
+        // Invalid input target: set the out parameter default and return false
+        failTarget.Instruction = methodConvert.PushDefault(symbol.Parameters[1].Type);
         methodConvert.AccessSlot(OpCode.STSFLD, index);            // Store default in out parameter capture
         methodConvert.Push(false);                                 // Push failure flag
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigIntegerTryParse.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BigIntegerTryParse.cs
@@ -59,6 +59,51 @@ public class Contract : SmartContract
         Assert.AreEqual((System.Numerics.BigInteger)123, parsed);
     }
 
+    [TestMethod]
+    public void BigIntegerTryParse_ReturnsFalse_And_DefaultValue_ForInvalidInput()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+using System.ComponentModel;
+using System.Numerics;
+
+public class Contract : SmartContract
+{
+    [DisplayName(""test"")]
+    public static (bool, BigInteger) Test(string s)
+    {
+        bool success = BigInteger.TryParse(s, out BigInteger result);
+        return (success, result);
+    }
+}";
+
+        var context = CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<BigIntegerTryParseContract>(context.CreateExecutable(), context.CreateManifest());
+
+        var result = contract.Test("abc");
+        Assert.IsNotNull(result);
+        var tuple = result!;
+
+        bool success = tuple[0] switch
+        {
+            StackItem stackItem => stackItem.GetBoolean(),
+            bool value => value,
+            _ => throw new AssertFailedException($"Unexpected success result type: {tuple[0]?.GetType().Name ?? "null"}")
+        };
+
+        System.Numerics.BigInteger parsed = tuple[1] switch
+        {
+            System.Numerics.BigInteger value => value,
+            StackItem stackItem => stackItem.GetInteger(),
+            _ => throw new AssertFailedException($"Unexpected parsed value type: {tuple[1]?.GetType().Name ?? "null"}")
+        };
+
+        Assert.IsFalse(success, "BigInteger.TryParse should report failure for an invalid integer string.");
+        Assert.AreEqual(System.Numerics.BigInteger.Zero, parsed);
+    }
+
     private static CompilationContext CompileSingleContract(string sourceCode)
     {
         var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");


### PR DESCRIPTION
## Summary
- validate the BigInteger.TryParse input shape before lowering to StdLib.atoi
- return `false` with the default out value for invalid input instead of faulting the VM
- add a regression test for invalid input on dynamically compiled contracts

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_BigIntegerTryParse`

Follow-up for the regression left after merged #1557.