### PR TITLE
Fix security docs tables of contents

### DIFF
--- a/docs/security/safe-arithmetic.md
+++ b/docs/security/safe-arithmetic.md
@@ -6,15 +6,13 @@ This guide provides comprehensive patterns for safe arithmetic in Neo N3 smart c
 ## Table of Contents
 
 - [Arithmetic Security Fundamentals](#arithmetic-security-fundamentals)
-- [BigInteger in Neo Contracts](#biginteger-in-neo-contracts)
+- [Neo N3 BigInteger Characteristics](#neo-n3-biginteger-characteristics)
 - [Safe Addition Operations](#safe-addition-operations)
 - [Safe Subtraction Operations](#safe-subtraction-operations)
 - [Safe Multiplication Operations](#safe-multiplication-operations)
 - [Safe Division Operations](#safe-division-operations)
 - [Percentage and Ratio Calculations](#percentage-and-ratio-calculations)
 - [Fixed-Point Arithmetic](#fixed-point-arithmetic)
-- [Rounding and Precision](#rounding-and-precision)
-- [Testing Arithmetic Security](#testing-arithmetic-security)
 
 ## Arithmetic Security Fundamentals
 

--- a/docs/security/security-testing.md
+++ b/docs/security/security-testing.md
@@ -9,13 +9,8 @@ Comprehensive testing frameworks and methodologies for validating security imple
 - [Security Testing Fundamentals](#security-testing-fundamentals)
 - [Test Planning and Strategy](#test-planning-and-strategy)
 - [Unit Testing for Security](#unit-testing-for-security)
-- [Integration Security Testing](#integration-security-testing)
 - [Vulnerability Testing](#vulnerability-testing)
-- [Performance and DoS Testing](#performance-and-dos-testing)
 - [Access Control Testing](#access-control-testing)
-- [State Management Testing](#state-management-testing)
-- [Automated Security Testing](#automated-security-testing)
-- [Security Test Reporting](#security-test-reporting)
 
 ## Security Testing Fundamentals
 


### PR DESCRIPTION
## Summary
- Fix stale table-of-contents entries in the security testing guide.
- Fix stale table-of-contents entries in the safe arithmetic guide.
- Keep only links that resolve to headings still present in each document.

## Validation
- Verified every table-of-contents anchor in `docs/security/security-testing.md` resolves to an existing heading.
- Verified every table-of-contents anchor in `docs/security/safe-arithmetic.md` resolves to an existing heading.
- `git diff --check`
- `git diff --cached --check`
