### PR TITLE
Fix safe arithmetic table of contents

### DIFF
--- a/docs/security/safe-arithmetic.md
+++ b/docs/security/safe-arithmetic.md
@@ -6,15 +6,13 @@ This guide provides comprehensive patterns for safe arithmetic in Neo N3 smart c
 ## Table of Contents
 
 - [Arithmetic Security Fundamentals](#arithmetic-security-fundamentals)
-- [BigInteger in Neo Contracts](#biginteger-in-neo-contracts)
+- [Neo N3 BigInteger Characteristics](#neo-n3-biginteger-characteristics)
 - [Safe Addition Operations](#safe-addition-operations)
 - [Safe Subtraction Operations](#safe-subtraction-operations)
 - [Safe Multiplication Operations](#safe-multiplication-operations)
 - [Safe Division Operations](#safe-division-operations)
 - [Percentage and Ratio Calculations](#percentage-and-ratio-calculations)
 - [Fixed-Point Arithmetic](#fixed-point-arithmetic)
-- [Rounding and Precision](#rounding-and-precision)
-- [Testing Arithmetic Security](#testing-arithmetic-security)
 
 ## Arithmetic Security Fundamentals
 


### PR DESCRIPTION
## Summary
- Fix the safe arithmetic guide table of contents so every anchor resolves.
- Remove stale entries for sections that are no longer present.
- Point the BigInteger entry at the current heading name.

## Validation
- Verified every table-of-contents anchor in `docs/security/safe-arithmetic.md` resolves to an existing heading.
- `git diff --check`
