### PR TITLE
Add checkpoint file helpers

### DIFF
--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -186,6 +186,8 @@ To create a checkpoint, simply call `Checkpoint()` from a `EngineStorage` class 
 It has the following methods:
 
 - **Restore(snapshot)**: This method can also be called from an `EngineStorage` or from our `TestEngine` class. It is used to restore the storage to a specified checkpoint.
+- **Load(path)**: Loads a checkpoint from a file.
+- **Save(path)**: Saves the checkpoint to a file.
 - **ToArray()**: Exports the checkpoint to a `byte[]`.
 - **Write(stream)**: Writes the checkpoint to a `Stream`.
 
@@ -217,6 +219,16 @@ engine = new TestEngine(false) { Storage = storage };
 // Ensure that all works
 
 Assert.AreEqual(100_000_000, engine.Native.NEO.TotalSupply);
+```
+
+Checkpoints can also be stored as files:
+
+```csharp
+var checkpoint = engine.Storage.Checkpoint();
+checkpoint.Save("storage.checkpoint");
+
+var loaded = EngineCheckpoint.Load("storage.checkpoint");
+engine.Storage.Restore(loaded);
 ```
 
 ### Custom mocks

--- a/src/Neo.SmartContract.Testing/Storage/EngineCheckpoint.cs
+++ b/src/Neo.SmartContract.Testing/Storage/EngineCheckpoint.cs
@@ -72,6 +72,17 @@ namespace Neo.SmartContract.Testing.Storage
         }
 
         /// <summary>
+        /// Load checkpoint from file
+        /// </summary>
+        /// <param name="path">File path</param>
+        /// <returns>EngineCheckpoint</returns>
+        public static EngineCheckpoint Load(string path)
+        {
+            using var stream = File.OpenRead(path);
+            return new EngineCheckpoint(stream);
+        }
+
+        /// <summary>
         /// Restore
         /// </summary>
         /// <param name="snapshot">Snapshot</param>
@@ -90,6 +101,16 @@ namespace Neo.SmartContract.Testing.Storage
             {
                 snapshot.Add(new StorageKey(entry.key), new StorageItem(entry.value));
             }
+        }
+
+        /// <summary>
+        /// Save checkpoint to file
+        /// </summary>
+        /// <param name="path">File path</param>
+        public void Save(string path)
+        {
+            using var stream = File.Create(path);
+            Write(stream);
         }
 
         /// <summary>

--- a/tests/Neo.SmartContract.Testing.UnitTests/Storage/TestStorageTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Storage/TestStorageTests.cs
@@ -63,6 +63,33 @@ namespace Neo.SmartContract.Testing.UnitTests.Storage
         }
 
         [TestMethod]
+        public void SaveAndLoadCheckpoint()
+        {
+            var engine = new TestEngine(true);
+            var checkpoint = engine.Storage.Checkpoint();
+            var path = Path.GetTempFileName();
+
+            try
+            {
+                checkpoint.Save(path);
+
+                Assert.IsTrue(new FileInfo(path).Length > 0);
+
+                var loaded = EngineCheckpoint.Load(path);
+                var storage = new EngineStorage(new MemoryStore());
+                loaded.Restore(storage.Snapshot);
+
+                engine = new TestEngine(storage, false);
+
+                Assert.AreEqual(100_000_000, engine.Native.NEO.TotalSupply);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestMethod]
         public void LoadExportImport()
         {
             EngineStorage store = new(new MemoryStore());


### PR DESCRIPTION
## Summary
- Add `EngineCheckpoint.Save(path)` for writing checkpoint data directly to a file.
- Add `EngineCheckpoint.Load(path)` for loading checkpoint data from a file.
- Document file-based checkpoint usage in the testing README.

## Testing
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter SaveAndLoadCheckpoint --no-restore`
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore`
- `git diff --check`