### PR TITLE
Add NeoDebugInfo root object error message

### DIFF
--- a/src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs
@@ -202,7 +202,7 @@ namespace Neo.SmartContract.Testing.Coverage
             using StreamReader reader = new(stream);
             var text = reader.ReadToEnd();
             var json = JToken.Parse(text) ?? throw new InvalidOperationException();
-            if (json is not JObject jo) throw new FormatException();
+            if (json is not JObject jo) throw new FormatException("The debug info root must be a JSON object.");
             return FromDebugInfoJson(jo);
         }
 

--- a/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
@@ -29,10 +29,13 @@ namespace Neo.SmartContract.Testing.UnitTests.Coverage
         [TestMethod]
         public void NeoDebugInfoLoadThrowsHelpfulMessageForNonObjectJson()
         {
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes("[]"));
             var load = typeof(NeoDebugInfo).GetMethod("Load", BindingFlags.Static | BindingFlags.NonPublic);
             Assert.IsNotNull(load);
+            using var validStream = new MemoryStream(Encoding.UTF8.GetBytes("{\"hash\":\"0x0000000000000000000000000000000000000000\",\"documents\":[],\"methods\":[]}"));
 
+            Assert.IsNotNull(load.Invoke(null, new object[] { validStream }));
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes("[]"));
             var exception = Assert.ThrowsException<TargetInvocationException>(() => load.Invoke(null, new object[] { stream }));
 
             Assert.IsInstanceOfType(exception.InnerException, typeof(FormatException));

--- a/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
@@ -12,7 +12,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Neo.SmartContract.Testing.Coverage;
+using System;
+using System.IO;
 using System.Numerics;
+using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Neo.SmartContract.Testing.UnitTests.Coverage
@@ -21,6 +25,19 @@ namespace Neo.SmartContract.Testing.UnitTests.Coverage
     public class CoverageDataTests
     {
         private static readonly Regex WhiteSpaceRegex = new("\\s");
+
+        [TestMethod]
+        public void NeoDebugInfoLoadThrowsHelpfulMessageForNonObjectJson()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes("[]"));
+            var load = typeof(NeoDebugInfo).GetMethod("Load", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(load);
+
+            var exception = Assert.ThrowsException<TargetInvocationException>(() => load.Invoke(null, new object[] { stream }));
+
+            Assert.IsInstanceOfType(exception.InnerException, typeof(FormatException));
+            Assert.AreEqual("The debug info root must be a JSON object.", exception.InnerException!.Message);
+        }
 
         [TestMethod]
         public void TestDump()


### PR DESCRIPTION
## Summary
- Gives `NeoDebugInfo.Load` a specific `FormatException` message when the debug-info root is not a JSON object.
- Preserves the existing exception type.

## Tested
- `git diff --check`
- `dotnet build src/Neo.SmartContract.Testing/Neo.SmartContract.Testing.csproj -v minimal`
