### PR TITLE
Make testing syscall registration idempotent

### DIFF
--- a/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
@@ -37,6 +37,11 @@ namespace Neo.SmartContract.Testing
         /// </summary>
         static TestingApplicationEngine()
         {
+            RegisterTestingSyscall();
+        }
+
+        private static void RegisterTestingSyscall()
+        {
             var items = typeof(ApplicationEngine)
                 .GetField("services", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
                 .GetValue(null) as Dictionary<uint, InteropDescriptor>;
@@ -50,7 +55,7 @@ namespace Neo.SmartContract.Testing
                 RequiredCallFlags = CallFlags.None,
             };
 
-            items?.Add(descriptor.Hash, descriptor);
+            items?.TryAdd(descriptor.Hash, descriptor);
         }
 
         /// <summary>

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Numerics;
+using System.Reflection;
 
 namespace Neo.SmartContract.Testing.UnitTests
 {
@@ -96,6 +97,17 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             engine.OnGetCallingScriptHash = (current, expected) => UInt160.Parse("0x0000000000000000000000000000000000000001");
             Assert.AreEqual("0x0000000000000000000000000000000000000001", engine.Execute(script).ConvertTo(typeof(UInt160))!.ToString());
+        }
+
+        [TestMethod]
+        public void TestingSyscallRegistrationIsIdempotent()
+        {
+            var engineType = typeof(TestEngine).Assembly.GetType("Neo.SmartContract.Testing.TestingApplicationEngine")!;
+            var registerMethod = engineType.GetMethod("RegisterTestingSyscall", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.IsNotNull(registerMethod);
+            registerMethod.Invoke(null, null);
+            registerMethod.Invoke(null, null);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- Move testing syscall registration into a reusable private helper.
- Use idempotent registration so repeated registration attempts do not throw.
- Add a regression test for duplicate registration attempts.

## Tests
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore --filter TestEngineTests.TestingSyscallRegistrationIsIdempotent`
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore`