### PR TITLE
Add verifiable testing API spelling

### DIFF
--- a/src/Neo.Compiler.CSharp/Extensions/ArtifactExtensions.cs
+++ b/src/Neo.Compiler.CSharp/Extensions/ArtifactExtensions.cs
@@ -28,7 +28,7 @@ namespace Neo.SmartContract.Testing.Extensions
         private const string TestingSmartContractInitializeType = "Neo.SmartContract.Testing.SmartContractInitialize";
         private const string TestingNep17StandardType = "Neo.SmartContract.Testing.TestingStandards.INep17Standard";
         private const string TestingOwnableType = "Neo.SmartContract.Testing.TestingStandards.IOwnable";
-        private const string TestingVerificableType = "Neo.SmartContract.Testing.TestingStandards.IVerificable";
+        private const string TestingVerifiableType = "Neo.SmartContract.Testing.TestingStandards.IVerifiable";
 
         static readonly string[] _protectedWords =
         [
@@ -137,7 +137,7 @@ namespace Neo.SmartContract.Testing.Extensions
 
             if (IsNep17(manifest)) inheritance.Add(TestingNep17StandardType);
             if (IsOwnable(manifest)) inheritance.Add(TestingOwnableType);
-            if (IsVerificable(manifest)) inheritance.Add(TestingVerificableType);
+            if (IsVerifiable(manifest)) inheritance.Add(TestingVerifiableType);
 
             sourceCode.WriteLine("using Neo.Cryptography.ECC;");
             sourceCode.WriteLine("using Neo.Extensions;");
@@ -616,7 +616,7 @@ namespace Neo.SmartContract.Testing.Extensions
                     u.Parameters[1].Type == ContractParameterType.Hash160);
         }
 
-        private static bool IsVerificable(ContractManifest manifest)
+        private static bool IsVerifiable(ContractManifest manifest)
         {
             var method = manifest.Abi.GetMethod("verify", 0);
             return method is { Safe: true } && method.ReturnType == ContractParameterType.Boolean;

--- a/src/Neo.SmartContract.Testing/Extensions/StandardExtensions.cs
+++ b/src/Neo.SmartContract.Testing/Extensions/StandardExtensions.cs
@@ -46,13 +46,24 @@ namespace Neo.SmartContract.Testing.Extensions
         }
 
         /// <summary>
+        /// Is Verifiable
+        /// </summary>
+        /// <param name="manifest">Manifest</param>
+        /// <returns>True if is Verifiable</returns>
+        public static bool IsVerifiable(this ContractManifest manifest)
+        {
+            return manifest.Abi.Methods.Any(u => u.Name == "verify" && u.Safe && u.Parameters.Length == 0);
+        }
+
+        /// <summary>
         /// Is Verificable
         /// </summary>
         /// <param name="manifest">Manifest</param>
         /// <returns>True if is Verificable</returns>
+        [Obsolete("Use IsVerifiable instead.")]
         public static bool IsVerificable(this ContractManifest manifest)
         {
-            return manifest.Abi.Methods.Any(u => u.Name == "verify" && u.Safe && u.Parameters.Length == 0);
+            return IsVerifiable(manifest);
         }
     }
 }

--- a/src/Neo.SmartContract.Testing/Native/Oracle.cs
+++ b/src/Neo.SmartContract.Testing/Native/Oracle.cs
@@ -14,7 +14,7 @@ using System.ComponentModel;
 
 namespace Neo.SmartContract.Testing.Native;
 
