### PR TITLE
Analyze task-like method signatures

### DIFF
--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -51,3 +51,4 @@ NC4053  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (file-local types)
 NC4054  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (ref readonly parameters)
 NC4055  | Usage    | Warning  | InitialValueAnalyzer (Parse enforcement)
 NC4056  | Security | Warning  | StorageKeyCollisionAnalyzer
+NC4057  | Type     | Error    | TaskLikeTypeUsageAnalyzer

--- a/src/Neo.SmartContract.Analyzer/TaskLikeTypeUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/TaskLikeTypeUsageAnalyzer.cs
@@ -1,0 +1,93 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TaskLikeTypeUsageAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Neo.SmartContract.Analyzer;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class TaskLikeTypeUsageAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NC4057";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Usage of task-like types is not allowed in Neo smart contracts",
+        "Neo smart contracts do not support task-like type: {0}",
+        "Type",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeParameter, SyntaxKind.Parameter);
+    }
+
+    private static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not MethodDeclarationSyntax methodDeclaration ||
+            methodDeclaration.Modifiers.Any(SyntaxKind.AsyncKeyword))
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetTypeInfo(methodDeclaration.ReturnType, context.CancellationToken).Type;
+        ReportIfTaskLike(context, methodDeclaration.ReturnType.GetLocation(), type);
+    }
+
+    private static void AnalyzeParameter(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ParameterSyntax parameter || parameter.Type is null)
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken)?.Type;
+        ReportIfTaskLike(context, parameter.Type.GetLocation(), type);
+    }
+
+    private static void ReportIfTaskLike(SyntaxNodeAnalysisContext context, Location location, ITypeSymbol? type)
+    {
+        if (!IsTaskLikeType(type))
+        {
+            return;
+        }
+
+        var diagnostic = Diagnostic.Create(Rule, location, type!.ToDisplayString());
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool IsTaskLikeType(ITypeSymbol? type)
+    {
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return false;
+        }
+
+        var originalType = namedType.OriginalDefinition;
+        if (originalType.ContainingNamespace.ToDisplayString() != "System.Threading.Tasks")
+        {
+            return false;
+        }
+
+        return originalType.MetadataName is "Task" or "Task`1" or "ValueTask" or "ValueTask`1";
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/TaskLikeTypeUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/TaskLikeTypeUsageAnalyzerUnitTests.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TaskLikeTypeUsageAnalyzerUnitTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.TaskLikeTypeUsageAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests;
+
+[TestClass]
+public class TaskLikeTypeUsageAnalyzerUnitTests
+{
+    [TestMethod]
+    public async Task TaskLikeMethodSignature_ShouldReportDiagnostic()
+    {
+        var test = """
+                   using System.Threading.Tasks;
+
+                   class Test
+                   {
+                       public {|#0:Task<int>|} Echo({|#1:Task<int>|} value) => value;
+                       public {|#2:ValueTask|} Run({|#3:ValueTask<int>|} value) => default;
+                   }
+                   """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(0).WithArguments("System.Threading.Tasks.Task<int>"),
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(1).WithArguments("System.Threading.Tasks.Task<int>"),
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(2).WithArguments("System.Threading.Tasks.ValueTask"),
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(3).WithArguments("System.Threading.Tasks.ValueTask<int>"),
+        };
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add an analyzer rule for task-like method return and parameter types
- report Task, Task<T>, ValueTask, and ValueTask<T> in non-async contract signatures
- register the new analyzer rule and cover it with unit tests

## Validation
- dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter "TaskLikeMethodSignature_ShouldReportDiagnostic" --no-restore
- dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --no-restore