### PR TITLE
Support C# 14 extension members

### DIFF
--- a/docs/csharp-syntax/UnsupportedFeatures.md
+++ b/docs/csharp-syntax/UnsupportedFeatures.md
@@ -67,7 +67,6 @@ The versioned syntax checklists flag every feature the Neo compiler currently re
   - Shape constraints (`shape_constraints`)
   - Discriminated union declarations (`discriminated_union_types`)
   - Default parameters in lambda expressions (`lambda_default_parameters`)
-  - Extension members (`extension_members`)
   - Additional Span/ReadOnlySpan conversions (`span_arraysegment_conversions`)
   - Modifiers on simple lambda parameters (`lambda_parameter_modifiers`)
   - Partial events and constructors (`partial_events_constructors`)

--- a/docs/csharp-syntax/csharp-14.md
+++ b/docs/csharp-syntax/csharp-14.md
@@ -48,23 +48,25 @@ var result = formatter(value: 12);
 
 ### extension_members - Extension members
 
-Status: unsupported
+Status: supported
 Scope: file
-Notes: Extension declarations introduce new top-level `extension` blocks that attach members to existing types. Roslyn must project the new members into metadata before Neo compiles the contract; the current toolchain rejects the syntax entirely.
+Notes: Instance extension methods and extension properties declared inside an `extension` block compile. Neo maps the extension receiver to the first method slot so member bodies can read it like a normal instance receiver. Static extension members and extension operators remain outside this covered subset.
 ```csharp
 using Neo.SmartContract.Framework;
 
-extension (this int value)
+public static class IntExtensions
 {
-    public int Twice()
+    extension(int value)
     {
-        return value * 2;
+        public int Twice() => value * 2;
+
+        public int Triple => value * 3;
     }
 }
 
 public class ExtensionMemberContract : SmartContract
 {
-    public static int Compute(int value) => value.Twice();
+    public static int Compute(int value) => value.Twice() + value.Triple;
 }
 ```
 

--- a/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/SourceConvert.cs
@@ -36,6 +36,16 @@ internal partial class MethodConvert
         int parameterSlotCount = Symbol.Parameters.Length + (NeedInstanceConstructor(Symbol) ? 1 : 0);
         RequireByteSizedSlotCount(Symbol, parameterSlotCount, "parameters");
 
+        if (NeedInstanceConstructor(Symbol) &&
+            TryGetExtensionReceiverParameter(out IParameterSymbol? receiverParameter) &&
+            receiverParameter is not null)
+        {
+            _parameters.TryAdd(receiverParameter, 0);
+            IParameterSymbol original = receiverParameter.OriginalDefinition;
+            if (!SymbolEqualityComparer.Default.Equals(receiverParameter, original))
+                _parameters.TryAdd(original, 0);
+        }
+
         for (int i = 0; i < Symbol.Parameters.Length; i++)
         {
             IParameterSymbol parameter = Symbol.Parameters[i];
@@ -54,6 +64,28 @@ internal partial class MethodConvert
                 _context.GetOrAddCapturedStaticField(parameter);
             }
         }
+    }
+
+    private bool TryGetExtensionReceiverParameter(out IParameterSymbol? receiverParameter)
+    {
+        receiverParameter = null;
+        if (Symbol.DeclaringSyntaxReferences.IsEmpty)
+            return false;
+
+        SyntaxNode syntax = Symbol.DeclaringSyntaxReferences[0].GetSyntax();
+        ExtensionDeclarationSyntax? extension = syntax.AncestorsAndSelf()
+            .OfType<ExtensionDeclarationSyntax>()
+            .FirstOrDefault();
+        if (extension is null)
+            return false;
+        if (extension.ParameterList?.Parameters.Count != 1)
+            return false;
+
+        SemanticModel model = ((ISourceAssemblySymbol)Symbol.ContainingAssembly)
+            .Compilation
+            .GetSemanticModel(extension.SyntaxTree);
+        receiverParameter = model.GetDeclaredSymbol(extension.ParameterList.Parameters[0]) as IParameterSymbol;
+        return receiverParameter is not null;
     }
 
     private void ConvertSource(SemanticModel model)

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Extensions.cs
@@ -17,6 +17,13 @@ namespace Neo.Compiler.CSharp.TestContracts
         {
             return a + b;
         }
+
+        extension(int value)
+        {
+            public int Twice() => value * 2;
+
+            public int Triple => value * 3;
+        }
     }
 
     public class Contract_Extensions : SmartContract.Framework.SmartContract
@@ -24,6 +31,21 @@ namespace Neo.Compiler.CSharp.TestContracts
         public static int TestSum(int a, int b)
         {
             return a.sum(b);
+        }
+
+        public static int TestExtensionMemberMethod(int value)
+        {
+            return value.Twice();
+        }
+
+        public static int TestExtensionMemberProperty(int value)
+        {
+            return value.Triple;
+        }
+
+        public static int TestExtensionMemberCombination(int value)
+        {
+            return value.Twice() + value.Triple;
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Extensions.cs
@@ -24,6 +24,20 @@ namespace Neo.Compiler.CSharp.TestContracts
 
             public int Triple => value * 3;
         }
