### PR TITLE
Improve standard test assertion diagnostics

### DIFF
--- a/src/Neo.SmartContract.Testing/TestingStandards/Nep17Tests.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/Nep17Tests.cs
@@ -93,11 +93,7 @@ public class Nep17Tests<T> : TestBase<T>
     /// <param name="amount">Amount</param>
     public void AssertTransferEvent(UInt160? from, UInt160? to, BigInteger? amount)
     {
-        Assert.AreEqual(1, raisedTransfer.Count);
-        Assert.AreEqual(raisedTransfer[0].from, from);
-        Assert.AreEqual(raisedTransfer[0].to, to);
-        Assert.AreEqual(raisedTransfer[0].amount, amount);
-        raisedTransfer.Clear();
+        AssertTransferEvent((from, to, amount));
     }
 
     /// <summary>
@@ -108,10 +104,10 @@ public class Nep17Tests<T> : TestBase<T>
     /// <param name="amount">Amount</param>
     public void AssertTransferEvent(params (UInt160? from, UInt160? to, BigInteger? amount)[] events)
     {
-        Assert.AreEqual(events.Length, raisedTransfer.Count);
-        CollectionAssert.AreEqual(raisedTransfer.Select(u => u.from).ToArray(), events.Select(u => u.from).ToArray());
-        CollectionAssert.AreEqual(raisedTransfer.Select(u => u.to).ToArray(), events.Select(u => u.to).ToArray());
-        CollectionAssert.AreEqual(raisedTransfer.Select(u => u.amount).ToArray(), events.Select(u => u.amount).ToArray());
+        var message = $"Expected transfer events: {FormatDiagnosticSequence(events, FormatTransferEvent)}; actual: {FormatDiagnosticSequence(raisedTransfer, FormatTransferEvent)}.";
+
+        Assert.AreEqual(events.Length, raisedTransfer.Count, message);
+        CollectionAssert.AreEqual(events, raisedTransfer.ToArray(), message);
         raisedTransfer.Clear();
     }
 
@@ -120,7 +116,12 @@ public class Nep17Tests<T> : TestBase<T>
     /// </summary>
     public void AssertNoTransferEvent()
     {
-        Assert.AreEqual(0, raisedTransfer.Count);
+        Assert.AreEqual(0, raisedTransfer.Count, $"Expected no transfer events, but captured: {FormatDiagnosticSequence(raisedTransfer, FormatTransferEvent)}.");
+    }
+
+    private static string FormatTransferEvent((UInt160? from, UInt160? to, BigInteger? amount) transfer)
+    {
+        return $"(from: {FormatDiagnosticValue(transfer.from)}, to: {FormatDiagnosticValue(transfer.to)}, amount: {FormatDiagnosticValue(transfer.amount)})";
     }
 
     #endregion

--- a/src/Neo.SmartContract.Testing/TestingStandards/OwnableTests.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/OwnableTests.cs
@@ -70,9 +70,11 @@ public class OwnableTests<T> : TestBase<T>
     /// <param name="to">To</param>
     public void AssertOnChangeOwnerEvent(UInt160? from, UInt160? to)
     {
-        Assert.AreEqual(1, raisedOnChangeOwner.Count);
-        Assert.AreEqual(raisedOnChangeOwner[0].from, from);
-        Assert.AreEqual(raisedOnChangeOwner[0].to, to);
+        var expected = new[] { (from, to) };
+        var message = $"Expected owner change events: {FormatDiagnosticSequence(expected, FormatOwnerChangeEvent)}; actual: {FormatDiagnosticSequence(raisedOnChangeOwner, FormatOwnerChangeEvent)}.";
+
+        Assert.AreEqual(expected.Length, raisedOnChangeOwner.Count, message);
+        CollectionAssert.AreEqual(expected, raisedOnChangeOwner.ToArray(), message);
         raisedOnChangeOwner.Clear();
     }
 
@@ -81,7 +83,12 @@ public class OwnableTests<T> : TestBase<T>
     /// </summary>
     public void AssertNoOnChangeOwnerEvent()
     {
-        Assert.AreEqual(0, raisedOnChangeOwner.Count);
+        Assert.AreEqual(0, raisedOnChangeOwner.Count, $"Expected no owner change events, but captured: {FormatDiagnosticSequence(raisedOnChangeOwner, FormatOwnerChangeEvent)}.");
+    }
+
+    private static string FormatOwnerChangeEvent((UInt160? from, UInt160? to) ownerChange)
+    {
+        return $"(from: {FormatDiagnosticValue(ownerChange.from)}, to: {FormatDiagnosticValue(ownerChange.to)})";
     }
 
     #endregion

--- a/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
+++ b/src/Neo.SmartContract.Testing/TestingStandards/TestBase.cs
@@ -14,8 +14,10 @@ using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Testing.Coverage;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Neo.SmartContract.Testing.TestingStandards;
 
@@ -110,17 +112,19 @@ public class TestBase<T> where T : SmartContract, IContractInfo
     /// <param name="logs">Logs</param>
     public void AssertLogs(params string[] logs)
     {
-        Assert.AreEqual(logs.Length, _contractLogs.Count);
-        CollectionAssert.AreEqual(_contractLogs, logs);
+        var message = $"Expected runtime logs: {FormatDiagnosticSequence(logs)}; actual: {FormatDiagnosticSequence(_contractLogs)}.";
+
+        Assert.AreEqual(logs.Length, _contractLogs.Count, message);
+        CollectionAssert.AreEqual(logs, _contractLogs, message);
         _contractLogs.Clear();
     }
 
     /// <summary>
-    /// Assert that Transfer event was NOT raised
+    /// Assert that Log event was NOT raised
     /// </summary>
     public void AssertNoLogs()
     {
-        Assert.AreEqual(0, _contractLogs.Count);
+        Assert.AreEqual(0, _contractLogs.Count, $"Expected no runtime logs, but captured: {FormatDiagnosticSequence(_contractLogs)}.");
     }
 
     protected void AssertGasConsumedInRangeCore(long minimumGasConsumed, long maximumGasConsumed)
@@ -148,6 +152,21 @@ public class TestBase<T> where T : SmartContract, IContractInfo
         {
             AssertGasConsumedInRangeCore(expectedGasConsumed - tolerance, expectedGasConsumed + tolerance);
         }
