### PR TITLE
Report failed dotnet restore immediately

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -419,7 +419,8 @@ namespace Neo.Compiler
                     FileName = "dotnet",
                     Arguments = $"restore \"{csproj}\"",
                     WorkingDirectory = folder
-                }) ?? throw new InvalidOperationException($"Unable to start dotnet restore for '{csproj}'.");
+                });
+                ArgumentNullException.ThrowIfNull(process);
                 process.WaitForExit();
                 if (process.ExitCode != 0)
                     throw new InvalidOperationException($"dotnet restore failed with exit code {process.ExitCode} for '{csproj}'.");

--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -419,8 +419,10 @@ namespace Neo.Compiler
                     FileName = "dotnet",
                     Arguments = $"restore \"{csproj}\"",
                     WorkingDirectory = folder
-                });
-                process?.WaitForExit();
+                }) ?? throw new InvalidOperationException($"Unable to start dotnet restore for '{csproj}'.");
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                    throw new InvalidOperationException($"dotnet restore failed with exit code {process.ExitCode} for '{csproj}'.");
             }
 
             if (!File.Exists(assetsPath))

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
@@ -13,6 +13,34 @@ namespace Neo.Compiler.CSharp.UnitTests;
 public class UnitTest_CompilationEngineReference
 {
     [TestMethod]
+    public void GetCompilation_ReportsRestoreFailureExitCode()
+    {
+        var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempFolder);
+        var projectFile = Path.Combine(tempFolder, "BadRestore.csproj");
+        File.WriteAllText(projectFile, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+""");
+
+        try
+        {
+            var engine = new CompilationEngine(new CompilationOptions());
+            var exception = Assert.ThrowsException<InvalidOperationException>(() => engine.GetCompilation(projectFile));
+
+            StringAssert.Contains(exception.Message, "dotnet restore failed");
+            StringAssert.Contains(exception.Message, "exit code");
+            StringAssert.Contains(exception.Message, projectFile);
+        }
+        finally
+        {
+            Directory.Delete(tempFolder, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public void UnsupportedDependencyAssetTypeIncludesContext()
     {
         const string dependencyName = "bad.asset/1.0.0";


### PR DESCRIPTION
## Summary
- check that dotnet restore starts successfully
- fail immediately when restore exits nonzero
- add coverage for restore failure reporting on an invalid project

## Validation
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_CompilationEngineReference -v minimal --no-restore