### PR TITLE
Reuse compiler temp slots after system call lowering

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/SlotHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/SlotHelpers.cs
@@ -11,6 +11,7 @@
 
 extern alias scfx;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -62,6 +63,24 @@ internal partial class MethodConvert
     {
         if (_context.Options.Optimize.HasFlag(CompilationOptions.OptimizationType.Basic))
             _anonymousVariables.Remove(index);
+    }
+
+    private AnonymousVariableScope PreserveAnonymousVariables()
+        => new(this);
+
+    private readonly struct AnonymousVariableScope(MethodConvert convert) : IDisposable
+    {
+        private readonly MethodConvert _convert = convert;
+        private readonly int _count = convert._anonymousVariables.Count;
+
+        public void Dispose()
+        {
+            if (!_convert._context.Options.Optimize.HasFlag(CompilationOptions.OptimizationType.Basic))
+                return;
+
+            while (_convert._anonymousVariables.Count > _count)
+                _convert._anonymousVariables.RemoveAt(_convert._anonymousVariables.Count - 1);
+        }
     }
 
     private void RemoveLocalVariable(ILocalSymbol symbol)

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
@@ -819,6 +819,8 @@ internal partial class MethodConvert
     private static void HandleEnumHasFlag(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (instanceExpression is null)
             throw new CompilationException(symbol, DiagnosticId.InvalidArgument, "Enum.HasFlag requires an instance.");
 
@@ -838,6 +840,8 @@ internal partial class MethodConvert
     private static void HandleEnumParseGeneric(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         var enumType = EnsureEnumTypeArgument(symbol, 0, instanceExpression);
         var members = GetEnumFields(enumType);
 
@@ -874,6 +878,8 @@ internal partial class MethodConvert
     private static void HandleEnumParseGenericIgnoreCase(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         var enumType = EnsureEnumTypeArgument(symbol, 0, instanceExpression);
         var members = GetEnumFields(enumType);
 
@@ -926,6 +932,8 @@ internal partial class MethodConvert
     private static void HandleEnumTryParseGeneric(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         var enumType = EnsureEnumTypeArgument(symbol, 0, instanceExpression);
         var members = GetEnumFields(enumType);
 
@@ -978,6 +986,8 @@ internal partial class MethodConvert
     private static void HandleEnumTryParseGenericIgnoreCase(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         var enumType = EnsureEnumTypeArgument(symbol, 0, instanceExpression);
         var members = GetEnumFields(enumType);
 

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Out.cs
@@ -217,6 +217,8 @@ partial class MethodConvert
     /// </remarks>
     private static void HandleBigIntegerTryParseWithOut(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is null) return;
         methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
         if (!methodConvert._context.TryGetCapturedStaticField(symbol.Parameters[1], out var index)) throw new CompilationException(symbol, DiagnosticId.SyntaxNotSupported, "Out parameter must be captured in a static field.");

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.String.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.String.cs
@@ -82,6 +82,8 @@ internal partial class MethodConvert
 
     private static void HandleStringLastIndexOf(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments, CallingConvention.StdCall);
         if (instanceExpression is not null)
@@ -187,6 +189,8 @@ internal partial class MethodConvert
 
     private static void HandleStringSplit(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (symbol.Parameters.Length == 0)
             throw new CompilationException(DiagnosticId.SyntaxNotSupported, "string.Split() without separators is not supported.");
 
@@ -500,6 +504,8 @@ internal partial class MethodConvert
 
     private static void HandleStringIsNullOrWhiteSpace(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (instanceExpression is not null)
             methodConvert.ConvertExpression(model, instanceExpression);
         if (arguments is not null)
@@ -591,6 +597,8 @@ internal partial class MethodConvert
     /// </remarks>
     private static void HandleStringCompare(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
 
@@ -1087,6 +1095,8 @@ internal partial class MethodConvert
     /// </remarks>
     private static void HandleStringTrim(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
 
@@ -1155,6 +1165,8 @@ internal partial class MethodConvert
 
     private static void HandleStringTrimCharInternal(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments, char? constantTrimChar)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
 
@@ -1216,6 +1228,8 @@ internal partial class MethodConvert
 
     private static void HandleStringTrimStartInternal(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments, bool useTrimChar, char? constantTrimChar)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
 
@@ -1269,6 +1283,8 @@ internal partial class MethodConvert
 
     private static void HandleStringTrimEndInternal(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments, bool useTrimChar, char? constantTrimChar)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
 
@@ -1419,6 +1435,8 @@ internal partial class MethodConvert
 
     private static void HandleStringRemove(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         bool hasCount = symbol.Parameters.Length == 2;
 
         if (arguments is not null)
@@ -1494,6 +1512,8 @@ internal partial class MethodConvert
 
     private static void HandleStringInsert(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        using var tempScope = methodConvert.PreserveAnonymousVariables();
+
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
         if (instanceExpression is not null)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InitSlot.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InitSlot.cs
@@ -17,6 +17,7 @@ using Neo.SmartContract.Testing;
 using Neo.VM;
 using System;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 
 namespace Neo.Compiler.CSharp.UnitTests
@@ -40,6 +41,91 @@ namespace Neo.Compiler.CSharp.UnitTests
             var operand = initSlot.Operand.Span;
             Assert.IsTrue(operand.Length >= 2, "INITSLOT must contain local and argument counts.");
             Assert.AreEqual(2, operand[1], "Generic helpers must allocate exactly the declared parameter count.");
+        }
+
+        [TestMethod]
+        public void EmitInitSlot_ReusesReleasedSystemCallTemps()
+        {
+            const string source = """
+                using Neo.SmartContract.Framework;
+                using System;
+                using System.Numerics;
+
+                namespace Neo.Compiler.CSharp.TestContracts;
+
+                public class TempSlotContract : SmartContract.Framework.SmartContract
+                {
+                    private enum Flags
+                    {
+                        None = 0,
+                        A = 1,
+                        B = 2
+                    }
+
+                    public static int Probe(string value)
+                    {
+                        int total = value.LastIndexOf("a");
+                        total += value.LastIndexOf("b");
+                        total += value.Trim().Length;
+                        total += value.TrimStart().Length;
+                        total += value.TrimEnd().Length;
+                        total += value.Remove(0, 1).Length;
+                        total += value.Insert(0, "z").Length;
+                        total += BigInteger.TryParse(value, out BigInteger parsed) ? 1 : 0;
+                        Flags parsedFlag = Enum.Parse<Flags>(value);
+                        Flags parsedFlagIgnoreCase = Enum.Parse<Flags>(value, true);
+                        total += parsedFlag == Flags.A ? 1 : 0;
+                        total += parsedFlagIgnoreCase == Flags.B ? 1 : 0;
+                        total += Enum.TryParse<Flags>(value, out Flags tryParsedFlag) ? 1 : 0;
+                        total += tryParsedFlag == Flags.A ? 1 : 0;
+                        total += Enum.TryParse<Flags>(value, true, out Flags tryParsedFlagIgnoreCase) ? 1 : 0;
+                        total += tryParsedFlagIgnoreCase == Flags.B ? 1 : 0;
+                        total += Flags.A.HasFlag(Flags.A) ? 1 : 0;
+                        return total;
+                    }
+                }
+                """;
+
+            var context = CompileSource(source);
+            var initSlot = GetInitSlotInstruction(context, static id =>
+                id.Contains("TempSlotContract.Probe", StringComparison.Ordinal));
+
+            var operand = initSlot.Operand.Span;
+            Assert.IsTrue(operand.Length >= 2, "INITSLOT must contain local and argument counts.");
+            Assert.IsTrue(operand[0] <= 12, $"System-call temporary locals should be reusable; actual local count was {operand[0]}.");
+
+            var unoptimizedContext = CompileSource(source, CompilationOptions.OptimizationType.None);
+            var unoptimizedInitSlot = GetInitSlotInstruction(unoptimizedContext, static id =>
+                id.Contains("TempSlotContract.Probe", StringComparison.Ordinal));
+
+            var unoptimizedOperand = unoptimizedInitSlot.Operand.Span;
+            Assert.IsTrue(unoptimizedOperand.Length >= 2, "INITSLOT must contain local and argument counts.");
+            Assert.IsTrue(unoptimizedOperand[0] > operand[0], "Disabling basic optimization should preserve unreleased anonymous slots.");
+        }
+
+        private static CompilationContext CompileSource(
+            string source,
+            CompilationOptions.OptimizationType optimize = CompilationOptions.OptimizationType.Basic)
+        {
+            string tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+            File.WriteAllText(tempPath, source);
+
+            try
+            {
+                var engine = new CompilationEngine(new CompilationOptions
+                {
+                    Debug = CompilationOptions.DebugType.Extended,
+                    Optimize = optimize
+                });
+                var context = engine.CompileSources(tempPath).Single();
+                Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics));
+                return context;
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
         }
 
         private static Neo.VM.Instruction GetInitSlotInstruction(CompilationContext context, Func<string, bool> matchesMethod)


### PR DESCRIPTION
## Summary
- add a scoped anonymous-local marker for compiler temp slot reuse
- release string, enum, and BigInteger.TryParse system-call temps after lowering
- add an INITSLOT regression covering repeated system-call temp allocation

## Testing
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_String|FullyQualifiedName~UnitTest_Enum|FullyQualifiedName~UnitTest_BigIntegerTryParse|FullyQualifiedName~UnitTest_InitSlot"