### PR TITLE
fix(compiler): avoid self contract dependency cycles

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -212,33 +212,7 @@ namespace Neo.Compiler
         public (List<INamedTypeSymbol> sortedClasses, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols) PrepareProjectContracts(string csproj)
         {
             Compilation ??= GetCompilation(csproj);
-            var classDependencies = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
-            var allSmartContracts = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-            var allClassSymbols = new List<INamedTypeSymbol?>();
-            foreach (var tree in Compilation.SyntaxTrees)
-            {
-                var semanticModel = Compilation.GetSemanticModel(tree);
-                var classNodes = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
-
-                foreach (var classNode in classNodes)
-                {
-                    var classSymbol = semanticModel.GetDeclaredSymbol(classNode);
-                    allClassSymbols.Add(classSymbol);
-                    if (classSymbol is { IsAbstract: false, DeclaredAccessibility: Accessibility.Public } && IsDerivedFromSmartContract(classSymbol))
-                    {
-                        allSmartContracts.Add(classSymbol);
-                        classDependencies[classSymbol] = [];
-                        foreach (var member in classSymbol.GetMembers())
-                        {
-                            var memberTypeSymbol = (member as IFieldSymbol)?.Type ?? (member as IPropertySymbol)?.Type;
-                            if (memberTypeSymbol is INamedTypeSymbol namedTypeSymbol && allSmartContracts.Contains(namedTypeSymbol) && !namedTypeSymbol.IsAbstract)
-                            {
-                                classDependencies[classSymbol].Add(namedTypeSymbol);
-                            }
-                        }
-                    }
-                }
-            }
+            var (classDependencies, allClassSymbols) = BuildContractDependencyGraph(Compilation);
 
             // Verify if there is any valid smart contract class
             if (classDependencies.Count == 0) throw new FormatException("No valid neo SmartContract found. Please make sure your contract is subclass of SmartContract and is not abstract.");
@@ -279,49 +253,7 @@ namespace Neo.Compiler
         private List<CompilationContext> CompileProjectContracts(Compilation compilation)
         {
             Contexts.Clear();
-            var classDependencies = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
-            var allSmartContracts = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-            var allClassSymbols = new List<INamedTypeSymbol?>();
-            var classSymbols = new List<INamedTypeSymbol>();
-            foreach (var tree in compilation.SyntaxTrees)
-            {
-                var semanticModel = compilation.GetSemanticModel(tree);
-                var classNodes = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
-
-                foreach (var classNode in classNodes)
-                {
-                    var classSymbol = semanticModel.GetDeclaredSymbol(classNode);
-                    allClassSymbols.Add(classSymbol);
-                    if (classSymbol is null) continue;
-
-                    classSymbols.Add(classSymbol);
-                    if (classSymbol is { IsAbstract: false, DeclaredAccessibility: Accessibility.Public } && IsDerivedFromSmartContract(classSymbol))
-                    {
-                        allSmartContracts.Add(classSymbol);
-                        classDependencies[classSymbol] = [];
-                    }
-                }
-            }
-
-            foreach (var classSymbol in classSymbols)
-            {
-                if (!allSmartContracts.Contains(classSymbol))
-                    continue;
-
-                foreach (var member in classSymbol.GetMembers())
-                {
-                    var memberTypeSymbol = (member as IFieldSymbol)?.Type ?? (member as IPropertySymbol)?.Type;
-                    if (memberTypeSymbol is not INamedTypeSymbol namedTypeSymbol)
-                        continue;
-                    if (namedTypeSymbol.IsAbstract)
-                        continue;
-                    if (!allSmartContracts.Contains(namedTypeSymbol))
-                        continue;
-                    if (classDependencies[classSymbol].Any(p => SymbolEqualityComparer.Default.Equals(p, namedTypeSymbol)))
-                        continue;
-                    classDependencies[classSymbol].Add(namedTypeSymbol);
-                }
-            }
+            var (classDependencies, allClassSymbols) = BuildContractDependencyGraph(compilation);
 
             // Verify if there is any valid smart contract class
             if (classDependencies.Count == 0) throw new FormatException("No valid neo SmartContract found. Please make sure your contract is subclass of SmartContract and is not abstract.");
@@ -340,6 +272,58 @@ namespace Neo.Compiler
             });
 
             return Contexts.Select(p => p.Value).ToList();