+    }
+
+    protected static string FormatDiagnosticValue(object? value)
+    {
+        return value switch
+        {
+            null => "null",
+            string text => $"\"{text}\"",
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+
+    protected static string FormatDiagnosticSequence<TItem>(IEnumerable<TItem> values, Func<TItem, string>? formatter = null)
+    {
+        return $"[{string.Join(", ", values.Select(value => formatter?.Invoke(value) ?? FormatDiagnosticValue(value)))}]";
     }
 
     #endregion

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestingStandards/StandardAssertionDiagnosticsTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestingStandards/StandardAssertionDiagnosticsTests.cs
@@ -1,0 +1,156 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// StandardAssertionDiagnosticsTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing.TestingStandards;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Neo.SmartContract.Testing.UnitTests.TestingStandards;
+
+[TestClass]
+public class StandardAssertionDiagnosticsTests
+{
+    [TestMethod]
+    public void AssertLogsReportsExpectedAndActualLogs()
+    {
+        var test = CreateUninitialized<TestBase<DiagnosticContract>>();
+        SetPrivateField(typeof(TestBase<DiagnosticContract>), test, "_contractLogs", new List<string> { "actual" });
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => test.AssertLogs("expected"));
+
+        StringAssert.Contains(exception.Message, "Expected runtime logs: [\"expected\"]");
+        StringAssert.Contains(exception.Message, "actual: [\"actual\"]");
+    }
+
+    [TestMethod]
+    public void AssertNoLogsReportsCapturedLogs()
+    {
+        var test = CreateUninitialized<TestBase<DiagnosticContract>>();
+        SetPrivateField(typeof(TestBase<DiagnosticContract>), test, "_contractLogs", new List<string> { "unexpected" });
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(test.AssertNoLogs);
+
+        StringAssert.Contains(exception.Message, "Expected no runtime logs");
+        StringAssert.Contains(exception.Message, "\"unexpected\"");
+    }
+
+    [TestMethod]
+    public void AssertTransferEventReportsExpectedAndActualEvents()
+    {
+        var test = CreateUninitialized<Nep17Tests<DiagnosticNep17Contract>>();
+        var actual = UInt160.Parse("0x0102030405060708090a0102030405060708090a");
+        var expected = UInt160.Parse("0x0a0908070605040302010a090807060504030201");
+        SetPrivateField(typeof(Nep17Tests<DiagnosticNep17Contract>), test, "raisedTransfer",
+            new List<(UInt160? from, UInt160? to, BigInteger? amount)> { (actual, null, 1) });
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => test.AssertTransferEvent(expected, null, 2));
+
+        StringAssert.Contains(exception.Message, "Expected transfer events");
+        StringAssert.Contains(exception.Message, expected.ToString());
+        StringAssert.Contains(exception.Message, actual.ToString());
+    }
+
+    [TestMethod]
+    public void AssertNoTransferEventReportsCapturedEvents()
+    {
+        var test = CreateUninitialized<Nep17Tests<DiagnosticNep17Contract>>();
+        var account = UInt160.Parse("0x0102030405060708090a0102030405060708090a");
+        SetPrivateField(typeof(Nep17Tests<DiagnosticNep17Contract>), test, "raisedTransfer",
+            new List<(UInt160? from, UInt160? to, BigInteger? amount)> { (account, null, 1) });
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(test.AssertNoTransferEvent);
+
+        StringAssert.Contains(exception.Message, "Expected no transfer events");
+        StringAssert.Contains(exception.Message, account.ToString());
+    }
+
+    [TestMethod]
+    public void AssertOnChangeOwnerEventReportsExpectedAndActualEvents()
+    {
+        var test = CreateUninitialized<OwnableTests<DiagnosticOwnableContract>>();
+        var actual = UInt160.Parse("0x0102030405060708090a0102030405060708090a");
+        var expected = UInt160.Parse("0x0a0908070605040302010a090807060504030201");
+        SetPrivateField(typeof(OwnableTests<DiagnosticOwnableContract>), test, "raisedOnChangeOwner",
+            new List<(UInt160? from, UInt160? to)> { (actual, null) });
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(() => test.AssertOnChangeOwnerEvent(expected, null));
+
+        StringAssert.Contains(exception.Message, "Expected owner change events");
+        StringAssert.Contains(exception.Message, expected.ToString());
+        StringAssert.Contains(exception.Message, actual.ToString());
+    }
+
+    [TestMethod]
+    public void AssertNoOnChangeOwnerEventReportsCapturedEvents()
+    {
+        var test = CreateUninitialized<OwnableTests<DiagnosticOwnableContract>>();
+        var account = UInt160.Parse("0x0102030405060708090a0102030405060708090a");
+        SetPrivateField(typeof(OwnableTests<DiagnosticOwnableContract>), test, "raisedOnChangeOwner",
+            new List<(UInt160? from, UInt160? to)> { (account, null) });
+
+        var exception = Assert.ThrowsExactly<AssertFailedException>(test.AssertNoOnChangeOwnerEvent);
+
+        StringAssert.Contains(exception.Message, "Expected no owner change events");
+        StringAssert.Contains(exception.Message, account.ToString());
+    }
+
+    private static T CreateUninitialized<T>() where T : class
+    {
+        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+    }
+
+    private static void SetPrivateField<T>(Type declaringType, T instance, string fieldName, object value)
+    {
+        var field = declaringType.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Field {fieldName} was not found.");
+
+        field.SetValue(instance, value);
+    }
+
+    private abstract class DiagnosticContract(SmartContractInitialize initialize) : SmartContract(initialize), IContractInfo
+    {
+        public static NefFile Nef => throw new NotSupportedException();
+        public static ContractManifest Manifest => throw new NotSupportedException();
+    }
+
+    private abstract class DiagnosticNep17Contract(SmartContractInitialize initialize) : SmartContract(initialize), INep17Standard, IContractInfo
+    {
+        public static NefFile Nef => throw new NotSupportedException();
+        public static ContractManifest Manifest => throw new NotSupportedException();
+
+#pragma warning disable CS0067
+        public event INep17Standard.delTransfer? OnTransfer;
+#pragma warning restore CS0067
+
+        public abstract string? Symbol { get; }
+        public abstract BigInteger? Decimals { get; }
+        public abstract BigInteger? TotalSupply { get; }
+        public abstract BigInteger? BalanceOf(UInt160? owner);
+        public abstract bool? Transfer(UInt160? from, UInt160? to, BigInteger? amount, object? data = null);
+    }
+
+    private abstract class DiagnosticOwnableContract(SmartContractInitialize initialize) : SmartContract(initialize), IOwnable, IContractInfo
+    {
+        public static NefFile Nef => throw new NotSupportedException();
+        public static ContractManifest Manifest => throw new NotSupportedException();
+
+#pragma warning disable CS0067
+        public event IOwnable.delSetOwner? OnSetOwner;
+#pragma warning restore CS0067
+
+        public abstract UInt160? Owner { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add detailed expected/actual messages to runtime log, transfer, and owner change assertion helpers
- keep assertion comparisons ordered as expected vs actual
- cover the diagnostics with focused standard assertion tests

## Tests
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter StandardAssertionDiagnosticsTests
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
- dotnet test tests/Neo.SmartContract.Template.UnitTests/Neo.SmartContract.Template.UnitTests.csproj
- dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj
- dotnet format --no-restore --verify-no-changes --verbosity diagnostic