### PR TITLE
Include dependency asset type in unsupported errors

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -470,7 +470,8 @@ namespace Neo.Compiler
         {
             if (!MetaReferences.TryGetValue(name, out var reference))
             {
-                switch (assets["libraries"]![name]!["type"]!.GetString())
+                string assetType = assets["libraries"]![name]!["type"]!.GetString();
+                switch (assetType)
                 {
                     case "package":
                         string packagesPath = assets["project"]!["restore"]!["packagesPath"]!.GetString();
@@ -507,7 +508,7 @@ namespace Neo.Compiler
                         reference = GetCompilationPreservingVersion(msbuildProject).ToMetadataReference();
                         break;
                     default:
-                        throw new NotSupportedException();
+                        throw new NotSupportedException($"Unsupported dependency asset type '{assetType}' for '{name}'.");
                 }
                 MetaReferences.Add(name, reference);
             }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
@@ -1,0 +1,56 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Json;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_CompilationEngineReference
+{
+    [TestMethod]
+    public void UnsupportedDependencyAssetTypeIncludesContext()
+    {
+        const string dependencyName = "bad.asset/1.0.0";
+        const string assetType = "unsupported-kind";
+        var engine = new CompilationEngine(new CompilationOptions());
+        var assets = new JObject
+        {
+            ["libraries"] = new JObject
+            {
+                [dependencyName] = new JObject
+                {
+                    ["type"] = assetType
+                }
+            },
+            ["project"] = new JObject
+            {
+                ["restore"] = new JObject
+                {
+                    ["packagesPath"] = Path.GetTempPath()
+                }
+            }
+        };
+        var method = typeof(CompilationEngine).GetMethod("GetReference", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method);
+
+        var exception = Assert.ThrowsException<TargetInvocationException>(() =>
+            method.Invoke(engine, new object[]
+            {
+                dependencyName,
+                new JObject(),
+                assets,
+                Path.GetTempPath(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            }));
+
+        Assert.IsInstanceOfType(exception.InnerException, typeof(NotSupportedException));
+        var innerException = (NotSupportedException)exception.InnerException!;
+        StringAssert.Contains(innerException.Message, assetType);
+        StringAssert.Contains(innerException.Message, dependencyName);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the unsupported dependency asset type and dependency name to the `NotSupportedException` message.
- Preserves the existing supported asset handling.

## Tested
- `git diff --check`
- `dotnet build src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -v minimal`
