### PR TITLE
Optimize: less DUP and DROP opcodes for `Enum.GetName`

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/StackHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/StackHelpers.cs
@@ -41,6 +41,18 @@ internal partial class MethodConvert
         });
     }
 
+    /// <summary>
+    /// Remove the last instruction added
+    /// </summary>
+    private Instruction PopInstruction()
+    {
+        if (_instructions.Count == 0)
+            throw new InvalidOperationException("No instructions to remove");
+        var last = _instructions[^1];
+        _instructions.RemoveAt(_instructions.Count - 1);
+        return last;
+    }
+
     private SequencePointInserter InsertSequencePoint(SyntaxNodeOrToken? syntax, [CallerLineNumber] int lineNumber = 0, [CallerFilePath] string? callerPath = null, [CallerMemberName] string? caller = null)
     {
         return new SequencePointInserter(_instructions, syntax, LocationInformation.BuildCompilerLocation(lineNumber, callerPath, caller));

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Enum.cs
@@ -396,7 +396,6 @@ internal partial class MethodConvert
 
         // Get the enum type from the Enum value
         var enumType = symbol.Parameters[0].Type;
-
         if (enumType is not INamedTypeSymbol enumTypeSymbol)
         {
             throw new CompilationException(symbol.Locations.FirstOrDefault()!.MetadataModule!, DiagnosticId.InvalidType, "Unable to determine enum type");
@@ -404,27 +403,25 @@ internal partial class MethodConvert
 
         var enumMembers = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>()
             .Where(field => field is { HasConstantValue: true, IsImplicitlyDeclared: false }).ToArray();
-
         foreach (var t in enumMembers)
         {
-            methodConvert.Dup();                                   // Duplicate input value
-            methodConvert.Push(t.ConstantValue);                   // Push enum value
-            methodConvert.Equal();                                 // Compare values
+            methodConvert.Dup();                 // Duplicate input value
+            methodConvert.Push(t.ConstantValue); // Push enum value, the enum value is an int value
 
             var nextCheck = new JumpTarget();
-            methodConvert.JumpIfNot(nextCheck);                    // If not equal, check next
+            methodConvert.Jump(OpCode.JMPNE, nextCheck);  // If not numeric equal, check next
 
-            methodConvert.Drop();                                  // Remove the duplicated input value
-            methodConvert.Push(t.Name);                            // Push enum name
-            methodConvert.Ret();                                   // Return enum name
+            methodConvert.Drop();        // Remove the duplicated input value
+            methodConvert.Push(t.Name);  // Push enum name
+            methodConvert.Ret();         // Return enum name
 
             nextCheck.Instruction = methodConvert.Nop();
         }
 
         // No match found
-        methodConvert.Drop();                                      // Remove the input value
-        methodConvert.PushNull();                                  // Push null (no matching enum name)
-        methodConvert.Ret();                                       // Return null
+        methodConvert.Drop();     // Remove the input value
+        methodConvert.PushNull(); // Push null (no matching enum name)
+        methodConvert.Ret();      // Return null
     }
 
     /// <summary>
@@ -448,7 +445,7 @@ internal partial class MethodConvert
 
         // Get the enum type from the first argument (typeof(enum))
         ITypeSymbol? enumTypeSymbol = null;
-        if (arguments is { Count: > 0 })
+        if (arguments is not null && arguments.Count > 0)
         {
             if ((arguments[0] as ArgumentSyntax)?.Expression is TypeOfExpressionSyntax typeOfExpression)
             {
@@ -467,32 +464,34 @@ internal partial class MethodConvert
 
         if (enumTypeSymbol is not { TypeKind: TypeKind.Enum })
         {
-            throw new CompilationException(arguments![0], DiagnosticId.InvalidType, "Unable to determine enum type from first argument");
+            throw new CompilationException(arguments[0], DiagnosticId.InvalidType, "Unable to determine enum type from first argument");
         }
 
         var enumMembers = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>()
             .Where(field => field is { HasConstantValue: true, IsImplicitlyDeclared: false }).ToArray();
 
+        var valueItem = methodConvert.PopInstruction(); // The second argument is the value to get the name of
+        var enumTypeItem = methodConvert.PopInstruction(); // The first argument is the enum type, It's unused when running
+        methodConvert.AddInstruction(valueItem);
         foreach (var t in enumMembers)
         {
-            methodConvert.Dup();                                   // Duplicate input value
-            methodConvert.Push(t.ConstantValue);                   // Push enum value
-            methodConvert.Equal();                                 // Compare values
+            methodConvert.Dup();                 // Duplicate input value
+            methodConvert.Push(t.ConstantValue); // Push enum value, the enum value is an int value
 
             var nextCheck = new JumpTarget();
-            methodConvert.JumpIfNot(nextCheck);                    // If not equal, check next
+            methodConvert.Jump(OpCode.JMPNE, nextCheck);  // If not numeric equal, check next
 
-            methodConvert.Drop(2);                                 // Remove the duplicated input value
-            methodConvert.Push(t.Name);                            // Push enum name
-            methodConvert.Ret();                                   // Return enum name
+            methodConvert.Drop();       // Remove the duplicated input value
+            methodConvert.Push(t.Name); // Push enum name
+            methodConvert.Ret();         // Return enum name
 
             nextCheck.Instruction = methodConvert.Nop();
         }
 
         // No match found
-        methodConvert.Drop(2);                                     // Remove the input value
-        methodConvert.PushNull();                                  // Push null (no matching enum name)
-        methodConvert.Ret();                                       // Return null
+        methodConvert.Drop();     // Remove the input value
+        methodConvert.PushNull(); // Push null (no matching enum name)
+        methodConvert.Ret();      // Return null
     }
 
     /// <summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Enum.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Enum.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Enum"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testEnumParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Any"",""offset"":0,""safe"":false},{""name"":""testEnumParseIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Any"",""offset"":87,""safe"":false},{""name"":""testEnumTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Boolean"",""offset"":241,""safe"":false},{""name"":""testEnumTryParseIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":319,""safe"":false},{""name"":""testEnumGetNames"",""parameters"":[],""returntype"":""Array"",""offset"":463,""safe"":false},{""name"":""testEnumGetValues"",""parameters"":[],""returntype"":""Array"",""offset"":500,""safe"":false},{""name"":""testEnumIsDefined"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":516,""safe"":false},{""name"":""testEnumIsDefinedByName"",""parameters"":[{""name"":""name"",""type"":""String""}],""returntype"":""Boolean"",""offset"":561,""safe"":false},{""name"":""testEnumGetName"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""String"",""offset"":627,""safe"":false},{""name"":""testEnumGetNameWithType"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""String"",""offset"":679,""safe"":false},{""name"":""testEnumHasFlag"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""flag"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":745,""safe"":false},{""name"":""testEnumToString"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""String"",""offset"":756,""safe"":false},{""name"":""testEnumToStringUnknown"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""String"",""offset"":809,""safe"":false},{""name"":""testEnumParseGeneric"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":862,""safe"":false},{""name"":""testEnumParseGenericIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Integer"",""offset"":991,""safe"":false},{""name"":""testEnumTryParseGeneric"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Boolean"",""offset"":1111,""safe"":false},{""name"":""testEnumTryParseGenericIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":1171,""safe"":false},{""name"":""testEnumGetValuesGeneric"",""parameters"":[],""returntype"":""Array"",""offset"":1275,""safe"":false},{""name"":""testEnumGetNamesGeneric"",""parameters"":[],""returntype"":""Array"",""offset"":1281,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":1308,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""itoa""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Enum"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testEnumParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Any"",""offset"":0,""safe"":false},{""name"":""testEnumParseIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Any"",""offset"":87,""safe"":false},{""name"":""testEnumTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Boolean"",""offset"":241,""safe"":false},{""name"":""testEnumTryParseIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":319,""safe"":false},{""name"":""testEnumGetNames"",""parameters"":[],""returntype"":""Array"",""offset"":463,""safe"":false},{""name"":""testEnumGetValues"",""parameters"":[],""returntype"":""Array"",""offset"":500,""safe"":false},{""name"":""testEnumIsDefined"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":516,""safe"":false},{""name"":""testEnumIsDefinedByName"",""parameters"":[{""name"":""name"",""type"":""String""}],""returntype"":""Boolean"",""offset"":561,""safe"":false},{""name"":""testEnumGetName"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""String"",""offset"":627,""safe"":false},{""name"":""testEnumGetNameWithType"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""String"",""offset"":676,""safe"":false},{""name"":""testEnumHasFlag"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""flag"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":725,""safe"":false},{""name"":""testEnumToString"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""String"",""offset"":736,""safe"":false},{""name"":""testEnumToStringUnknown"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""String"",""offset"":789,""safe"":false},{""name"":""testEnumParseGeneric"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":842,""safe"":false},{""name"":""testEnumParseGenericIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Integer"",""offset"":971,""safe"":false},{""name"":""testEnumTryParseGeneric"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Boolean"",""offset"":1091,""safe"":false},{""name"":""testEnumTryParseGenericIgnoreCase"",""parameters"":[{""name"":""value"",""type"":""String""},{""name"":""ignoreCase"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":1151,""safe"":false},{""name"":""testEnumGetValuesGeneric"",""parameters"":[],""returntype"":""Array"",""offset"":1255,""safe"":false},{""name"":""testEnumGetNamesGeneric"",""parameters"":[],""returntype"":""Array"",""offset"":1261,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":1288,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""itoa""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARpdG9hAQABDwAA/R8FVwABDAhUZXN0RW51bXhKDAZWYWx1ZTGXJgcRU0VFQEoMBlZhbHVlMpcmBxJTRUVASgwGVmFsdWUzlyYHE1NFRUBFDBJObyBzdWNoIGVudW0gdmFsdWU6VwACDAhUZXN0RW51bXh5Ji4MABBKeMq1JiJKeFDOSgBhAHu7JAlRUItQnCLpAGGfAEGeUVCLUJwi3EXbKEp5JjQMBlZBTFVFMZcmB0VFRRFASnkmIAwGVkFMVUUylyYHRUVFEkBKeSYMDAZWQUxVRTMiCgwGVmFsdWUzlyYHRUVFE0BFRQwSTm8gc3VjaCBlbnVtIHZhbHVlOlcAAQwIVGVzdEVudW14C2FKDAZWYWx1ZTGXJghFRRFgCEBKDAZWYWx1ZTKXJghFRRJgCEBKDAZWYWx1ZTOXJghFRRNgCEBFRRBgCVhhQFcAAgwIVGVzdEVudW14eQtjJjBQRQwAEEp4yrUmIkp4UM5KAGEAe7skCVFQi1CcIukAYZ8AQZ5RUItQnCLcRdsoSnkmNgwGVkFMVUUxlyYIRUURYghASnkmIQwGVkFMVUUylyYIRUUSYghASnkmDAwGVkFMVUUzIgoMBlZhbHVlM5cmCEVFE2IIQEVFEGIJQAwIVGVzdEVudW0MBlZhbHVlMwwGVmFsdWUyDAZWYWx1ZTETwEAMCFRlc3RFbnVtExIRE8BAVwABDAhUZXN0RW51bXhKEZcmBkVFCEBKEpcmBkVFCEBKE5cmBkVFCEBFRQlAVwABDAhUZXN0RW51bXhKDAZWYWx1ZTGXJgZFRQhASgwGVmFsdWUylyYGRUUIQEoMBlZhbHVlM5cmBkVFCEBFRQlAVwABeEoRlyYMRQwGVmFsdWUxQEoSlyYMRQwGVmFsdWUyQEoTlyYMRQwGVmFsdWUzQEULQFcAAQwIVGVzdEVudW14ShGXJg1FRQwGVmFsdWUxQEoSlyYNRUUMBlZhbHVlMkBKE5cmDUVFDAZWYWx1ZTNARUULQFcBAnh5cGiRaJdAVwABeEoRlyYMRQwGVmFsdWUxQEoSlyYMRQwGVmFsdWUyQEoTlyYMRQwGVmFsdWUzQDcAAEBXAAF4ShGXJgxFDAZWYWx1ZTFAShKXJgxFDAZWYWx1ZTJAShOXJgxFDAZWYWx1ZTNANwAAQFcBAQl4NEdwaAwGVmFsdWUxlyYEEUBoDAZWYWx1ZTKXJgQSQGgMBlZhbHVlM5cmBBNACCYXDBJObyBzdWNoIGVudW0gdmFsdWU6aDpXAAJ5Ji8MABBKeMq1JiJKeFDOSgBhAHu7JAlRUItQnCLpAGGfAEGeUVCLUJwi3EXbKEB4QFcCAnl4NMZwaHFpDAZWQUxVRTGXJgQRQGkMBlZBTFVFMpcmBBJAaQwGVkFMVUUzlyYEE0BpDAZWYWx1ZTGXJgQRQGkMBlZhbHVlMpcmBBJAaQwGVmFsdWUzlyYEE0AIJhcMEk5vIHN1Y2ggZW51bSB2YWx1ZTppOlcBAQl4NU7///9waAwGVmFsdWUxlyYECEBoDAZWYWx1ZTKXJgQIQGgMBlZhbHVlM5cmBAhACCYECUBoOlcCAnl4NRL///9waHFpDAZWQUxVRTGXJgQIQGkMBlZBTFVFMpcmBAhAaQwGVkFMVUUzlyYECEBpDAZWYWx1ZTGXJgQIQGkMBlZhbHVlMpcmBAhAaQwGVmFsdWUzlyYECEAIJgQJQGk6ExIRE8BADAZWYWx1ZTMMBlZhbHVlMgwGVmFsdWUxE8BAVgRA67BAjQ==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARpdG9hAQABDwAA/QsFVwABDAhUZXN0RW51bXhKDAZWYWx1ZTGXJgcRU0VFQEoMBlZhbHVlMpcmBxJTRUVASgwGVmFsdWUzlyYHE1NFRUBFDBJObyBzdWNoIGVudW0gdmFsdWU6VwACDAhUZXN0RW51bXh5Ji4MABBKeMq1JiJKeFDOSgBhAHu7JAlRUItQnCLpAGGfAEGeUVCLUJwi3EXbKEp5JjQMBlZBTFVFMZcmB0VFRRFASnkmIAwGVkFMVUUylyYHRUVFEkBKeSYMDAZWQUxVRTMiCgwGVmFsdWUzlyYHRUVFE0BFRQwSTm8gc3VjaCBlbnVtIHZhbHVlOlcAAQwIVGVzdEVudW14C2FKDAZWYWx1ZTGXJghFRRFgCEBKDAZWYWx1ZTKXJghFRRJgCEBKDAZWYWx1ZTOXJghFRRNgCEBFRRBgCVhhQFcAAgwIVGVzdEVudW14eQtjJjBQRQwAEEp4yrUmIkp4UM5KAGEAe7skCVFQi1CcIukAYZ8AQZ5RUItQnCLcRdsoSnkmNgwGVkFMVUUxlyYIRUURYghASnkmIQwGVkFMVUUylyYIRUUSYghASnkmDAwGVkFMVUUzIgoMBlZhbHVlM5cmCEVFE2IIQEVFEGIJQAwIVGVzdEVudW0MBlZhbHVlMwwGVmFsdWUyDAZWYWx1ZTETwEAMCFRlc3RFbnVtExIRE8BAVwABDAhUZXN0RW51bXhKEZcmBkVFCEBKEpcmBkVFCEBKE5cmBkVFCEBFRQlAVwABDAhUZXN0RW51bXhKDAZWYWx1ZTGXJgZFRQhASgwGVmFsdWUylyYGRUUIQEoMBlZhbHVlM5cmBkVFCEBFRQlAVwABeEoRKgxFDAZWYWx1ZTFAShIqDEUMBlZhbHVlMkBKEyoMRQwGVmFsdWUzQEULQFcAAXhKESoMRQwGVmFsdWUxQEoSKgxFDAZWYWx1ZTJAShMqDEUMBlZhbHVlM0BFC0BXAQJ4eXBokWiXQFcAAXhKEZcmDEUMBlZhbHVlMUBKEpcmDEUMBlZhbHVlMkBKE5cmDEUMBlZhbHVlM0A3AABAVwABeEoRlyYMRQwGVmFsdWUxQEoSlyYMRQwGVmFsdWUyQEoTlyYMRQwGVmFsdWUzQDcAAEBXAQEJeDRHcGgMBlZhbHVlMZcmBBFAaAwGVmFsdWUylyYEEkBoDAZWYWx1ZTOXJgQTQAgmFwwSTm8gc3VjaCBlbnVtIHZhbHVlOmg6VwACeSYvDAAQSnjKtSYiSnhQzkoAYQB7uyQJUVCLUJwi6QBhnwBBnlFQi1CcItxF2yhAeEBXAgJ5eDTGcGhxaQwGVkFMVUUxlyYEEUBpDAZWQUxVRTKXJgQSQGkMBlZBTFVFM5cmBBNAaQwGVmFsdWUxlyYEEUBpDAZWYWx1ZTKXJgQSQGkMBlZhbHVlM5cmBBNACCYXDBJObyBzdWNoIGVudW0gdmFsdWU6aTpXAQEJeDVO////cGgMBlZhbHVlMZcmBAhAaAwGVmFsdWUylyYECEBoDAZWYWx1ZTOXJgQIQAgmBAlAaDpXAgJ5eDUS////cGhxaQwGVkFMVUUxlyYECEBpDAZWQUxVRTKXJgQIQGkMBlZBTFVFM5cmBAhAaQwGVmFsdWUxlyYECEBpDAZWYWx1ZTKXJgQIQGkMBlZhbHVlM5cmBAhACCYECUBpOhMSERPAQAwGVmFsdWUzDAZWYWx1ZTIMBlZhbHVlMRPAQFYEQPCX/Uk=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -28,27 +28,24 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeEoRlyYMRQwGVmFsdWUxQEoSlyYMRQwGVmFsdWUyQEoTlyYMRQwGVmFsdWUzQEULQA==
+    /// Script: VwABeEoRKgxFDAZWYWx1ZTFAShIqDEUMBlZhbHVlMkBKEyoMRQwGVmFsdWUzQEULQA==
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
     /// PUSH1 [1 datoshi]
-    /// EQUAL [32 datoshi]
-    /// JMPIFNOT 0C [2 datoshi]
+    /// JMPNE 0C [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHDATA1 56616C756531 'Value1' [8 datoshi]
     /// RET [0 datoshi]
     /// DUP [2 datoshi]
     /// PUSH2 [1 datoshi]
-    /// EQUAL [32 datoshi]
-    /// JMPIFNOT 0C [2 datoshi]
+    /// JMPNE 0C [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHDATA1 56616C756532 'Value2' [8 datoshi]
     /// RET [0 datoshi]
     /// DUP [2 datoshi]
     /// PUSH3 [1 datoshi]
-    /// EQUAL [32 datoshi]
-    /// JMPIFNOT 0C [2 datoshi]
+    /// JMPNE 0C [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHDATA1 56616C756533 'Value3' [8 datoshi]
     /// RET [0 datoshi]
@@ -94,35 +91,27 @@ public abstract class Contract_Enum(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABDAhUZXN0RW51bXhKEZcmDUVFDAZWYWx1ZTFAShKXJg1FRQwGVmFsdWUyQEoTlyYNRUUMBlZhbHVlM0BFRQtA
+    /// Script: VwABeEoRKgxFDAZWYWx1ZTFAShIqDEUMBlZhbHVlMkBKEyoMRQwGVmFsdWUzQEULQA==
     /// INITSLOT 0001 [64 datoshi]
-    /// PUSHDATA1 54657374456E756D 'TestEnum' [8 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
     /// PUSH1 [1 datoshi]
-    /// EQUAL [32 datoshi]
-    /// JMPIFNOT 0D [2 datoshi]
-    /// DROP [2 datoshi]
+    /// JMPNE 0C [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHDATA1 56616C756531 'Value1' [8 datoshi]
     /// RET [0 datoshi]
     /// DUP [2 datoshi]
     /// PUSH2 [1 datoshi]
-    /// EQUAL [32 datoshi]
-    /// JMPIFNOT 0D [2 datoshi]
-    /// DROP [2 datoshi]
+    /// JMPNE 0C [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHDATA1 56616C756532 'Value2' [8 datoshi]
     /// RET [0 datoshi]
     /// DUP [2 datoshi]
     /// PUSH3 [1 datoshi]
-    /// EQUAL [32 datoshi]
-    /// JMPIFNOT 0D [2 datoshi]
-    /// DROP [2 datoshi]
+    /// JMPNE 0C [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHDATA1 56616C756533 'Value3' [8 datoshi]
     /// RET [0 datoshi]
-    /// DROP [2 datoshi]
     /// DROP [2 datoshi]
     /// PUSHNULL [1 datoshi]
     /// RET [0 datoshi]


### PR DESCRIPTION

An example:
```csharp
public enum ALooooooooooogEnumName {
    A1,
    A2,
    A3,
}

public class HelloWorld : SmartContract
{
    [Safe]
    public static string? GetEnumName(int en)
    {
        return Enum.GetName(typeof(ALooooooooooogEnumName), en);
    }
}
```

Before:
```
00000000: INITSLOT 0, 1
00000003: PUSH [414C6F6F6F6F6F6F6F6F6F6F6F67456E756D4E616D65] // ALooooooooooogEnumName
0000001b: LDARG 0
0000001c: DUP
0000001d: PUSH 0
0000001e: EQUAL
0000001f: JMPIFNOT <00000028>
00000021: DROP
00000022: DROP
00000023: PUSH [4131] // A1
00000027: RET
00000028: DUP
00000029: PUSH 1
0000002a: EQUAL
0000002b: JMPIFNOT <00000034>
0000002d: DROP
0000002e: DROP
0000002f: PUSH [4132] // A2
00000033: RET
00000034: DUP
00000035: PUSH 2
00000036: EQUAL
00000037: JMPIFNOT <00000040>
00000039: DROP
0000003a: DROP
0000003b: PUSH [4133] // A3
0000003f: RET
00000040: DROP
00000041: DROP
00000042: PUSH <null>
00000043: RET
00000044: JMP <00000046>
00000046: RET
```

Optimized:
```
00000000: INITSLOT 0, 1
00000003: LDARG 0
00000004: DUP
00000005: PUSH 0
00000006: JMPNE <0000000e>
00000008: DROP
00000009: PUSH [4131] // A1
0000000d: RET
0000000e: DUP
0000000f: PUSH 1
00000010: JMPNE <00000018>
00000012: DROP
00000013: PUSH [4132] // A2
00000017: RET
00000018: DUP
00000019: PUSH 2
0000001a: JMPNE <00000022>
0000001c: DROP
0000001d: PUSH [4133] // A3
00000021: RET
00000022: DROP
00000023: PUSH <null>
00000024: RET
00000025: JMP <00000027>
00000027: RET
```