### PR TITLE
Centralize compiler instance field layout lookup

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.CoalesceAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.CoalesceAssignment.cs
@@ -195,7 +195,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(left.ContainingType.GetFields(), left);
+            int index = GetInstanceFieldIndex(left);
             AddInstruction(OpCode.LDARG0);
             Push(index);
             AddInstruction(OpCode.OVER);
@@ -296,7 +296,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+            int index = GetInstanceFieldIndex(field);
             ConvertExpression(model, left.Expression);
             Push(index);
             AddInstruction(OpCode.OVER);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
@@ -175,7 +175,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(left.ContainingType.GetFields(), left);
+            int index = GetInstanceFieldIndex(left);
             AddInstruction(OpCode.LDARG0);
             AddInstruction(OpCode.DUP);
             Push(index);
@@ -242,7 +242,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+            int index = GetInstanceFieldIndex(field);
             ConvertExpression(model, left.Expression);
             AddInstruction(OpCode.DUP);
             Push(index);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.SimpleAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.SimpleAssignment.cs
@@ -101,7 +101,7 @@ internal partial class MethodConvert
             return;
         }
 
-        int fieldIndex = Array.IndexOf(fieldSymbol.ContainingType.GetFields(), fieldSymbol);
+        int fieldIndex = GetInstanceFieldIndex(fieldSymbol);
         AccessSlot(OpCode.LDARG, 0);
         Push(fieldIndex);
         AddInstruction(OpCode.ROT);
@@ -185,7 +185,7 @@ internal partial class MethodConvert
                 }
                 else
                 {
-                    int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+                    int index = GetInstanceFieldIndex(field);
                     AddInstruction(OpCode.LDARG0);
                     Push(index);
                     AddInstruction(OpCode.ROT);
@@ -242,7 +242,7 @@ internal partial class MethodConvert
                 }
                 else
                 {
-                    int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+                    int index = GetInstanceFieldIndex(field);
                     ConvertExpression(model, left.Expression);
                     Push(index);
                     AddInstruction(OpCode.ROT);
@@ -397,7 +397,7 @@ internal partial class MethodConvert
                 }
                 else
                 {
-                    int fieldIndex = Array.IndexOf(field.ContainingType.GetFields(), field);
+                    int fieldIndex = GetInstanceFieldIndex(field);
                     AccessSlot(OpCode.LDLOC, valueSlot);
                     AccessSlot(OpCode.LDLOC, receiverSlot);
                     Push(fieldIndex);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/IdentifierNameExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/IdentifierNameExpression.cs
@@ -62,7 +62,7 @@ internal partial class MethodConvert
                 }
                 else
                 {
-                    int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+                    int index = GetInstanceFieldIndex(field);
                     AddInstruction(OpCode.LDARG0);
                     Push(index);
                     AddInstruction(OpCode.PICKITEM);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/MemberExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/MemberExpression.cs
@@ -69,7 +69,7 @@ internal partial class MethodConvert
                 }
                 else
                 {
-                    int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+                    int index = GetInstanceFieldIndex(field);
                     ConvertExpression(model, expression.Expression);
                     Push(index);
                     AddInstruction(OpCode.PICKITEM);
@@ -104,7 +104,7 @@ internal partial class MethodConvert
             return;
         }
 
-        int fieldIndex = Array.IndexOf(fieldSymbol.ContainingType.GetFields(), fieldSymbol);
+        int fieldIndex = GetInstanceFieldIndex(fieldSymbol);
         AccessSlot(OpCode.LDARG, 0);
         Push(fieldIndex);
         AddInstruction(OpCode.PICKITEM);
@@ -138,7 +138,7 @@ internal partial class MethodConvert
         switch (symbol)
         {
             case IFieldSymbol field:
-                int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+                int index = GetInstanceFieldIndex(field);
                 Push(index);
                 AddInstruction(OpCode.PICKITEM);
                 break;

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/ObjectCreationExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/ObjectCreationExpression.cs
@@ -107,7 +107,7 @@ internal partial class MethodConvert
             ISymbol symbol = model.GetSymbolInfo(ae.Left).Symbol!;
             if (symbol is not IFieldSymbol field)
                 return false;
-            int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+            int index = GetInstanceFieldIndex(field);
             indexToValue.Add(index, ae.Right);
         }
         var virtualMethods = members.OfType<IMethodSymbol>().Where(p => p.IsVirtualMethod()).ToArray();
