### PR TITLE
Return contract contexts in deterministic order

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -273,7 +273,7 @@ namespace Neo.Compiler
                 Contexts.TryAdd(c, context);
             });
 
-            return Contexts.Select(p => p.Value).ToList();
+            return sortedClasses.Select(c => Contexts[c]).ToList();
         }
 
         private List<CompilationContext> CompileProjectContracts(Compilation compilation)
@@ -339,7 +339,7 @@ namespace Neo.Compiler
                 Contexts.TryAdd(c, context);
             });
 
-            return Contexts.Select(p => p.Value).ToList();
+            return sortedClasses.Select(c => Contexts[c]).ToList();
         }
 
         /// <summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
@@ -5,6 +5,7 @@ using Neo.Compiler;
 using Neo.Json;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Neo.Compiler.CSharp.UnitTests;
@@ -12,6 +13,38 @@ namespace Neo.Compiler.CSharp.UnitTests;
 [TestClass]
 public class UnitTest_CompilationEngineReference
 {
+    [TestMethod]
+    public void CompileSources_ReturnsContractsInSourceOrder()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+
+public class AlphaContract : SmartContract
+{
+    public static int Main() => 1;
+}
+
+public class BetaContract : SmartContract
+{
+    public static int Main() => 2;
+}
+
+public class GammaContract : SmartContract
+{
+    public static int Main() => 3;
+}
+
+public class DeltaContract : SmartContract
+{
+    public static int Main() => 4;
+}";
+
+        var contexts = CompileContracts(source);
+
+        CollectionAssert.AreEqual(
+            new[] { "AlphaContract", "BetaContract", "GammaContract", "DeltaContract" },
+            contexts.Select(p => p.ContractName).ToArray());
+    }
+
     [TestMethod]
     public void GetCompilation_ReportsRestoreFailureExitCode()
     {
@@ -80,5 +113,33 @@ public class UnitTest_CompilationEngineReference
         var innerException = (NotSupportedException)exception.InnerException!;
         StringAssert.Contains(innerException.Message, assetType);
         StringAssert.Contains(innerException.Message, dependencyName);
+    }
+
+    private static CompilationContext[] CompileContracts(string sourceCode)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, sourceCode);
+
+        try
+        {
+            var engine = new CompilationEngine(new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            });
+            var repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            return engine.CompileSources(new CompilationSourceReferences
+            {
+                Projects = new[] { frameworkProject }
+            }, tempFile).ToArray();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Return compiled contract contexts in the deterministic topological order already computed by the compiler.
- Avoid exposing `ConcurrentDictionary` enumeration order to callers.
- Add regression coverage for multi-contract source ordering.

## Validation
- Confirmed the new ordering test failed before the fix due to concurrent dictionary result order.
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter UnitTest_CompilationEngineReference`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj`
- `git diff --check`
