### PR TITLE
Fix master-n3 test project classification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Build Solution
       run: dotnet build ./neo-devpack-dotnet.sln
     - name: Add package coverlet.msbuild
-      run: find tests -name *.csproj | xargs -I % dotnet add % package coverlet.msbuild
+      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild
     - name: Test Neo.Compiler.CSharp.UnitTests
       run: |
         dotnet test ./tests/Neo.Compiler.CSharp.UnitTests \

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_PostfixUnary.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_PostfixUnary.cs
@@ -9,7 +9,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-using Microsoft.ApplicationInsights.DataContracts;
 using Neo.SmartContract.Framework;
 using Neo.SmartContract.Framework.Native;
 using Neo.SmartContract.Framework.Services;

--- a/tests/Neo.Compiler.CSharp.TestContracts/Neo.Compiler.CSharp.TestContracts.csproj
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Neo.Compiler.CSharp.TestContracts.csproj
@@ -4,7 +4,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
+		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TestContractsProjectConfiguration.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TestContractsProjectConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests
+{
+    [TestClass]
+    public class UnitTest_TestContractsProjectConfiguration
+    {
+        [DataTestMethod]
+        [DataRow("tests/Neo.Compiler.CSharp.TestContracts/Neo.Compiler.CSharp.TestContracts.csproj")]
+        [DataRow("tests/Neo.SmartContract.Framework.TestContracts/Neo.SmartContract.Framework.TestContracts.csproj")]
+        public void TestContractsAreNotMarkedAsTestProjects(string projectRelativePath)
+        {
+            var projectPath = Path.Combine(FindRepositoryRoot(), projectRelativePath);
+            var project = XDocument.Load(projectPath);
+            var isTestProject = project
+                .Descendants()
+                .Where(element => element.Name.LocalName == "IsTestProject")
+                .Select(element => element.Value.Trim())
+                .Single();
+
+            Assert.AreEqual("false", isTestProject);
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory is not null)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "neo-devpack-dotnet.sln")))
+                {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+
+            throw new InvalidOperationException("Unable to locate repository root.");
+        }
+    }
+}

--- a/tests/Neo.SmartContract.Framework.TestContracts/Neo.SmartContract.Framework.TestContracts.csproj
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Neo.SmartContract.Framework.TestContracts.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
+		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- Mark the two TestContracts projects as non-test projects so solution-level `dotnet test` does not invoke VSTest on helper contract assemblies.
- Limit the workflow's `coverlet.msbuild` setup to real UnitTests projects instead of every project under `tests`.
- Remove an unused ApplicationInsights import from `Contract_PostfixUnary` that was only compiling because test package references leaked into the helper contract project.
- Add a regression test covering the TestContracts project classification.

## Root cause
`Neo.Compiler.CSharp.TestContracts` and `Neo.SmartContract.Framework.TestContracts` are helper contract assemblies, but they were marked with `IsTestProject=true`. That caused solution-level test execution and the CI coverage setup step to treat them as test projects. After the helper projects were corrected, the workflow still used `find tests -name *.csproj`, so it attempted to add `coverlet.msbuild` to the helper projects and remained exposed to feed failures during package mutation.

## Validation
- `find tests -path '*UnitTests/*.csproj' | sort`
- `git diff --check`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --filter "Test_Abort|TestContractsAreNotMarkedAsTestProjects"`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj -c Release --no-build --filter TestContractsAreNotMarkedAsTestProjects`
- `dotnet build tests/Neo.Compiler.CSharp.TestContracts/Neo.Compiler.CSharp.TestContracts.csproj -c Release`
- `dotnet build tests/Neo.SmartContract.Framework.TestContracts/Neo.SmartContract.Framework.TestContracts.csproj -c Release`
- `dotnet test neo-devpack-dotnet.sln -c Release --logger "console;verbosity=minimal"`
- `dotnet test neo-devpack-dotnet.sln -c Release --no-build --logger "console;verbosity=minimal"`