@@ -209,7 +209,7 @@ internal partial class MethodConvert
             {
                 case IFieldSymbol field:
                     AddInstruction(OpCode.DUP);
-                    int index = Array.IndexOf(field.ContainingType.GetFields(), field);
+                    int index = GetInstanceFieldIndex(field);
                     Push(index);
                     ConvertExpression(model, ae.Right);
                     AddInstruction(OpCode.SETITEM);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PostfixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PostfixUnary.cs
@@ -160,7 +160,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(symbol.ContainingType.GetFields(), symbol);
+            int index = GetInstanceFieldIndex(symbol);
             AddInstruction(OpCode.LDARG0);
             AddInstruction(OpCode.DUP);
             Push(index);
@@ -237,7 +237,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(symbol.ContainingType.GetFields(), symbol);
+            int index = GetInstanceFieldIndex(symbol);
             ConvertExpression(model, operand.Expression);
             AddInstruction(OpCode.DUP);
             Push(index);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
@@ -177,7 +177,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(symbol.ContainingType.GetFields(), symbol);
+            int index = GetInstanceFieldIndex(symbol);
             AddInstruction(OpCode.LDARG0);
             AddInstruction(OpCode.DUP);
             Push(index);
@@ -254,7 +254,7 @@ internal partial class MethodConvert
         }
         else
         {
-            int index = Array.IndexOf(symbol.ContainingType.GetFields(), symbol);
+            int index = GetInstanceFieldIndex(symbol);
             ConvertExpression(model, operand.Expression);
             AddInstruction(OpCode.DUP);
             Push(index);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/CallHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/CallHelpers.cs
@@ -434,7 +434,7 @@ internal partial class MethodConvert
         if (isRef)
         {
             AccessSlot(OpCode.LDSFLD, instanceSlot);
-            int fieldOffset = Array.IndexOf(field.ContainingType.GetFields(), field);
+            int fieldOffset = GetInstanceFieldIndex(field);
             Push(fieldOffset);
             AddInstruction(OpCode.PICKITEM);
         }
@@ -532,7 +532,7 @@ internal partial class MethodConvert
             throw new CompilationException(DiagnosticId.SyntaxNotSupported, $"Missing instance context for field '{field.Name}' in out argument synchronization.");
 
         AccessSlot(OpCode.LDSFLD, instanceSlot.Value);
-        int fieldOffset = Array.IndexOf(field.ContainingType.GetFields(), field);
+        int fieldOffset = GetInstanceFieldIndex(field);
         Push(fieldOffset);
         AddInstruction(OpCode.ROT);
         AddInstruction(OpCode.SETITEM);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/FieldLayoutHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/FieldLayoutHelpers.cs
@@ -1,0 +1,25 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// FieldLayoutHelpers.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+
+namespace Neo.Compiler;
+
+internal partial class MethodConvert
+{
+    private static int GetInstanceFieldIndex(IFieldSymbol field)
+    {
+        int index = System.Array.IndexOf(field.ContainingType.GetFields(), field);
+        if (index < 0)
+            throw new CompilationException(field, DiagnosticId.SyntaxNotSupported, $"Field '{field.Name}' was not found on containing type '{field.ContainingType.Name}'.");
+        return index;
+    }
+}

--- a/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.RefBindings.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.RefBindings.cs
@@ -260,9 +260,7 @@ internal partial class MethodConvert
         }
 
         AccessSlot(OpCode.STLOC, instanceSlot);
-        int fieldIndex = Array.IndexOf(field.ContainingType.GetFields(), field);
-        if (fieldIndex < 0)
-            throw new CompilationException(field, DiagnosticId.SyntaxNotSupported, $"Field '{field.Name}' was not found on containing type '{field.ContainingType.Name}'.");
+        int fieldIndex = GetInstanceFieldIndex(field);
         return RefBinding.InstanceField(instanceSlot, fieldIndex);
     }
 


### PR DESCRIPTION
## Summary
- add one helper for resolving instance field offsets
- route member access, assignment, unary, ref, and out field paths through it
- keep the existing field layout algorithm while removing repeated lookup code

## Testing
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_Assignment|FullyQualifiedName~UnitTest_ComplexAssign|FullyQualifiedName~UnitTest_Inc_Dec|FullyQualifiedName~UnitTest_MemberAccess|FullyQualifiedName~UnitTest_Property|FullyQualifiedName~UnitTest_Ref|FullyQualifiedName~UnitTest_Out|FullyQualifiedName~UnitTest_Instance"