-public abstract class Oracle(SmartContractInitialize initialize) : SmartContract(initialize), TestingStandards.IVerificable
+public abstract class Oracle(SmartContractInitialize initialize) : SmartContract(initialize), TestingStandards.IVerifiable
 {
     #region Compiled data
 

--- a/src/Neo.SmartContract.Testing/TestingStandards/IVerifiable.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/IVerifiable.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+
+namespace Neo.SmartContract.Testing.TestingStandards;
+
+public interface IVerifiable
+{
+    /// <summary>
+    /// Safe property
+    /// </summary>
+    public bool? Verify { [DisplayName("verify")] get; }
+}

--- a/src/Neo.SmartContract.Testing/TestingStandards/IVerificable.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/IVerificable.cs
@@ -9,14 +9,11 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using System.ComponentModel;
+using System;
 
 namespace Neo.SmartContract.Testing.TestingStandards;
 
-public interface IVerificable
+[Obsolete("Use IVerifiable instead.")]
+public interface IVerificable : IVerifiable
 {
-    /// <summary>
-    /// Safe property
-    /// </summary>
-    public bool? Verify { [DisplayName("verify")] get; }
 }

--- a/src/Neo.SmartContract.Testing/TestingStandards/OwnableTests.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/OwnableTests.cs
@@ -91,7 +91,7 @@ public class OwnableTests<T> : TestBase<T>
     [TestMethod]
     public virtual void TestVerify()
     {
-        if (Contract is IVerificable verificable)
+        if (Contract is IVerifiable verificable)
         {
             Engine.SetTransactionSigners(Alice);
             Assert.IsTrue(verificable.Verify);

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep11/TestingArtifacts/Nep11ContractTemplate.artifacts.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep11/TestingArtifacts/Nep11ContractTemplate.artifacts.cs
@@ -9,7 +9,7 @@ using System.Numerics;
 
 namespace Neo.SmartContract.Testing;
 
-public abstract class Nep11ContractTemplate(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.IOwnable, Neo.SmartContract.Testing.TestingStandards.IVerificable, IContractInfo
+public abstract class Nep11ContractTemplate(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.IOwnable, Neo.SmartContract.Testing.TestingStandards.IVerifiable, IContractInfo
 {
     #region Compiled data
 

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep17/TestingArtifacts/Nep17ContractTemplate.artifacts.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep17/TestingArtifacts/Nep17ContractTemplate.artifacts.cs
@@ -9,7 +9,7 @@ using System.Numerics;
 
 namespace Neo.SmartContract.Testing;
 
-public abstract class Nep17ContractTemplate(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.INep17Standard, Neo.SmartContract.Testing.TestingStandards.IOwnable, Neo.SmartContract.Testing.TestingStandards.IVerificable, IContractInfo
+public abstract class Nep17ContractTemplate(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.INep17Standard, Neo.SmartContract.Testing.TestingStandards.IOwnable, Neo.SmartContract.Testing.TestingStandards.IVerifiable, IContractInfo
 {
     #region Compiled data
 

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractsolution/TestingArtifacts/NeoContractSolutionTemplate.artifacts.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractsolution/TestingArtifacts/NeoContractSolutionTemplate.artifacts.cs
@@ -9,7 +9,7 @@ using System.Numerics;
 
 namespace Neo.SmartContract.Testing;
 
-public abstract class NeoContractSolutionTemplate(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.IOwnable, Neo.SmartContract.Testing.TestingStandards.IVerificable, IContractInfo
+public abstract class NeoContractSolutionTemplate(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.IOwnable, Neo.SmartContract.Testing.TestingStandards.IVerifiable, IContractInfo
 {
     #region Compiled data
 

--- a/tests/Neo.SmartContract.Testing.UnitTests/Extensions/ArtifactExtensionsTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Extensions/ArtifactExtensionsTests.cs
@@ -41,7 +41,7 @@ namespace Neo.SmartContract.Testing.UnitTests.Extensions
 
                                     namespace Neo.SmartContract.Testing;
 
-                                    public abstract class Contract1(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.INep17Standard, Neo.SmartContract.Testing.TestingStandards.IVerificable, IContractInfo
+                                    public abstract class Contract1(Neo.SmartContract.Testing.SmartContractInitialize initialize) : Neo.SmartContract.Testing.SmartContract(initialize), Neo.SmartContract.Testing.TestingStandards.INep17Standard, Neo.SmartContract.Testing.TestingStandards.IVerifiable, IContractInfo
                                     {
                                         #region Compiled data
 
@@ -148,6 +148,51 @@ namespace Neo.SmartContract.Testing.UnitTests.Extensions
                                     }
 
                                     """.Replace("\r\n", "\n").TrimStart());
+        }
+
+        [TestMethod]
+        public void TestIsVerifiableRecognizesSafeBooleanVerify()
+        {
+            var manifest = CreateVerifyManifest(safe: true);
+
+            Assert.IsTrue(manifest.IsVerifiable());
+#pragma warning disable CS0618
+            Assert.IsTrue(manifest.IsVerificable());
+#pragma warning restore CS0618
+        }
+
+        [TestMethod]
+        public void TestIsVerifiableRejectsUnsafeVerify()
+        {
+            var manifest = CreateVerifyManifest(safe: false);
+
+            Assert.IsFalse(manifest.IsVerifiable());
+        }
+
+        private static ContractManifest CreateVerifyManifest(bool safe)
+        {
+            return new ContractManifest
+            {
+                Name = "TestContract",
+                Groups = [],
+                SupportedStandards = [],
+                Abi = new ContractAbi
+                {
+                    Methods =
+                    [
+                        new ContractMethodDescriptor
+                        {
+                            Name = "verify",
+                            Parameters = [],
+                            ReturnType = ContractParameterType.Boolean,
+                            Safe = safe
+                        }
+                    ],
+                    Events = []
+                },
+                Permissions = [],
+                Trusts = WildcardContainer<ContractPermissionDescriptor>.Create()
+            };
         }
     }
 }


### PR DESCRIPTION
Summary:
- add correctly spelled IVerifiable and IsVerifiable testing APIs
- keep obsolete IVerificable and IsVerificable aliases for compatibility
- update generated artifact expectations to use IVerifiable

Tests:
- dotnet build src/Neo.SmartContract.Testing/Neo.SmartContract.Testing.csproj
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter ArtifactExtensionsTests
