### PR TITLE
Update remaining 2024 copyright headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ charset = utf-8
 end_of_line = lf
 #indent_style = tab  # TODO
 
-file_header_template = Copyright (C) 2015-2025 The Neo Project.\n\n{fileName} file belongs to the neo project and is free\nsoftware distributed under the MIT software license, see the\naccompanying file LICENSE in the main directory of the\nrepository or http://www.opensource.org/licenses/mit-license.php\nfor more details.\n\nRedistribution and use in source and binary forms with or without\nmodifications are permitted.
+file_header_template = Copyright (C) 2015-2026 The Neo Project.\n\n{fileName} file belongs to the neo project and is free\nsoftware distributed under the MIT software license, see the\naccompanying file LICENSE in the main directory of the\nrepository or http://www.opensource.org/licenses/mit-license.php\nfor more details.\n\nRedistribution and use in source and binary forms with or without\nmodifications are permitted.
 
 ###############################
 # Roslyn Analyzer Rules

--- a/src/Neo.Compiler.CSharp/ContractInterfaceGenerator.cs
+++ b/src/Neo.Compiler.CSharp/ContractInterfaceGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2024 The Neo Project.
+// Copyright (C) 2015-2026 The Neo Project.
 //
 // ContractInterfaceGenerator.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestNotary.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestNotary.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2015-2024 The Neo Project.
+// Copyright (C) 2015-2026 The Neo Project.
 //
 // TestNotary.cs file belongs to the neo project and is free
 // software distributed under the MIT software license, see the


### PR DESCRIPTION
## Summary
- Updates two remaining `2015-2024` source headers to `2015-2026`.
- Leaves file contents otherwise unchanged.

## Tested
- `git diff --check`
- `dotnet build src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -v minimal`
