### PR TITLE
Analyze unsupported platform APIs

### DIFF
--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -52,3 +52,4 @@ NC4054  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (ref readonly paramete
 NC4055  | Usage    | Warning  | InitialValueAnalyzer (Parse enforcement)
 NC4056  | Security | Warning  | StorageKeyCollisionAnalyzer
 NC4057  | Type     | Error    | TaskLikeTypeUsageAnalyzer
+NC4058  | Usage    | Error    | UnsupportedPlatformApiAnalyzer

--- a/src/Neo.SmartContract.Analyzer/UnsupportedPlatformApiAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/UnsupportedPlatformApiAnalyzer.cs
@@ -1,0 +1,172 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnsupportedPlatformApiAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Neo.SmartContract.Analyzer;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnsupportedPlatformApiAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NC4058";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Unsupported platform API is used",
+        "Neo smart contracts do not support platform API: {0}",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly string[] ForbiddenNamespaces =
+    [
+        "System.IO",
+        "System.Net",
+        "System.Reflection",
+        "System.Threading"
+    ];
+
+    private static readonly string[] ForbiddenSystemTypes =
+    [
+        "Activator",
+        "Console",
+        "DateTime",
+        "DateTimeOffset",
+        "Environment",
+        "GC",
+        "Guid",
+        "Random",
+        "TimeSpan",
+        "Type"
+    ];
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeUsingDirective, SyntaxKind.UsingDirective);
+        context.RegisterSyntaxNodeAction(AnalyzeQualifiedName, SyntaxKind.QualifiedName);
+        context.RegisterSyntaxNodeAction(AnalyzeIdentifierName, SyntaxKind.IdentifierName);
+        context.RegisterSyntaxNodeAction(AnalyzeMemberAccess, SyntaxKind.SimpleMemberAccessExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression);
+    }
+
+    private static void AnalyzeUsingDirective(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not UsingDirectiveSyntax usingDirective || usingDirective.Name is null)
+        {
+            return;
+        }
+
+        var name = usingDirective.Name.ToString();
+        if (IsForbiddenNamespace(name))
+        {
+            Report(context, usingDirective.GetLocation(), name);
+        }
+    }
+
+    private static void AnalyzeQualifiedName(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not QualifiedNameSyntax qualifiedName)
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetTypeInfo(qualifiedName, context.CancellationToken).Type;
+        ReportIfForbiddenType(context, qualifiedName.GetLocation(), type);
+    }
+
+    private static void AnalyzeIdentifierName(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not IdentifierNameSyntax identifier ||
+            identifier.IsVar ||
+            identifier.Parent is QualifiedNameSyntax or MemberAccessExpressionSyntax or UsingDirectiveSyntax)
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetTypeInfo(identifier, context.CancellationToken).Type;
+        ReportIfForbiddenType(context, identifier.GetLocation(), type);
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ObjectCreationExpressionSyntax objectCreation)
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetTypeInfo(objectCreation, context.CancellationToken).Type;
+        ReportIfForbiddenType(context, objectCreation.Type.GetLocation(), type);
+    }
+
+    private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return;
+        }
+
+        var symbol = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
+        if (symbol is INamedTypeSymbol type)
+        {
+            ReportIfForbiddenType(context, memberAccess.GetLocation(), type);
+        }
+    }
+
+    private static void ReportIfForbiddenType(SyntaxNodeAnalysisContext context, Location location, ITypeSymbol? type)
+    {
+        if (type is not INamedTypeSymbol namedType || !IsForbiddenType(namedType))
+        {
+            return;
+        }
+
+        Report(context, location, namedType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+    }
+
+    private static bool IsForbiddenType(INamedTypeSymbol type)
+    {
+        var namespaceName = type.ContainingNamespace.ToDisplayString();
+        if (IsForbiddenNamespace(namespaceName))
+        {
+            return true;
+        }
+
+        return namespaceName == "System" && Array.IndexOf(ForbiddenSystemTypes, type.Name) >= 0;
+    }
+
+    private static bool IsForbiddenNamespace(string namespaceName)
+    {
+        foreach (var forbiddenNamespace in ForbiddenNamespaces)
+        {
+            if (namespaceName == forbiddenNamespace ||
+                namespaceName.StartsWith(forbiddenNamespace + ".", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void Report(SyntaxNodeAnalysisContext context, Location location, string api)
+    {
+        var diagnostic = Diagnostic.Create(Rule, location, api);
+        context.ReportDiagnostic(diagnostic);
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/UnsupportedPlatformApiAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/UnsupportedPlatformApiAnalyzerUnitTests.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnsupportedPlatformApiAnalyzerUnitTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.UnsupportedPlatformApiAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests;
+
+[TestClass]
+public class UnsupportedPlatformApiAnalyzerUnitTests
+{
+    [TestMethod]
+    public async Task UnsupportedPlatformNamespaces_ShouldReportDiagnostic()
+    {
+        var test = """
+                   {|#0:using System.IO;|}
+                   {|#1:using System.Net;|}
+                   {|#2:using System.Reflection;|}
+                   {|#3:using System.Threading;|}
+
+                   class Test
+                   {
+                   }
+                   """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(0).WithArguments("System.IO"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(1).WithArguments("System.Net"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(2).WithArguments("System.Reflection"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(3).WithArguments("System.Threading"),
+        };
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task UnsupportedPlatformTypes_ShouldReportDiagnostic()
+    {
+        var test = """
+                   class Test
+                   {
+                       void Run()
+                       {
+                           var memory = new {|#0:System.IO.MemoryStream|}();
+                           {|#1:System.Console|}.WriteLine("neo");
+                           var now = {|#2:System.DateTime|}.UtcNow;
+                           var id = {|#3:System.Guid|}.NewGuid();
+                           var random = new {|#4:System.Random|}();
+                       }
+                   }
+                   """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(0).WithArguments("System.IO.MemoryStream"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(1).WithArguments("System.Console"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(2).WithArguments("System.DateTime"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(3).WithArguments("System.Guid"),
+            VerifyCS.Diagnostic(UnsupportedPlatformApiAnalyzer.DiagnosticId).WithLocation(4).WithArguments("System.Random"),
+        };
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add analyzer coverage for unsupported platform namespaces such as System.IO, System.Net, System.Reflection, and System.Threading
- report unsupported runtime types such as Console, DateTime, Guid, Random, and Environment
- register the new analyzer rule and cover namespace and type usages with tests

## Validation
- dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter "UnsupportedPlatformApiAnalyzerUnitTests" --no-restore
- dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --no-restore