### PR TITLE
Fix: InstructionToString with PUSHDATA2, PUSHDATA4

### DIFF
--- a/src/Neo.Disassembler.CSharp/Disassembler.cs
+++ b/src/Neo.Disassembler.CSharp/Disassembler.cs
@@ -104,13 +104,13 @@ public static class Disassembler
         else
         {
             var operandString = BitConverter.ToString(operand.ToArray()).Replace("-", "");
-
             switch (instruction.OpCode)
             {
                 case OpCode.PUSHDATA1:
+                case OpCode.PUSHDATA2:
+                case OpCode.PUSHDATA4:
                     {
                         ret = $"{opcode} {operandString}";
-
                         try
                         {
                             // Try ascii


### PR DESCRIPTION

Only OpCode.PUSHDATA1, No PUSHDATA2 and PUSHDATA4