### PR TITLE
Cache restored packages in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DOTNET_VERSION: 10.0.x
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
   DOTNET_TEST_PARAMETERS: --no-build /p:CollectCoverage=true -l "console;verbosity=detailed"
   COVERLET_EXCLUDE_COVERAGE: /p:Exclude=\"[Neo.SmartContract.TestEngine]*,[Neo.Disassembler.CSharp]*,[Neo.Compiler.CSharp.UnitTests]*,[Neo]*,[Neo.IO]*,[Neo.Json]*,[Neo.VM]*,[Neo.Extensions]*,[Neo.Cryptography.BLS12_381]*\"
   COVERLET_OUTPUT: /p:CoverletOutput=${{ github.workspace }}/coverage-join/
@@ -31,6 +32,11 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.NUGET_PACKAGES }}
+        key: ${{ runner.os }}-dotnet-${{ env.DOTNET_VERSION }}-nuget-${{ hashFiles('NuGet.Config', 'src/Directory.Build.props', 'tests/Directory.Build.props', '**/*.csproj') }}
     - name: Check format
       run: |
         dotnet format --no-restore --verify-no-changes --verbosity diagnostic


### PR DESCRIPTION
## Summary
- Store the NuGet package cache inside the workflow workspace.
- Cache restored packages for the Test job with a dependency-specific key.
- Use an exact cache key without restore fallbacks so dependency version changes create a fresh cache instead of restoring older packages.

## Why
CI still needs Neo CI packages from the MyGet feed. MyGet has been returning intermittent 500 responses during restore, which can fail PR checks before the code is built. Caching the restored package folder reduces repeated requests to MyGet for the same dependency set while keeping MyGet available when a new Neo package version is required.

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/main.yml'); puts 'workflow yaml ok'"`
- `git diff --check`
- GitHub Actions Test job passed

## Notes
GitHub Actions cache entries are immutable, so this workflow does not use restore fallbacks. When dependency versions change, the key changes and CI creates a new cache instead of restoring the previous dependency set. Older caches will expire under the normal cache retention policy.
