### PR TITLE
Filter smart contract storage exports

### DIFF
--- a/src/Neo.SmartContract.Testing/Storage/SmartContractStorage.cs
+++ b/src/Neo.SmartContract.Testing/Storage/SmartContractStorage.cs
@@ -241,8 +241,9 @@ namespace Neo.SmartContract.Testing.Storage
         /// </summary>
         public JObject Export()
         {
+            var contractId = GetContractId();
             var buffer = new byte[(sizeof(int))];
-            BinaryPrimitives.WriteInt32LittleEndian(buffer, GetContractId());
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, contractId);
             var keyId = Convert.ToBase64String(buffer);
 
             // Write prefix
@@ -253,6 +254,8 @@ namespace Neo.SmartContract.Testing.Storage
 
             foreach (var entry in _smartContract.Engine.Storage.Snapshot.Seek(Array.Empty<byte>(), Persistence.SeekDirection.Forward))
             {
+                if (entry.Key.Id != contractId) continue;
+
                 // "key":"value" in base64
 
                 prefix[Convert.ToBase64String(entry.Key.Key.ToArray())] = Convert.ToBase64String(entry.Value.Value.ToArray());

--- a/tests/Neo.SmartContract.Testing.UnitTests/SmartContractStorageTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/SmartContractStorageTests.cs
@@ -10,9 +10,11 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Json;
 using System;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 
 namespace Neo.SmartContract.Testing.UnitTests
 {
@@ -64,6 +66,24 @@ namespace Neo.SmartContract.Testing.UnitTests
             // Check altered data
 
             Assert.AreEqual(BigInteger.MinusOne, engine.Native.NEO.RegisterPrice);
+        }
+
+        [TestMethod]
+        public void TestExportIncludesOnlyCurrentContractStorage()
+        {
+            TestEngine engine = new(true);
+
+            var neoKey = "neo-export-scope";
+            var gasKey = "gas-export-scope";
+
+            engine.Native.NEO.Storage.Put(neoKey, BigInteger.One);
+            engine.Native.GAS.Storage.Put(gasKey, BigInteger.One);
+
+            var storage = engine.Native.NEO.Storage.Export();
+            var prefix = (JObject)storage.Properties.Single().Value!;
+
+            Assert.IsTrue(prefix.ContainsProperty(Convert.ToBase64String(Encoding.UTF8.GetBytes(neoKey))));
+            Assert.IsFalse(prefix.ContainsProperty(Convert.ToBase64String(Encoding.UTF8.GetBytes(gasKey))));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Filter smart contract storage export entries by the current contract id.
- Add a regression test that verifies exporting NEO storage does not include GAS storage keys.

## Tests
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore --filter SmartContractStorageTests.TestExportIncludesOnlyCurrentContractStorage`
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore`