### PR TITLE
Add notification watcher

### DIFF
--- a/src/Neo.SmartContract.Testing/NotificationWatcher.cs
+++ b/src/Neo.SmartContract.Testing/NotificationWatcher.cs
@@ -1,0 +1,64 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NotificationWatcher.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Neo.SmartContract.Testing
+{
+    [DebuggerDisplay("Count={Notifications.Count}")]
+    public sealed class NotificationWatcher : IDisposable
+    {
+        private readonly TestEngine _testEngine;
+        private readonly List<RuntimeNotification> _notifications = [];
+        private bool _disposed;
+
+        /// <summary>
+        /// Captured runtime notifications.
+        /// </summary>
+        public IReadOnlyList<RuntimeNotification> Notifications => _notifications;
+
+        /// <summary>
+        /// Clear captured runtime notifications.
+        /// </summary>
+        public void Reset()
+        {
+            _notifications.Clear();
+        }
+
+        /// <summary>
+        /// Constructor of NotificationWatcher.
+        /// </summary>
+        /// <param name="engine">Test engine.</param>
+        public NotificationWatcher(TestEngine engine)
+        {
+            _testEngine = engine;
+            _testEngine.OnRuntimeNotify += OnRuntimeNotify;
+        }
+
+        private void OnRuntimeNotify(UInt160 sender, string eventName, Neo.VM.Types.Array state)
+        {
+            _notifications.Add(new RuntimeNotification(sender, eventName, state));
+        }
+
+        /// <summary>
+        /// Stop capturing runtime notifications.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            _testEngine.OnRuntimeNotify -= OnRuntimeNotify;
+            _disposed = true;
+        }
+    }
+}