+
+        extension(ExtensionBox box)
+        {
+            public int ExtensionValue
+            {
+                get => box.Value;
+                set => box.Value = value;
+            }
+        }
+    }
+
+    public class ExtensionBox
+    {
+        public int Value { get; set; }
     }
 
     public class Contract_Extensions : SmartContract.Framework.SmartContract
@@ -46,6 +60,13 @@ namespace Neo.Compiler.CSharp.TestContracts
         public static int TestExtensionMemberCombination(int value)
         {
             return value.Twice() + value.Triple;
+        }
+
+        public static int TestExtensionMemberPropertySetter(int value)
+        {
+            var box = new ExtensionBox();
+            box.ExtensionValue = value;
+            return box.Value;
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Extensions.cs
@@ -13,16 +13,72 @@ public abstract class Contract_Extensions(Neo.SmartContract.Testing.SmartContrac
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Extensions"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testSum"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Extensions"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testSum"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testExtensionMemberMethod"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":61,""safe"":false},{""name"":""testExtensionMemberProperty"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":121,""safe"":false},{""name"":""testExtensionMemberCombination"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":181,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD1XAAJ5eDQDQFcAAnh5nkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9A65VCBA==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAO5XAAJ5eDQDQFcAAnh5nkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwABeDQDQFcAAXgSoEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwABeDQDQFcAAXgToEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwABeDSLeDTEnkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AqUZ2aA==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
     #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeDSLeDTEnkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9A
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALL 8B [512 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALL C4 [512 datoshi]
+    /// ADD [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 04 [2 datoshi]
+    /// JMP 0A [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 1E [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 0C [2 datoshi]
+    /// PUSHINT64 0000000001000000 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testExtensionMemberCombination")]
+    public abstract BigInteger? TestExtensionMemberCombination(BigInteger? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeDQDQA==
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALL 03 [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testExtensionMemberMethod")]
+    public abstract BigInteger? TestExtensionMemberMethod(BigInteger? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeDQDQA==
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// CALL 03 [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testExtensionMemberProperty")]
+    public abstract BigInteger? TestExtensionMemberProperty(BigInteger? value);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Extensions.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Extensions(Neo.SmartContract.Testing.SmartContrac
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Extensions"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testSum"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testExtensionMemberMethod"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":61,""safe"":false},{""name"":""testExtensionMemberProperty"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":121,""safe"":false},{""name"":""testExtensionMemberCombination"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":181,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Extensions"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testSum"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testExtensionMemberMethod"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":61,""safe"":false},{""name"":""testExtensionMemberProperty"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":121,""safe"":false},{""name"":""testExtensionMemberCombination"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":181,""safe"":false},{""name"":""testExtensionMemberPropertySetter"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":238,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAO5XAAJ5eDQDQFcAAnh5nkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwABeDQDQFcAAXgSoEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwABeDQDQFcAAXgToEoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AVwABeDSLeDTEnkoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9AqUZ2aA==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0KAVcAAnl4NANAVwACeHmeSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BXAAF4NANAVwABeBKgSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BXAAF4NANAVwABeBOgSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BXAAF4NIt4NMSeSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn0BXAQEQEcBweEpoNAdFaBDOQFcAAnlKeBBR0EVApD9c5w==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -79,6 +79,29 @@ public abstract class Contract_Extensions(Neo.SmartContract.Testing.SmartContrac
     /// </remarks>
     [DisplayName("testExtensionMemberProperty")]
     public abstract BigInteger? TestExtensionMemberProperty(BigInteger? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEBEBHAcHhKaDQHRWgQzkA=
+    /// INITSLOT 0101 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// PACK [2048 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// CALL 07 [512 datoshi]
+    /// DROP [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testExtensionMemberPropertySetter")]
+    public abstract BigInteger? TestExtensionMemberPropertySetter(BigInteger? value);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Extensions.cs
@@ -23,5 +23,23 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(5, Contract.TestSum(3, 2));
             AssertGasConsumed(1065060);
         }
+
+        [TestMethod]
+        public void TestExtensionMemberMethod()
+        {
+            Assert.AreEqual(8, Contract.TestExtensionMemberMethod(4));
+        }
+
+        [TestMethod]
+        public void TestExtensionMemberProperty()
+        {
+            Assert.AreEqual(12, Contract.TestExtensionMemberProperty(4));
+        }
+
+        [TestMethod]
+        public void TestExtensionMemberCombination()
+        {
+            Assert.AreEqual(20, Contract.TestExtensionMemberCombination(4));
+        }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Extensions.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Extensions.cs
@@ -41,5 +41,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             Assert.AreEqual(20, Contract.TestExtensionMemberCombination(4));
         }
+
+        [TestMethod]
+        public void TestExtensionMemberPropertySetter()
+        {
+            Assert.AreEqual(7, Contract.TestExtensionMemberPropertySetter(7));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support C# 14 extension member methods/properties by mapping the extension block receiver parameter to the hidden instance slot
- add runtime tests for extension member methods, getter properties, setter properties, and combined usage
- regenerate the `Contract_Extensions` testing artifact

## Scope
- covers instance extension members used as helper syntax
- static extension members and extension operators are left for separate focused PRs
- no CI/workflow changes

## Validation
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_Extensions" -v minimal`
