### PR TITLE
Report invalid direct constants as user diagnostics

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
@@ -67,6 +67,10 @@ internal partial class MethodConvert
             Push(value);
             return true;
         }
+        catch (CompilationException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             throw CompilationException.Unexpected("evaluating constant expression during conversion", e);
@@ -242,14 +246,21 @@ internal partial class MethodConvert
     private object ConvertComplexConstantTypes(ITypeSymbol typeSymbol, object value, ExpressionSyntax syntax)
     {
         string fullName = typeSymbol.ToDisplayString();
-        return fullName switch
+        try
         {
-            "Neo.SmartContract.Framework.UInt160" => ConvertToUInt160((string)value!),
-            "Neo.SmartContract.Framework.UInt256" => ConvertToUInt256((string)value!, syntax),
-            "Neo.SmartContract.Framework.ECPoint" => ConvertToECPoint((string)value!),
-            "Neo.SmartContract.Framework.ByteArray" => ((string)value!).HexToBytes(true),
-            _ => value
-        };
+            return fullName switch
+            {
+                "Neo.SmartContract.Framework.UInt160" => ConvertToUInt160((string)value!),
+                "Neo.SmartContract.Framework.UInt256" => ConvertToUInt256((string)value!, syntax),
+                "Neo.SmartContract.Framework.ECPoint" => ConvertToECPoint((string)value!),
+                "Neo.SmartContract.Framework.ByteArray" => ((string)value!).HexToBytes(true),
+                _ => value
+            };
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            throw new CompilationException(syntax, DiagnosticId.InvalidInitialValue, $"Invalid {typeSymbol.Name} literal");
+        }
     }
 
     private byte[] ConvertToUInt160(string strValue)

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
@@ -47,6 +47,7 @@ internal partial class MethodConvert
 
     private bool TryConvertConstant(SemanticModel model, ExpressionSyntax syntax, SyntaxNode? syntaxNode)
     {
+        ITypeSymbol? typeSymbol = null;
         try
         {
             // Get the correct model for the syntax node (fixes partial class issues)
@@ -57,7 +58,7 @@ internal partial class MethodConvert
             if (value == null)
                 return false;
 
-            ITypeSymbol? typeSymbol = GetTypeSymbol(syntaxNode, model);
+            typeSymbol = GetTypeSymbol(syntaxNode, model);
 
             if (typeSymbol != null)
             {
@@ -70,6 +71,10 @@ internal partial class MethodConvert
         catch (CompilationException)
         {
             throw;
+        }
+        catch (Exception e) when (typeSymbol is not null && e is FormatException or ArgumentException)
+        {
+            throw new CompilationException(syntax, DiagnosticId.InvalidInitialValue, $"Invalid {typeSymbol.Name} literal");
         }
         catch (Exception e)
         {
@@ -246,21 +251,14 @@ internal partial class MethodConvert
     private object ConvertComplexConstantTypes(ITypeSymbol typeSymbol, object value, ExpressionSyntax syntax)
     {
         string fullName = typeSymbol.ToDisplayString();
-        try
+        return fullName switch
         {
-            return fullName switch
-            {
-                "Neo.SmartContract.Framework.UInt160" => ConvertToUInt160((string)value!),
-                "Neo.SmartContract.Framework.UInt256" => ConvertToUInt256((string)value!, syntax),
-                "Neo.SmartContract.Framework.ECPoint" => ConvertToECPoint((string)value!),
-                "Neo.SmartContract.Framework.ByteArray" => ((string)value!).HexToBytes(true),
-                _ => value
-            };
-        }
-        catch (Exception ex) when (ex is FormatException or ArgumentException)
-        {
-            throw new CompilationException(syntax, DiagnosticId.InvalidInitialValue, $"Invalid {typeSymbol.Name} literal");
-        }
+            "Neo.SmartContract.Framework.UInt160" => ConvertToUInt160((string)value!),
+            "Neo.SmartContract.Framework.UInt256" => ConvertToUInt256((string)value!, syntax),
+            "Neo.SmartContract.Framework.ECPoint" => ConvertToECPoint((string)value!),
+            "Neo.SmartContract.Framework.ByteArray" => ((string)value!).HexToBytes(true),
+            _ => value
+        };
     }
 
     private byte[] ConvertToUInt160(string strValue)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DirectInitDiagnostics.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DirectInitDiagnostics.cs
@@ -1,0 +1,79 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_DirectInitDiagnostics.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_DirectInitDiagnostics
+{
+    [TestMethod]
+    public void InvalidDirectUInt256LiteralReportsInvalidInitialValue()
+    {
+        var context = CompileSingleContract("""
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    private static readonly UInt256 Hash = "abc";
+
+    public static UInt256 Test()
+    {
+        return Hash;
+    }
+}
+""");
+
+        var diagnostics = string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString()));
+        Assert.IsFalse(context.Success, diagnostics);
+        Assert.IsTrue(context.Diagnostics.Any(d => d.Id == DiagnosticId.InvalidInitialValue), diagnostics);
+        Assert.IsFalse(context.Diagnostics.Any(d => d.Id == DiagnosticId.UnexpectedCompilerError), diagnostics);
+    }
+
+    private static CompilationContext CompileSingleContract(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+
+            var engine = new CompilationEngine(options);
+            var repoRoot = SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile);
+
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            return contexts[0];
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DirectInitDiagnostics.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DirectInitDiagnostics.cs
@@ -24,12 +24,33 @@ public class UnitTest_DirectInitDiagnostics
     [TestMethod]
     public void InvalidDirectUInt256LiteralReportsInvalidInitialValue()
     {
-        var context = CompileSingleContract("""
+        var context = CompileSingleContractWithUInt256Literal("abc");
+
+        var diagnostics = string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString()));
+        Assert.IsFalse(context.Success, diagnostics);
+        Assert.IsTrue(context.Diagnostics.Any(d => d.Id == DiagnosticId.InvalidInitialValue), diagnostics);
+        Assert.IsFalse(context.Diagnostics.Any(d => d.Id == DiagnosticId.UnexpectedCompilerError), diagnostics);
+    }
+
+    [TestMethod]
+    public void WrongLengthDirectUInt256LiteralReportsInvalidInitialValue()
+    {
+        var context = CompileSingleContractWithUInt256Literal("abcd");
+
+        var diagnostics = string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString()));
+        Assert.IsFalse(context.Success, diagnostics);
+        Assert.IsTrue(context.Diagnostics.Any(d => d.Id == DiagnosticId.InvalidInitialValue), diagnostics);
+        Assert.IsFalse(context.Diagnostics.Any(d => d.Id == DiagnosticId.UnexpectedCompilerError), diagnostics);
+    }
+
+    private static CompilationContext CompileSingleContractWithUInt256Literal(string literal)
+    {
+        return CompileSingleContract($$"""
 using Neo.SmartContract.Framework;
 
 public class Contract : SmartContract
 {
-    private static readonly UInt256 Hash = "abc";
+    private static readonly UInt256 Hash = "{{literal}}";
 
     public static UInt256 Test()
     {
@@ -37,11 +58,6 @@ public class Contract : SmartContract
     }
 }
 """);
-
-        var diagnostics = string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString()));
-        Assert.IsFalse(context.Success, diagnostics);
-        Assert.IsTrue(context.Diagnostics.Any(d => d.Id == DiagnosticId.InvalidInitialValue), diagnostics);
-        Assert.IsFalse(context.Diagnostics.Any(d => d.Id == DiagnosticId.UnexpectedCompilerError), diagnostics);
     }
 
     private static CompilationContext CompileSingleContract(string sourceCode)


### PR DESCRIPTION
## Summary
- preserve existing CompilationException diagnostics during constant conversion
- map invalid direct framework literals to NC3005 instead of NC5001
- add a regression test for invalid direct UInt256 initialization

## Validation
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_DirectInitDiagnostics -v minimal --no-restore