### PR TITLE
Write project compile errors to stderr

### DIFF
--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -364,7 +364,7 @@ namespace Neo.Compiler
                     catch (Exception ex) when (!(ex is FormatException && ex.Message.Contains("No valid neo SmartContract found")))
                     {
                         // Only log errors for projects that aren't smart contracts
-                        Console.WriteLine($"Error compiling project {Path.GetFileName(projectPath)}: {ex.Message}");
+                        Console.Error.WriteLine($"Error compiling project {Path.GetFileName(projectPath)}: {ex.Message}");
                     }
                 }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NewCommand.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NewCommand.cs
@@ -206,6 +206,29 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsTrue(File.Exists(Path.Combine(_testOutputPath, contractName, "bin", "sc", $"{contractName}.artifacts.dll")));
         }
 
+        [TestMethod]
+        public void TestSolutionProjectCompilationErrorsGoToStdErr()
+        {
+            string solutionPath = Path.Combine(_testOutputPath, "Broken.sln");
+            string projectDirectory = Path.Combine(_testOutputPath, "Broken");
+            Directory.CreateDirectory(projectDirectory);
+            File.WriteAllText(Path.Combine(projectDirectory, "Broken.csproj"), "<Project>");
+            File.WriteAllText(solutionPath, """
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Broken", "Broken\Broken.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Global
+EndGlobal
+""");
+
+            var result = RunCompilerCommand($"\"{solutionPath}\"");
+
+            Assert.AreEqual(1, result.ExitCode);
+            StringAssert.Contains(result.StdErr, "Error compiling project Broken.csproj:");
+            Assert.IsFalse(result.StdOut.Contains("Error compiling project Broken.csproj:", StringComparison.Ordinal));
+        }
+
         private CommandResult RunCompilerCommand(string arguments)
         {
             var args = SplitArgs(arguments);


### PR DESCRIPTION
## Summary
- Routes project-level compile failure output through `Console.Error` instead of `Console.WriteLine`.
- Keeps the existing diagnostic text unchanged.

## Tested
- `git diff --check`
- `dotnet build src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -v minimal`