+        }
+
+        private static (Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols) BuildContractDependencyGraph(Compilation compilation)
+        {
+            var classDependencies = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+            var allSmartContracts = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var allClassSymbols = new List<INamedTypeSymbol?>();
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var classNodes = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
+
+                foreach (var classNode in classNodes)
+                {
+                    var classSymbol = semanticModel.GetDeclaredSymbol(classNode);
+                    allClassSymbols.Add(classSymbol);
+
+                    if (classSymbol is not { IsAbstract: false, DeclaredAccessibility: Accessibility.Public } || !IsDerivedFromSmartContract(classSymbol))
+                        continue;
+
+                    allSmartContracts.Add(classSymbol);
+                    classDependencies[classSymbol] = [];
+                }
+            }
+
+            foreach (var contractSymbol in allSmartContracts)
+            {
+                AddMemberDependencies(contractSymbol, allSmartContracts, classDependencies);
+            }
+
+            return (classDependencies, allClassSymbols);
+        }
+
+        private static void AddMemberDependencies(INamedTypeSymbol contractSymbol, HashSet<INamedTypeSymbol> allSmartContracts, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies)
+        {
+            foreach (var member in contractSymbol.GetMembers())
+            {
+                var memberTypeSymbol = (member as IFieldSymbol)?.Type ?? (member as IPropertySymbol)?.Type;
+                if (memberTypeSymbol is not INamedTypeSymbol namedTypeSymbol)
+                    continue;
+                if (namedTypeSymbol.IsAbstract)
+                    continue;
+                if (!allSmartContracts.Contains(namedTypeSymbol))
+                    continue;
+                if (SymbolEqualityComparer.Default.Equals(contractSymbol, namedTypeSymbol))
+                    continue;
+                if (classDependencies[contractSymbol].Any(p => SymbolEqualityComparer.Default.Equals(p, namedTypeSymbol)))
+                    continue;
+
+                classDependencies[contractSymbol].Add(namedTypeSymbol);
+            }
         }
 
         /// <summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractDependencies.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractDependencies.cs
@@ -1,0 +1,126 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_ContractDependencies
+{
+    private const string SelfReferentialContractSource = """
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static Contract? Next { get; set; }
+}
+""";
+
+    [TestMethod]
+    public void CompileSources_SelfReferentialContract_CompilesSuccessfully()
+    {
+        var context = CompileSingleSource(SelfReferentialContractSource);
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+    }
+
+    [TestMethod]
+    public void PrepareProjectContracts_SelfReferentialContract_CompilesSuccessfully()
+    {
+        using var project = TemporaryProject.Create("SelfReferenceContract", SelfReferentialContractSource);
+
+        var options = new CompilationOptions
+        {
+            Optimize = CompilationOptions.OptimizationType.All,
+            Nullable = NullableContextOptions.Enable,
+            SkipRestoreIfAssetsPresent = true
+        };
+
+        var engine = new CompilationEngine(options);
+        var (sortedClasses, classDependencies, allClassSymbols) = engine.PrepareProjectContracts(project.ProjectPath);
+        var context = engine.CompileProject(project.ProjectPath, sortedClasses, classDependencies, allClassSymbols, "Contract").Single();
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+    }
+
+    private static CompilationContext CompileSingleSource(string sourceCode)
+    {
+        using var project = TemporaryProject.Create("SingleSourceContract", sourceCode);
+
+        var options = new CompilationOptions
+        {
+            Optimize = CompilationOptions.OptimizationType.All,
+            Nullable = NullableContextOptions.Enable,
+            SkipRestoreIfAssetsPresent = true
+        };
+
+        var engine = new CompilationEngine(options);
+        var references = new CompilationSourceReferences
+        {
+            Projects = new[] { project.FrameworkProjectPath }
+        };
+
+        var contexts = engine.CompileSources(references, project.SourcePath);
+        Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+        return contexts[0];
+    }
+
+    private sealed class TemporaryProject : IDisposable
+    {
+        private TemporaryProject(string directory, string projectPath, string sourcePath, string frameworkProjectPath)
+        {
+            Directory = directory;
+            ProjectPath = projectPath;
+            SourcePath = sourcePath;
+            FrameworkProjectPath = frameworkProjectPath;
+        }
+
+        public string Directory { get; }
+
+        public string ProjectPath { get; }
+
+        public string SourcePath { get; }
+
+        public string FrameworkProjectPath { get; }
+
+        public static TemporaryProject Create(string projectName, string sourceCode)
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "Neo.Compiler.UnitTests", Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(directory);
+
+            var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProjectPath = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+            var sourcePath = Path.Combine(directory, "Contract.cs");
+            var projectPath = Path.Combine(directory, $"{projectName}.csproj");
+
+            File.WriteAllText(sourcePath, sourceCode);
+            File.WriteAllText(projectPath, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>{{RuntimeAssemblyResolver.CompilerTargetFrameworkMoniker}}</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{{frameworkProjectPath}}" />
+  </ItemGroup>
+</Project>
+""");
+
+            return new TemporaryProject(directory, projectPath, sourcePath, frameworkProjectPath);
+        }
+
+        public void Dispose()
+        {
+            if (System.IO.Directory.Exists(Directory))
+            {
+                System.IO.Directory.Delete(Directory, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- unify smart contract dependency graph construction across `PrepareProjectContracts` and `CompileProjectContracts`
- ignore self-referential smart contract member dependencies so `Contract` fields/properties of type `Contract` do not create a false cycle
- add regression tests covering both `CompileSources` and `PrepareProjectContracts` paths

## Problem
A self-referential contract like:

```csharp
using Neo.SmartContract.Framework;

public class Contract : SmartContract
{
    public static Contract? Next { get; set; }
}
```

caused `nccs` to crash with `System.InvalidOperationException: Cyclic dependency detected` instead of compiling normally.

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --filter "FullyQualifiedName~UnitTest_ContractDependencies|FullyQualifiedName~UnitTest_TempProjectGeneration|FullyQualifiedName~ProjectBoundaryTests"`
- direct CLI repro with the minimal self-referential contract now exits successfully
