### PR TITLE
Map NuGet package sources

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Build Solution
       run: dotnet build ./neo-devpack-dotnet.sln
     - name: Add package coverlet.msbuild
-      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild
+      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --source https://api.nuget.org/v3/index.json
     - name: Test Neo.Compiler.CSharp.UnitTests
       run: |
         dotnet test ./tests/Neo.Compiler.CSharp.UnitTests \

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,4 +5,14 @@
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="MyGet-neo" value="https://www.myget.org/F/neo/api/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="NuGet.org">
+      <package pattern="*" />
+      <package pattern="Neo.SmartContract.*" />
+    </packageSource>
+    <packageSource key="MyGet-neo">
+      <package pattern="Neo" />
+      <package pattern="Neo.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
## Summary
- Map public packages to NuGet.org and Neo CI packages to the Neo MyGet feed.
- Limit the CI `coverlet.msbuild` package install to NuGet.org.
- Reduce failures caused by the Neo MyGet feed being queried for packages that are available from NuGet.org.

## Validation
- `ruby -r rexml/document -e "REXML::Document.new(File.read('NuGet.Config')); puts 'nuget config xml ok'"`
- `git diff --check`
- `dotnet restore ./src/Neo.SmartContract.Analyzer/Neo.SmartContract.Analyzer.csproj --configfile NuGet.Config --no-cache -v minimal`

## Notes
- Packages such as `Neo`, `Neo.Extensions`, and `Neo.IO` at `3.9.3-CI02036` are still served by the Neo MyGet feed because they are not available on NuGet.org.
