### PR TITLE
Add deterministic test signers

### DIFF
--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -95,12 +95,14 @@ And for read and write, we have:
 
 #### Methods
 
-It has four methods:
+It includes these methods and helpers:
 
 - **Execute(script)**: Executes a script on the neo virtual machine and returns the execution result.
 - **Deploy(nef, manifest, data, customMock)**: Deploys the smart contract by calling the native method `ContractManagement.deploy`. It allows setting [custom mocks](#custom-mocks), which will be detailed later. And returns the instance of the contract that has been deployed.
 - **FromHash(hash, customMocks, checkExistence)**: Creates an instance without needing a `NefFile` or `Manifest`, only requiring the contract's hash. It does not consider whether the contract exists on the chain unless `checkExistence` is set to `true`.
 - **SetTransactionSigners(signers)**: Set the `Signer` of the `Transaction`.
+- **Alice, Bob and Charlie**: Deterministic test signers that can be reused in account-based tests. They are not funded automatically.
+- **CreateSigner(account, scope)**: Creates a `Signer` for an existing account and witness scope.
 - **GetNewSigner(scope)**: A static method that provides us with a random `Signer` signed by default by `CalledByEntry`.
 - **GetDeployHash(nef, manifest)**: Gets the hash that will result from deploying a contract with the defined `NefFile` and `Manifest`.
 
@@ -331,9 +333,9 @@ engine.Native.NEO.RegisterPrice = 123;
 
 Assert.AreEqual(123, engine.Native.NEO.RegisterPrice);
 
-// Now test it without this signature
+// Now test it with another deterministic test account
 
-engine.SetTransactionSigners(TestEngine.GetNewSigner());
+engine.SetTransactionSigners(TestEngine.Bob);
 
 Assert.ThrowsException<TargetInvocationException>(() => engine.Native.NEO.RegisterPrice = 123);
 ```

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -92,6 +92,36 @@ namespace Neo.SmartContract.Testing
         };
 
         /// <summary>
+        /// Stable Alice account for repeatable tests.
+        /// </summary>
+        public static readonly UInt160 AliceAccount = UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314");
+
+        /// <summary>
+        /// Stable Bob account for repeatable tests.
+        /// </summary>
+        public static readonly UInt160 BobAccount = UInt160.Parse("0x1112131415161718191a1b1c1d1e1f2021222324");
+
+        /// <summary>
+        /// Stable Charlie account for repeatable tests.
+        /// </summary>
+        public static readonly UInt160 CharlieAccount = UInt160.Parse("0x2122232425262728292a2b2c2d2e2f3031323334");
+
+        /// <summary>
+        /// Stable Alice signer with CalledByEntry scope.
+        /// </summary>
+        public static Signer Alice => CreateSigner(AliceAccount);
+
+        /// <summary>
+        /// Stable Bob signer with CalledByEntry scope.
+        /// </summary>
+        public static Signer Bob => CreateSigner(BobAccount);
+
+        /// <summary>
+        /// Stable Charlie signer with CalledByEntry scope.
+        /// </summary>
+        public static Signer Charlie => CreateSigner(CharlieAccount);
+
+        /// <summary>
         /// Storage
         /// </summary>
         public EngineStorage Storage { get; internal set; }
@@ -809,6 +839,21 @@ namespace Neo.SmartContract.Testing
         }
 
         /// <summary>
+        /// Create a signer for an existing account.
+        /// </summary>
+        /// <param name="account">Account</param>
+        /// <param name="scope">Witness scope</param>
+        /// <returns>Signer</returns>
+        public static Signer CreateSigner(UInt160 account, WitnessScope scope = WitnessScope.CalledByEntry)
+        {
+            return new Signer()
+            {
+                Account = account,
+                Scopes = scope,
+            };
+        }
+
+        /// <summary>
         /// Generate a random new Signers with CalledByEntry scope by default
         /// </summary>
         /// <param name="scope">Witness scope</param>
@@ -823,11 +868,7 @@ namespace Neo.SmartContract.Testing
 
             if (data[0] == 0) data[0] = 1;
 
-            return new Signer()
-            {
-                Account = new UInt160(data),
-                Scopes = scope,
-            };
+            return CreateSigner(new UInt160(data), scope);
         }
     }
 }

--- a/src/Neo.SmartContract.Testing/TestingStandards/OwnableTests.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/OwnableTests.cs
@@ -95,7 +95,7 @@ public class OwnableTests<T> : TestBase<T>
         {
             Engine.SetTransactionSigners(Alice);
             Assert.IsTrue(verificable.Verify);
-            Engine.SetTransactionSigners(TestEngine.GetNewSigner());
+            Engine.SetTransactionSigners(Bob);
             Assert.IsFalse(verificable.Verify);
         }
     }
@@ -103,9 +103,7 @@ public class OwnableTests<T> : TestBase<T>
     [TestMethod]
     public virtual void TestSenderAsDefaultOwner()
     {
-        var random = TestEngine.GetNewSigner();
-
-        Engine.SetTransactionSigners(random);
+        Engine.SetTransactionSigners(Charlie);
 
         var expectedHash = Engine.GetDeployHash(NefFile, Manifest);
         var check = Engine.FromHash<T>(expectedHash, false);
@@ -115,8 +113,8 @@ public class OwnableTests<T> : TestBase<T>
         Assert.AreEqual(check.Hash, ownable.Hash);
         check.OnSetOwner -= onSetOwner;
 
-        AssertOnChangeOwnerEvent(null, random.Account);
-        Assert.AreEqual(random.Account, ownable.Owner);
+        AssertOnChangeOwnerEvent(null, Charlie.Account);
+        Assert.AreEqual(Charlie.Account, ownable.Owner);
     }
 
     [TestMethod]

--- a/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
@@ -24,8 +24,9 @@ public class TestBase<T> where T : SmartContract, IContractInfo
     private readonly List<string> _contractLogs = [];
 
     public static CoveredContract? Coverage { get; private set; }
-    public static Signer Alice { get; set; } = TestEngine.GetNewSigner();
-    public static Signer Bob { get; set; } = TestEngine.GetNewSigner();
+    public static Signer Alice => TestEngine.Alice;
+    public static Signer Bob => TestEngine.Bob;
+    public static Signer Charlie => TestEngine.Charlie;
 
     public NefFile NefFile { get; private set; } = default!;
     public ContractManifest Manifest { get; private set; } = default!;

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractCall.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractCall.cs
@@ -20,7 +20,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestInitialize]
         public void Init()
         {
-            Alice.Account = UInt160.Parse("0102030405060708090A0102030405060708090A");
+            Engine.SetTransactionSigners(TestEngine.CreateSigner(UInt160.Parse("0102030405060708090A0102030405060708090A")));
             var c1 = Engine.Deploy<Contract1>(Contract1.Nef, Contract1.Manifest);
             Assert.AreEqual("0xb6ae1662a8228ed73e372b0d0ea11716445a4281", c1.Hash.ToString());
         }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NEP11.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NEP11.cs
@@ -47,7 +47,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void UnitTest_Transfer_MissingToken_Throws()
         {
-            var to = TestEngine.GetNewSigner().Account;
+            var to = TestEngine.BobAccount;
             var ex = Assert.ThrowsException<TestException>(() => Contract.Transfer(to, new byte[] { 0x02 }, null));
             StringAssert.Contains(ex.InnerException?.Message ?? ex.Message, "does not exist");
         }

--- a/tests/Neo.SmartContract.Framework.UnitTests/Nep11MintUniquenessTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Nep11MintUniquenessTest.cs
@@ -24,8 +24,8 @@ public class Nep11MintUniquenessTest
         var engine = new TestEngine(true);
         var contract = engine.Deploy<Nep11MintUniquenessContract>(nef, manifest);
 
-        var firstOwner = TestEngine.GetNewSigner().Account;
-        var secondOwner = TestEngine.GetNewSigner().Account;
+        var firstOwner = TestEngine.AliceAccount;
+        var secondOwner = TestEngine.BobAccount;
         var tokenId = new byte[] { 0x42 };
 
         contract.Mint(tokenId, firstOwner);

--- a/tests/Neo.SmartContract.Framework.UnitTests/OwnableTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/OwnableTest.cs
@@ -20,8 +20,8 @@ namespace Neo.SmartContract.Framework.UnitTests;
 [TestClass]
 public class OwnableTest
 {
-    private static readonly Signer Alice = TestEngine.GetNewSigner();
-    private static readonly Signer Bob = TestEngine.GetNewSigner();
+    private static readonly Signer Alice = TestEngine.Alice;
+    private static readonly Signer Bob = TestEngine.Bob;
 
     [TestMethod]
     public void Ownable_UsesSenderAsDefaultOwner_And_OnlyOwnerGuardsProtectedMethods()

--- a/tests/Neo.SmartContract.Framework.UnitTests/PausableTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/PausableTest.cs
@@ -23,7 +23,7 @@ namespace Neo.SmartContract.Framework.UnitTests;
 [TestClass]
 public class PausableTest
 {
-    private static readonly Signer Sender = TestEngine.GetNewSigner();
+    private static readonly Signer Sender = TestEngine.Alice;
 
     [TestMethod]
     public void Pausable_WhenNotPaused_AllowsCalls_And_PauseBlocks()

--- a/tests/Neo.SmartContract.Framework.UnitTests/Services/RuntimeTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Services/RuntimeTest.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.Extensions;
 using Neo.VM;
@@ -22,15 +23,13 @@ namespace Neo.SmartContract.Framework.UnitTests.Services
     [TestClass]
     public class RuntimeTest : DebugAndTestBase<Contract_Runtime>
     {
-        static RuntimeTest()
-        {
-            // We need a deterministic deployer for Random method
+        private static readonly Signer RandomSigner = TestEngine.CreateSigner(UInt160.Parse("0102030405060708090A0102030405060708090A"));
 
-            Alice = new Network.P2P.Payloads.Signer()
-            {
-                Account = UInt160.Parse("0102030405060708090A0102030405060708090A"),
-                Scopes = Network.P2P.Payloads.WitnessScope.CalledByEntry
-            };
+        protected override TestEngine CreateTestEngine()
+        {
+            var engine = new TestEngine(true);
+            engine.SetTransactionSigners(RandomSigner);
+            return engine;
         }
 
         [TestMethod]
@@ -84,7 +83,9 @@ namespace Neo.SmartContract.Framework.UnitTests.Services
         [TestMethod]
         public void Test_Random()
         {
-            Engine.SetTransactionSigners(Alice);
+            // We need a deterministic signer for Random method
+
+            Engine.SetTransactionSigners(RandomSigner);
             Engine.Transaction.Nonce = 0x01020304;
             Engine.PersistingBlock.Nonce = 0x01020304;
             Assert.AreEqual(BigInteger.Parse("140181351494432352371728933832694804614"), Contract.GetRandom());
@@ -120,7 +121,7 @@ namespace Neo.SmartContract.Framework.UnitTests.Services
         {
             // True
 
-            var signer = Testing.TestEngine.GetNewSigner();
+            var signer = Testing.TestEngine.Bob;
 
             Engine.SetTransactionSigners(signer);
             Assert.IsTrue(Contract.CheckWitness(signer.Account));

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep17/Nep17ContractTests.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractnep17/Nep17ContractTests.cs
@@ -186,19 +186,19 @@ namespace Neo.SmartContract.Template.UnitTests.templates.neocontractnep17
                 newOwnerRaised = newOwner;
             };
 
-            // Deploy with random owner, we can use the same storage
-            // because the contract hash contains the Sender, and now it's random
+            // Deploy with another owner, we can use the same storage
+            // because the contract hash contains the Sender
 
-            var rand = TestEngine.GetNewSigner().Account;
-            var nep17 = Engine.Deploy<Nep17ContractTemplate>(NefFile, Manifest, rand);
+            var owner = TestEngine.CharlieAccount;
+            var nep17 = Engine.Deploy<Nep17ContractTemplate>(NefFile, Manifest, owner);
             Assert.AreEqual(check.Hash, nep17.Hash);
 
             Coverage?.Join(nep17.GetCoverage());
 
-            Assert.AreEqual(rand, nep17.Owner);
+            Assert.AreEqual(owner, nep17.Owner);
             Assert.IsNull(previousOwnerRaised);
             Assert.AreEqual(newOwnerRaised, nep17.Owner);
-            Assert.AreEqual(newOwnerRaised, rand);
+            Assert.AreEqual(newOwnerRaised, owner);
         }
     }
 }

--- a/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractowner/OwnableContractTests.cs
+++ b/tests/Neo.SmartContract.Template.UnitTests/templates/neocontractowner/OwnableContractTests.cs
@@ -95,19 +95,19 @@ namespace Neo.SmartContract.Template.UnitTests.templates.neocontractowner
                 newOwnerRaised = newOwner;
             };
 
-            // Deploy with random owner, we can use the same storage
-            // because the contract hash contains the Sender, and now it's random
+            // Deploy with another owner, we can use the same storage
+            // because the contract hash contains the Sender
 
-            var rand = TestEngine.GetNewSigner().Account;
-            var nep17 = Engine.Deploy<OwnableTemplate>(NefFile, Manifest, rand);
+            var owner = TestEngine.CharlieAccount;
+            var nep17 = Engine.Deploy<OwnableTemplate>(NefFile, Manifest, owner);
             Assert.AreEqual(check.Hash, nep17.Hash);
 
             Coverage?.Join(nep17.GetCoverage());
 
-            Assert.AreEqual(rand, nep17.Owner);
+            Assert.AreEqual(owner, nep17.Owner);
             Assert.IsNull(previousOwnerRaised);
             Assert.AreEqual(newOwnerRaised, nep17.Owner);
-            Assert.AreEqual(newOwnerRaised, rand);
+            Assert.AreEqual(newOwnerRaised, owner);
         }
 
         [TestMethod]

--- a/tests/Neo.SmartContract.Testing.UnitTests/NativeArtifactsTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/NativeArtifactsTests.cs
@@ -143,9 +143,9 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             Assert.AreEqual(123, engine.Native.NEO.RegisterPrice);
 
-            // Now test it without this signature
+            // Now test it with another deterministic test account
 
-            engine.SetTransactionSigners(TestEngine.GetNewSigner());
+            engine.SetTransactionSigners(TestEngine.Bob);
 
             var exception = Assert.ThrowsExactly<TestException>(() => _ = engine.Native.NEO.RegisterPrice = 123);
             Assert.IsInstanceOfType<TargetInvocationException>(exception.InnerException);

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -12,9 +12,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Testing.Extensions;
 using Neo.SmartContract.Testing.Exceptions;
 using Neo.SmartContract.Testing.Native;
+using Neo.SmartContract.Testing.TestingStandards;
 using Neo.VM;
 using Neo.VM.Types;
 using System;
@@ -32,6 +34,14 @@ namespace Neo.SmartContract.Testing.UnitTests
         {
             public abstract int myReturnMethod();
             protected MyUndeployedContract(SmartContractInitialize initialize) : base(initialize) { }
+        }
+
+        public abstract class TestingStandardsContract : SmartContract, IContractInfo
+        {
+            public static NefFile Nef => throw new NotSupportedException();
+            public static Neo.SmartContract.Manifest.ContractManifest Manifest => throw new NotSupportedException();
+
+            protected TestingStandardsContract(SmartContractInitialize initialize) : base(initialize) { }
         }
 
         //[TestMethod]
@@ -122,6 +132,58 @@ namespace Neo.SmartContract.Testing.UnitTests
             ExecuteRuntimeLog(engine, "ignored");
 
             Assert.AreEqual(0, watcher.Logs.Count);
+        }
+
+        [TestMethod]
+        public void BuiltInTestSignersUseStableAccounts()
+        {
+            Assert.AreEqual(UInt160.Parse("0x0102030405060708090a0b0c0d0e0f1011121314"), TestEngine.AliceAccount);
+            Assert.AreEqual(UInt160.Parse("0x1112131415161718191a1b1c1d1e1f2021222324"), TestEngine.BobAccount);
+            Assert.AreEqual(UInt160.Parse("0x2122232425262728292a2b2c2d2e2f3031323334"), TestEngine.CharlieAccount);
+
+            Assert.AreEqual(TestEngine.AliceAccount, TestEngine.Alice.Account);
+            Assert.AreEqual(TestEngine.BobAccount, TestEngine.Bob.Account);
+            Assert.AreEqual(TestEngine.CharlieAccount, TestEngine.Charlie.Account);
+            Assert.AreEqual(WitnessScope.CalledByEntry, TestEngine.Alice.Scopes);
+            Assert.AreEqual(WitnessScope.CalledByEntry, TestEngine.Bob.Scopes);
+            Assert.AreEqual(WitnessScope.CalledByEntry, TestEngine.Charlie.Scopes);
+        }
+
+        [TestMethod]
+        public void BuiltInTestSignersReturnFreshSignerInstances()
+        {
+            var alice = TestEngine.Alice;
+            alice.Account = UInt160.Zero;
+            alice.Scopes = WitnessScope.Global;
+
+            Assert.AreEqual(TestEngine.AliceAccount, TestEngine.Alice.Account);
+            Assert.AreEqual(WitnessScope.CalledByEntry, TestEngine.Alice.Scopes);
+        }
+
+        [TestMethod]
+        public void CreateSignerUsesRequestedAccountAndScope()
+        {
+            var signer = TestEngine.CreateSigner(TestEngine.BobAccount, WitnessScope.Global);
+
+            Assert.AreEqual(TestEngine.BobAccount, signer.Account);
+            Assert.AreEqual(WitnessScope.Global, signer.Scopes);
+        }
+
+        [TestMethod]
+        public void GetNewSignerCreatesAdHocAccountWithRequestedScope()
+        {
+            var signer = TestEngine.GetNewSigner(WitnessScope.Global);
+
+            Assert.AreNotEqual(UInt160.Zero, signer.Account);
+            Assert.AreEqual(WitnessScope.Global, signer.Scopes);
+        }
+
+        [TestMethod]
+        public void TestingStandardsUseBuiltInTestSigners()
+        {
+            Assert.AreEqual(TestEngine.AliceAccount, TestBase<TestingStandardsContract>.Alice.Account);
+            Assert.AreEqual(TestEngine.BobAccount, TestBase<TestingStandardsContract>.Bob.Account);
+            Assert.AreEqual(TestEngine.CharlieAccount, TestBase<TestingStandardsContract>.Charlie.Account);
         }
 
         private static UInt160 ExecuteRuntimeLog(TestEngine engine, string message)

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestTreasury.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestTreasury.cs
@@ -88,7 +88,7 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             Assert.IsTrue(_engine.Native.Treasury.Verify()!.Value);
 
-            _engine.SetTransactionSigners(TestEngine.GetNewSigner());
+            _engine.SetTransactionSigners(TestEngine.Alice);
 
             Assert.IsFalse(_engine.Native.Treasury.Verify()!.Value);
         }


### PR DESCRIPTION
## Summary
- Add stable Alice, Bob, and Charlie signers and account hashes to TestEngine.
- Add CreateSigner(account, scope) for fixed account and scope combinations.
- Use the built-in signers in testing standards and migrate account-focused unit tests away from ad hoc random signers.
- Update the docs to show deterministic test signers in signature tests.

## Rationale
Deterministic test identities make account-based tests easier to read and reproduce. GetNewSigner remains available for callers that need an ad hoc unknown account, while the built-in signers keep common test addresses stable between test runs. The accounts are not funded automatically, so the default chain state stays unchanged.

## Testing
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
- dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj
- dotnet test tests/Neo.SmartContract.Template.UnitTests/Neo.SmartContract.Template.UnitTests.csproj
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "UnitTest_NEP11|UnitTest_ContractCall"