### PR TITLE
Update nccs template framework package version

### DIFF
--- a/src/Neo.Compiler.CSharp/TemplateManager.cs
+++ b/src/Neo.Compiler.CSharp/TemplateManager.cs
@@ -166,7 +166,7 @@ namespace Neo.Compiler
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Neo.SmartContract.Framework"" Version=""3.9.0"" />
+    <PackageReference Include=""Neo.SmartContract.Framework"" Version=""3.9.1"" />
   </ItemGroup>
 
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
@@ -186,7 +186,7 @@ namespace Neo.Compiler.CSharp.UnitTests
             string csprojContent = File.ReadAllText(csprojFilePath);
             Assert.IsTrue(csprojContent.Contains("<TargetFramework>net10.0</TargetFramework>"));
             Assert.IsTrue(csprojContent.Contains("<PackageReference Include=\"Neo.SmartContract.Framework\""));
-            Assert.IsTrue(csprojContent.Contains("Version=\"3.9.0\""));
+            Assert.IsTrue(csprojContent.Contains("Version=\"3.9.1\""));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- Updates the framework package version emitted by `nccs new` templates from `3.9.0` to `3.9.1`.
- Updates the template-manager unit test expectation.

## Tested
- `git diff --check`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_TemplateManager -v minimal`
