### PR TITLE
Use invariant culture in floating analyzer code fixes

### DIFF
--- a/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
@@ -154,7 +154,7 @@ namespace Neo.SmartContract.Analyzer
             {
                 if (literalExpression.Kind() == SyntaxKind.NumericLiteralExpression)
                 {
-                    var literalValue = double.Parse(literalExpression.Token.ValueText);
+                    var literalValue = double.Parse(literalExpression.Token.ValueText, CultureInfo.InvariantCulture);
                     return literalValue != Math.Floor(literalValue);
                 }
             }

--- a/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
@@ -154,7 +154,7 @@ namespace Neo.SmartContract.Analyzer
             {
                 if (literalExpression.Kind() == SyntaxKind.NumericLiteralExpression)
                 {
-                    var literalValue = double.Parse(literalExpression.Token.ValueText);
+                    var literalValue = double.Parse(literalExpression.Token.ValueText, CultureInfo.InvariantCulture);
                     return literalValue != Math.Floor(literalValue);
                 }
             }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Verifier =
@@ -99,6 +101,22 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                 .WithSpan(4, 31, 4, 46).WithArguments("double");
 
             await Verifier.VerifyCodeFixAsync(originalCode, expectedDiagnostic, fixedCode).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DoubleUsageAnalyzer_ReplaceWithVar_UnderCommaDecimalCulture()
+        {
+            // Regression: the code fix must not depend on CurrentCulture when parsing literals.
+            var previous = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("es-ES");
+            try
+            {
+                await DoubleUsageAnalyzer_ReplaceWithVar().ConfigureAwait(false);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = previous;
+            }
         }
 
     }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Verifier =
@@ -99,6 +101,22 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                 .WithSpan(4, 30, 4, 44).WithArguments("float");
 
             await Verifier.VerifyCodeFixAsync(originalCode, expectedDiagnostic, fixedCode).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task FloatUsageAnalyzer_ReplaceWithVar_UnderCommaDecimalCulture()
+        {
+            // Regression: the code fix must not depend on CurrentCulture when parsing literals.
+            var previous = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("es-ES");
+            try
+            {
+                await FloatUsageAnalyzer_ReplaceWithVar().ConfigureAwait(false);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = previous;
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- Parses floating-point literal text with `CultureInfo.InvariantCulture` in double/float analyzer code-fix helpers.
- Adds regression tests that run the fix path under a comma-decimal culture.

Closes #1582.

## Tested
- `git diff --check`
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter 'DoubleUsageAnalyzer_ReplaceWithVar_UnderCommaDecimalCulture|FloatUsageAnalyzer_ReplaceWithVar_UnderCommaDecimalCulture' -v minimal`
