### PR TITLE
Add read-only messages to RPC storage mutations

### DIFF
--- a/src/Neo.SmartContract.Testing/Storage/Rpc/RpcSnapshot.cs
+++ b/src/Neo.SmartContract.Testing/Storage/Rpc/RpcSnapshot.cs
@@ -42,7 +42,7 @@ internal class RpcSnapshot : IStoreSnapshot
     {
         if (IsDirty)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("RpcStore snapshots are read-only and cannot commit local mutations.");
         }
     }
 

--- a/src/Neo.SmartContract.Testing/Storage/Rpc/RpcStore.cs
+++ b/src/Neo.SmartContract.Testing/Storage/Rpc/RpcStore.cs
@@ -53,8 +53,8 @@ public class RpcStore : IStore
     /// <param name="url">Url</param>
     public RpcStore(string url) : this(new Uri(url)) { }
 
-    public void Delete(byte[] key) => throw new NotImplementedException();
-    public void Put(byte[] key, byte[] value) => throw new NotImplementedException();
+    public void Delete(byte[] key) => throw new NotImplementedException("RpcStore is read-only; use a local store for mutations.");
+    public void Put(byte[] key, byte[] value) => throw new NotImplementedException("RpcStore is read-only; use a local store for mutations.");
     public IStoreSnapshot GetSnapshot()
     {
         var snapshot = new RpcSnapshot(this);

--- a/tests/Neo.SmartContract.Testing.UnitTests/Storage/Rpc/RpcStoreTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Storage/Rpc/RpcStoreTests.cs
@@ -12,12 +12,37 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing.Storage;
 using Neo.SmartContract.Testing.Storage.Rpc;
+using System;
 
 namespace Neo.SmartContract.Testing.UnitTests.Storage
 {
     [TestClass]
     public class RpcStoreTests
     {
+        [TestMethod]
+        public void RpcStoreMutationsExplainReadOnlyBehavior()
+        {
+            var store = new RpcStore("http://localhost:10332");
+
+            var deleteException = Assert.ThrowsException<NotImplementedException>(() => store.Delete(new byte[] { 1 }));
+            StringAssert.Contains(deleteException.Message, "read-only");
+
+            var putException = Assert.ThrowsException<NotImplementedException>(() => store.Put(new byte[] { 1 }, new byte[] { 2 }));
+            StringAssert.Contains(putException.Message, "read-only");
+        }
+
+        [TestMethod]
+        public void RpcSnapshotCommitExplainsReadOnlyBehaviorWhenDirty()
+        {
+            var store = new RpcStore("http://localhost:10332");
+            var snapshot = store.GetSnapshot();
+            snapshot.Put(new byte[] { 1 }, new byte[] { 2 });
+
+            var exception = Assert.ThrowsException<NotImplementedException>(() => snapshot.Commit());
+
+            StringAssert.Contains(exception.Message, "read-only");
+        }
+
         [TestMethod]
         public void TestRpcStore()
         {


### PR DESCRIPTION
## Summary
- Adds messages to `RpcStore.Put`, `RpcStore.Delete`, and `RpcSnapshot.Commit`.
- Clarifies that RPC-backed storage is read-only and local storage should be used for mutations.

## Tested
- `git diff --check`
- `dotnet build src/Neo.SmartContract.Testing/Neo.SmartContract.Testing.csproj -v minimal`
