### PR TITLE
Clarify character helper semantics

### DIFF
--- a/docs/csharp-syntax/SemanticDifferences.md
+++ b/docs/csharp-syntax/SemanticDifferences.md
@@ -33,3 +33,15 @@ Accepted false literals:
 Notes:
 - This intentionally diverges from .NET `bool.TryParse`, which only accepts `true` and `false` case-insensitively.
 - Whitespace-padded inputs such as `" true "` are still rejected.
+
+## `char` and `string` character helpers
+
+The compiler supports a contract-oriented subset of `char` and `string` helper methods. Character classification and casing helpers are ASCII-oriented rather than full .NET Unicode category operations.
+
+Examples:
+- `char.IsLetter`, `char.IsUpper`, and `char.IsLower` check the `A-Z` and `a-z` ranges.
+- `char.ToUpper`, `char.ToLower`, `char.ToUpperInvariant`, and `char.ToLowerInvariant` convert ASCII letters and leave other characters unchanged.
+- `string.ToUpper` and `string.ToLower` apply the same ASCII-oriented casing behavior to each character.
+- `char.GetNumericValue` returns integer values for `0-9` and `-1` for other characters. It does not return `double` values or implement the full .NET Unicode numeric category behavior.
+
+This keeps contract execution deterministic and avoids culture-dependent behavior.

--- a/docs/csharp-syntax/csharp-1.md
+++ b/docs/csharp-syntax/csharp-1.md
@@ -178,7 +178,7 @@ unsafe
 
 Status: supported
 Scope: method
-Notes: Common `string` APIs such as indexing, substring, and replacement work as expected.
+Notes: Common `string` APIs such as indexing, substring, and replacement compile successfully. Case conversion and character classification are ASCII-oriented in Neo contracts; see [Semantic Differences](SemanticDifferences.md#char-and-string-character-helpers).
 ```csharp
 string phrase = "neo compiler";
 int spaceIndex = phrase.IndexOf(' ');
@@ -246,7 +246,7 @@ bool hasSingleBit = System.Numerics.BitOperations.IsPow2(32);
 
 Status: supported
 Scope: method
-Notes: `char` classification and casing helpers compile and behave like desktop C#.
+Notes: `char` classification and casing helpers compile for the supported ASCII-oriented contract semantics. They do not provide full .NET Unicode category behavior; see [Semantic Differences](SemanticDifferences.md#char-and-string-character-helpers).
 ```csharp
 char symbol = 'n';
 bool isLetter = char.IsLetter(symbol);


### PR DESCRIPTION
## Summary
- document ASCII-oriented char and string helper semantics
- clarify that char.GetNumericValue does not implement full .NET Unicode numeric behavior
- link C# 1 syntax notes to the semantic differences page

## Validation
- git diff --check