### PR TITLE
Record forward contract dependencies during prepare

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -215,6 +215,7 @@ namespace Neo.Compiler
             var classDependencies = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
             var allSmartContracts = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             var allClassSymbols = new List<INamedTypeSymbol?>();
+            var classSymbols = new List<INamedTypeSymbol>();
             foreach (var tree in Compilation.SyntaxTrees)
             {
                 var semanticModel = Compilation.GetSemanticModel(tree);
@@ -224,19 +225,34 @@ namespace Neo.Compiler
                 {
                     var classSymbol = semanticModel.GetDeclaredSymbol(classNode);
                     allClassSymbols.Add(classSymbol);
+                    if (classSymbol is null) continue;
+
+                    classSymbols.Add(classSymbol);
                     if (classSymbol is { IsAbstract: false, DeclaredAccessibility: Accessibility.Public } && IsDerivedFromSmartContract(classSymbol))
                     {
                         allSmartContracts.Add(classSymbol);
                         classDependencies[classSymbol] = [];
-                        foreach (var member in classSymbol.GetMembers())
-                        {
-                            var memberTypeSymbol = (member as IFieldSymbol)?.Type ?? (member as IPropertySymbol)?.Type;
-                            if (memberTypeSymbol is INamedTypeSymbol namedTypeSymbol && allSmartContracts.Contains(namedTypeSymbol) && !namedTypeSymbol.IsAbstract)
-                            {
-                                classDependencies[classSymbol].Add(namedTypeSymbol);
-                            }
-                        }
                     }
+                }
+            }
+
+            foreach (var classSymbol in classSymbols)
+            {
+                if (!allSmartContracts.Contains(classSymbol))
+                    continue;
+
+                foreach (var member in classSymbol.GetMembers())
+                {
+                    var memberTypeSymbol = (member as IFieldSymbol)?.Type ?? (member as IPropertySymbol)?.Type;
+                    if (memberTypeSymbol is not INamedTypeSymbol namedTypeSymbol)
+                        continue;
+                    if (namedTypeSymbol.IsAbstract)
+                        continue;
+                    if (!allSmartContracts.Contains(namedTypeSymbol))
+                        continue;
+                    if (classDependencies[classSymbol].Any(p => SymbolEqualityComparer.Default.Equals(p, namedTypeSymbol)))
+                        continue;
+                    classDependencies[classSymbol].Add(namedTypeSymbol);
                 }
             }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
@@ -5,6 +5,7 @@ using Neo.Compiler;
 using Neo.Json;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Neo.Compiler.CSharp.UnitTests;
@@ -12,6 +13,64 @@ namespace Neo.Compiler.CSharp.UnitTests;
 [TestClass]
 public class UnitTest_CompilationEngineReference
 {
+    [TestMethod]
+    public void PrepareProjectContracts_RecordsForwardContractDependencies()
+    {
+        var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempFolder);
+        var projectFile = Path.Combine(tempFolder, "ForwardDependency.csproj");
+        var sourceFile = Path.Combine(tempFolder, "ForwardDependency.cs");
+        var repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+        var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+        File.WriteAllText(projectFile, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{{frameworkProject}}" />
+  </ItemGroup>
+</Project>
+""");
+
+        File.WriteAllText(sourceFile, """
+using Neo.SmartContract.Framework;
+
+public class AlphaContract : SmartContract
+{
+    private BetaContract? _beta;
+
+    public static int Main() => 1;
+}
+
+public class BetaContract : SmartContract
+{
+    public static int Main() => 2;
+}
+""");
+
+        try
+        {
+            var engine = new CompilationEngine(new CompilationOptions
+            {
+                SkipRestoreIfAssetsPresent = true
+            });
+
+            var (_, classDependencies, _) = engine.PrepareProjectContracts(projectFile);
+            var alpha = classDependencies.Keys.Single(p => p.Name == "AlphaContract");
+            var beta = classDependencies.Keys.Single(p => p.Name == "BetaContract");
+
+            Assert.IsTrue(classDependencies[alpha].Any(p => SymbolEqualityComparer.Default.Equals(p, beta)),
+                "PrepareProjectContracts should record dependencies on contracts declared later in the project.");
+        }
+        finally
+        {
+            Directory.Delete(tempFolder, recursive: true);
+        }
+    }
+
     [TestMethod]
     public void GetCompilation_ReportsRestoreFailureExitCode()
     {


### PR DESCRIPTION
## Summary
- Change `PrepareProjectContracts` to collect all class symbols before scanning contract member dependencies.
- Record dependencies on smart contracts declared later in the project.
- Add regression coverage for a forward contract field reference in the prepare path.

## Validation
- Confirmed the new forward-dependency prepare test failed before the fix.
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter PrepareProjectContracts_RecordsForwardContractDependencies`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj`
- `git diff --check`