--- a/src/Neo.SmartContract.Testing/README.md
+++ b/src/Neo.SmartContract.Testing/README.md
@@ -26,6 +26,8 @@ The **Neo.SmartContract.Testing** project is designed to facilitate the developm
     - [Example of use](#example-of-use)
 - [Runtime log watcher](#runtime-log-watcher)
     - [Example of use](#example-of-use)
+- [Notification watcher](#notification-watcher)
+    - [Example of use](#example-of-use)
 - [Forging signatures](#forging-signatures)
     - [Example of use](#example-of-use)
 - [Event testing](#event-testing)
@@ -300,6 +302,24 @@ Assert.AreEqual("saved", logs.Logs[0].Message);
 
 logs.Reset();
 Assert.AreEqual(0, logs.Logs.Count);
+```
+
+### Notification watcher
+
+The `NotificationWatcher` class captures runtime notifications emitted during contract execution, so tests can assert event names, senders, and state without wiring custom event handlers.
+
+#### Example of use
+
+```csharp
+using var notifications = engine.CreateNotificationWatcher();
+
+contract.Transfer(from, to, 1, null);
+
+Assert.AreEqual(1, notifications.Notifications.Count);
+Assert.AreEqual("Transfer", notifications.Notifications[0].EventName);
+
+notifications.Reset();
+Assert.AreEqual(0, notifications.Notifications.Count);
 ```
 
 ### Forging signatures

--- a/src/Neo.SmartContract.Testing/RuntimeNotification.cs
+++ b/src/Neo.SmartContract.Testing/RuntimeNotification.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// RuntimeNotification.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.VM.Types;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Neo.SmartContract.Testing
+{
+    [DebuggerDisplay("{Sender}: {EventName}")]
+    public sealed class RuntimeNotification
+    {
+        /// <summary>
+        /// Contract that emitted the notification.
+        /// </summary>
+        public UInt160 Sender { get; }
+
+        /// <summary>
+        /// Notification event name.
+        /// </summary>
+        public string EventName { get; }
+
+        /// <summary>
+        /// Notification state.
+        /// </summary>
+        public IReadOnlyList<StackItem> State { get; }
+
+        /// <summary>
+        /// Constructor of RuntimeNotification.
+        /// </summary>
+        /// <param name="sender">Contract that emitted the notification.</param>
+        /// <param name="eventName">Notification event name.</param>
+        /// <param name="state">Notification state.</param>
+        public RuntimeNotification(UInt160 sender, string eventName, IEnumerable<StackItem> state)
+        {
+            Sender = sender;
+            EventName = eventName;
+            State = state.Select(item => item.DeepCopy(true)).ToArray();
+        }
+    }
+}

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -48,6 +48,9 @@ namespace Neo.SmartContract.Testing
         public delegate void OnRuntimeLogDelegate(UInt160 sender, string message);
         public event OnRuntimeLogDelegate? OnRuntimeLog;
 
+        public delegate void OnRuntimeNotifyDelegate(UInt160 sender, string eventName, Neo.VM.Types.Array state);
+        public event OnRuntimeNotifyDelegate? OnRuntimeNotify;
+
         /// <summary>
         /// Default Protocol Settings
         /// </summary>
@@ -318,6 +321,8 @@ namespace Neo.SmartContract.Testing
 
         internal void ApplicationEngineNotify(object? sender, NotifyEventArgs e)
         {
+            OnRuntimeNotify?.Invoke(e.ScriptHash, e.EventName, e.State);
+
             if (_contracts.TryGetValue(e.ScriptHash, out var contracts))
             {
                 foreach (var contract in contracts)
@@ -374,6 +379,15 @@ namespace Neo.SmartContract.Testing
         public RuntimeLogWatcher CreateRuntimeLogWatcher()
         {
             return new RuntimeLogWatcher(this);
+        }
+
+        /// <summary>
+        /// Create notification watcher
+        /// </summary>
+        /// <returns>Notification watcher</returns>
+        public NotificationWatcher CreateNotificationWatcher()
+        {
+            return new NotificationWatcher(this);
         }
 
         /// <summary>

--- a/tests/Neo.SmartContract.Testing.UnitTests/NotificationWatcherTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/NotificationWatcherTests.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// NotificationWatcherTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Network.P2P.Payloads;
+using System.Linq;
+using System.Numerics;
+
+namespace Neo.SmartContract.Testing.UnitTests
+{
+    [TestClass]
+    public class NotificationWatcherTests
+    {
+        [TestMethod]
+        public void CreateNotificationWatcherTracksNotifications()
+        {
+            TestEngine engine = new(true);
+            engine.SetTransactionSigners(WitnessScope.Global, engine.ValidatorsAddress);
+
+            var watcher = engine.CreateNotificationWatcher();
+            var addressTo = UInt160.Parse("0x1230000000000000000000000000000000000000");
+
+            Assert.IsTrue(engine.Native.NEO.Transfer(engine.Transaction.Sender, addressTo, 123, null));
+
+            var transfer = watcher.Notifications.First(notification =>
+                notification.Sender == engine.Native.NEO.Hash && notification.EventName == "Transfer");
+
+            Assert.AreEqual(3, transfer.State.Count);
+            Assert.AreEqual(new BigInteger(123), transfer.State[2].GetInteger());
+
+            watcher.Reset();
+
+            Assert.AreEqual(0, watcher.Notifications.Count);
+
+            watcher.Dispose();
+            Assert.IsTrue(engine.Native.NEO.Transfer(engine.Transaction.Sender, UInt160.Parse("0x4560000000000000000000000000000000000000"), 1, null));
+
+            Assert.AreEqual(0, watcher.Notifications.Count);
+        }
+
+        [TestMethod]
+        public void RuntimeNotificationDeepCopiesStateItems()
+        {
+            var nestedState = new Neo.VM.Types.Array([new Neo.VM.Types.Integer(1)]);
+            var sourceState = new Neo.VM.Types.Array([nestedState]);
+
+            var notification = new RuntimeNotification(UInt160.Zero, "Event", sourceState);
+
+            nestedState.Add(new Neo.VM.Types.Integer(2));
+            sourceState.Add(new Neo.VM.Types.Integer(3));
+
+            Assert.AreEqual(1, notification.State.Count);
+            var capturedNestedState = (Neo.VM.Types.Array)notification.State[0];
+            Assert.AreEqual(1, capturedNestedState.Count);
+            Assert.AreEqual(new BigInteger(1), capturedNestedState[0].GetInteger());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NotificationWatcher` and `RuntimeNotification` to capture runtime notifications during test execution.
- Expose `CreateNotificationWatcher()` on `TestEngine`.
- Document watcher usage and add coverage for capture, reset, and dispose behavior.

## Tests
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore --filter NotificationWatcherTests.CreateNotificationWatcherTracksNotifications`
- `dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore`