### PR TITLE
Add runtime log watcher

### DIFF
--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -24,6 +24,8 @@ The **Neo.SmartContract.Testing** project is designed to facilitate the developm
     - [Example of use](#example-of-use)
 - [Fee watcher](#fee-watcher)
     - [Example of use](#example-of-use)
+- [Runtime log watcher](#runtime-log-watcher)
+    - [Example of use](#example-of-use)
 - [Forging signatures](#forging-signatures)
     - [Example of use](#example-of-use)
 - [Event testing](#event-testing)
@@ -268,6 +270,24 @@ using var fee = engine.CreateFeeWatcher();
     Assert.AreEqual("GAS", engine.Native.GAS.Symbol);
     Assert.AreEqual(984060L, fee);
 }
+```
+
+### Runtime log watcher
+
+The `RuntimeLogWatcher` class captures runtime logs emitted during contract execution, so tests can assert log messages without wiring custom event handlers.
+
+#### Example of use
+
+```csharp
+using var logs = engine.CreateRuntimeLogWatcher();
+
+contract.Save("example");
+
+Assert.AreEqual(1, logs.Logs.Count);
+Assert.AreEqual("saved", logs.Logs[0].Message);
+
+logs.Reset();
+Assert.AreEqual(0, logs.Logs.Count);
 ```
 
 ### Forging signatures

--- a/src/Neo.SmartContract.Testing/RuntimeLog.cs
+++ b/src/Neo.SmartContract.Testing/RuntimeLog.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RuntimeLog.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Diagnostics;
+
+namespace Neo.SmartContract.Testing
+{
+    [DebuggerDisplay("{Sender}: {Message}")]
+    public sealed class RuntimeLog
+    {
+        /// <summary>
+        /// Contract that emitted the log.
+        /// </summary>
+        public UInt160 Sender { get; }
+
+        /// <summary>
+        /// Log message.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Constructor of RuntimeLog.
+        /// </summary>
+        /// <param name="sender">Contract that emitted the log.</param>
+        /// <param name="message">Log message.</param>
+        public RuntimeLog(UInt160 sender, string message)
+        {
+            Sender = sender;
+            Message = message;
+        }
+    }
+}

--- a/src/Neo.SmartContract.Testing/RuntimeLogWatcher.cs
+++ b/src/Neo.SmartContract.Testing/RuntimeLogWatcher.cs
@@ -1,0 +1,64 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RuntimeLogWatcher.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Neo.SmartContract.Testing
+{
+    [DebuggerDisplay("Count={Logs.Count}")]
+    public sealed class RuntimeLogWatcher : IDisposable
+    {
+        private readonly TestEngine _testEngine;
+        private readonly List<RuntimeLog> _logs = [];
+        private bool _disposed;
+
+        /// <summary>
+        /// Captured runtime logs.
+        /// </summary>
+        public IReadOnlyList<RuntimeLog> Logs => _logs;
+
+        /// <summary>
+        /// Clear captured runtime logs.
+        /// </summary>
+        public void Reset()
+        {
+            _logs.Clear();
+        }
+
+        /// <summary>
+        /// Constructor of RuntimeLogWatcher.
+        /// </summary>
+        /// <param name="engine">Test engine.</param>
+        public RuntimeLogWatcher(TestEngine engine)
+        {
+            _testEngine = engine;
+            _testEngine.OnRuntimeLog += OnRuntimeLog;
+        }
+
+        private void OnRuntimeLog(UInt160 sender, string message)
+        {
+            _logs.Add(new RuntimeLog(sender, message));
+        }
+
+        /// <summary>
+        /// Stop capturing runtime logs.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            _testEngine.OnRuntimeLog -= OnRuntimeLog;
+            _disposed = true;
+        }
+    }
+}

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -368,6 +368,15 @@ namespace Neo.SmartContract.Testing
         }
 
         /// <summary>
+        /// Create runtime log watcher
+        /// </summary>
+        /// <returns>Runtime log watcher</returns>
+        public RuntimeLogWatcher CreateRuntimeLogWatcher()
+        {
+            return new RuntimeLogWatcher(this);
+        }
+
+        /// <summary>
         /// Get deploy hash
         /// </summary>
         /// <param name="nef">Nef</param>

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -99,6 +99,43 @@ namespace Neo.SmartContract.Testing.UnitTests
         }
 
         [TestMethod]
+        public void CreateRuntimeLogWatcherTracksLogs()
+        {
+            TestEngine engine = new(true);
+
+            var watcher = engine.CreateRuntimeLogWatcher();
+
+            var firstSender = ExecuteRuntimeLog(engine, "first");
+            var secondSender = ExecuteRuntimeLog(engine, "second");
+
+            Assert.AreEqual(2, watcher.Logs.Count);
+            Assert.AreEqual(firstSender, watcher.Logs[0].Sender);
+            Assert.AreEqual("first", watcher.Logs[0].Message);
+            Assert.AreEqual(secondSender, watcher.Logs[1].Sender);
+            Assert.AreEqual("second", watcher.Logs[1].Message);
+
+            watcher.Reset();
+
+            Assert.AreEqual(0, watcher.Logs.Count);
+
+            watcher.Dispose();
+            ExecuteRuntimeLog(engine, "ignored");
+
+            Assert.AreEqual(0, watcher.Logs.Count);
+        }
+
+        private static UInt160 ExecuteRuntimeLog(TestEngine engine, string message)
+        {
+            var builder = new ScriptBuilder();
+            builder.EmitPush(message);
+            builder.EmitSysCall(ApplicationEngine.System_Runtime_Log);
+            var script = builder.ToArray();
+            engine.Execute(script);
+
+            return script.ToScriptHash();
+        }
+
+        [TestMethod]
         public void TestHashExists()
         {
             TestEngine engine = new(false);


### PR DESCRIPTION
## Summary
- Add runtime log watcher support for capturing `Runtime.Log` output during contract tests.
- Add `TestEngine.CreateRuntimeLogWatcher()` as a simple factory method.
- Document the new watcher in the testing README.

## Testing
- `dotnet restore tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj -v minimal`
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter CreateRuntimeLogWatcherTracksLogs --no-restore`
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore`
- `git diff --check origin/master-n3..HEAD`