### PR TITLE
Add typed storage read helpers

### DIFF
--- a/src/Neo.SmartContract.Testing/Storage/SmartContractStorage.cs
+++ b/src/Neo.SmartContract.Testing/Storage/SmartContractStorage.cs
@@ -139,38 +139,114 @@ namespace Neo.SmartContract.Testing.Storage
         /// <summary>
         /// Read an integer entry from the smart contract storage
         /// </summary>
+        /// <remarks>Returns zero when the key is not found. Use TryGetInteger to distinguish missing entries.</remarks>
         /// <param name="key">Key</param>
         public BigInteger GetInteger(byte key) => GetInteger(new byte[] { key });
 
         /// <summary>
         /// Read an integer entry from the smart contract storage
         /// </summary>
+        /// <remarks>Returns zero when the key is not found. Use TryGetInteger to distinguish missing entries.</remarks>
         /// <param name="key">Key</param>
         public BigInteger GetInteger(string key) => GetInteger(Utility.StrictUTF8.GetBytes(key));
 
         /// <summary>
         /// Read an integer entry from the smart contract storage
         /// </summary>
+        /// <remarks>Returns zero when the key is not found. Use TryGetInteger to distinguish missing entries.</remarks>
         /// <param name="key">Key</param>
-        public BigInteger GetInteger(ReadOnlyMemory<byte> key) => new(Get(key).Span);
+        public BigInteger GetInteger(ReadOnlyMemory<byte> key)
+        {
+            TryGetInteger(key, out var value);
+            return value;
+        }
+
+        /// <summary>
+        /// Try to read an integer entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGetInteger(byte key, out BigInteger value) => TryGetInteger(new byte[] { key }, out value);
+
+        /// <summary>
+        /// Try to read an integer entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGetInteger(string key, out BigInteger value) => TryGetInteger(Utility.StrictUTF8.GetBytes(key), out value);
+
+        /// <summary>
+        /// Try to read an integer entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGetInteger(ReadOnlyMemory<byte> key, out BigInteger value)
+        {
+            if (!TryGet(key, out var bytes))
+            {
+                value = BigInteger.Zero;
+                return false;
+            }
+
+            value = new BigInteger(bytes.Span);
+            return true;
+        }
 
         /// <summary>
         /// Read a UTF-8 string entry from the smart contract storage
         /// </summary>
+        /// <remarks>Returns an empty string when the key is not found. Use TryGetString to distinguish missing entries.</remarks>
         /// <param name="key">Key</param>
         public string GetString(byte key) => GetString(new byte[] { key });
 
         /// <summary>
         /// Read a UTF-8 string entry from the smart contract storage
         /// </summary>
+        /// <remarks>Returns an empty string when the key is not found. Use TryGetString to distinguish missing entries.</remarks>
         /// <param name="key">Key</param>
         public string GetString(string key) => GetString(Utility.StrictUTF8.GetBytes(key));
 
         /// <summary>
         /// Read a UTF-8 string entry from the smart contract storage
         /// </summary>
+        /// <remarks>Returns an empty string when the key is not found. Use TryGetString to distinguish missing entries.</remarks>
         /// <param name="key">Key</param>
-        public string GetString(ReadOnlyMemory<byte> key) => Utility.StrictUTF8.GetString(Get(key).Span);
+        public string GetString(ReadOnlyMemory<byte> key)
+        {
+            TryGetString(key, out var value);
+            return value;
+        }
+
+        /// <summary>
+        /// Try to read a UTF-8 string entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGetString(byte key, out string value) => TryGetString(new byte[] { key }, out value);
+
+        /// <summary>
+        /// Try to read a UTF-8 string entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGetString(string key, out string value) => TryGetString(Utility.StrictUTF8.GetBytes(key), out value);
+
+        /// <summary>
+        /// Try to read a UTF-8 string entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGetString(ReadOnlyMemory<byte> key, out string value)
+        {
+            if (!TryGet(key, out var bytes))
+            {
+                value = string.Empty;
+                return false;
+            }
+
+            value = Utility.StrictUTF8.GetString(bytes.Span);
+            return true;
+        }
 
         /// <summary>
         /// Put an entry in the smart contract storage

--- a/src/Neo.SmartContract.Testing/Storage/SmartContractStorage.cs
+++ b/src/Neo.SmartContract.Testing/Storage/SmartContractStorage.cs
@@ -103,6 +103,76 @@ namespace Neo.SmartContract.Testing.Storage
         }
 
         /// <summary>
+        /// Try to read an entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGet(byte key, out ReadOnlyMemory<byte> value) => TryGet(new byte[] { key }, out value);
+
+        /// <summary>
+        /// Try to read an entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGet(string key, out ReadOnlyMemory<byte> value) => TryGet(Utility.StrictUTF8.GetBytes(key), out value);
+
+        /// <summary>
+        /// Try to read an entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        public bool TryGet(ReadOnlyMemory<byte> key, out ReadOnlyMemory<byte> value)
+        {
+            var skey = new StorageKey() { Id = GetContractId(), Key = key };
+            var entry = _smartContract.Engine.Storage.Snapshot.TryGet(skey);
+
+            if (entry is null)
+            {
+                value = ReadOnlyMemory<byte>.Empty;
+                return false;
+            }
+
+            value = entry.Value;
+            return true;
+        }
+
+        /// <summary>
+        /// Read an integer entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        public BigInteger GetInteger(byte key) => GetInteger(new byte[] { key });
+
+        /// <summary>
+        /// Read an integer entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        public BigInteger GetInteger(string key) => GetInteger(Utility.StrictUTF8.GetBytes(key));
+
+        /// <summary>
+        /// Read an integer entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        public BigInteger GetInteger(ReadOnlyMemory<byte> key) => new(Get(key).Span);
+
+        /// <summary>
+        /// Read a UTF-8 string entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        public string GetString(byte key) => GetString(new byte[] { key });
+
+        /// <summary>
+        /// Read a UTF-8 string entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        public string GetString(string key) => GetString(Utility.StrictUTF8.GetBytes(key));
+
+        /// <summary>
+        /// Read a UTF-8 string entry from the smart contract storage
+        /// </summary>
+        /// <param name="key">Key</param>
+        public string GetString(ReadOnlyMemory<byte> key) => Utility.StrictUTF8.GetString(Get(key).Span);
+
+        /// <summary>
         /// Put an entry in the smart contract storage
         /// </summary>
         /// <param name="key">Key</param>

--- a/tests/Neo.SmartContract.Testing.UnitTests/SmartContractStorageTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/SmartContractStorageTests.cs
@@ -92,7 +92,9 @@ namespace Neo.SmartContract.Testing.UnitTests
             TestEngine engine = new(true);
 
             engine.Native.NEO.Storage.Put("integer-key", BigInteger.MinusOne);
+            engine.Native.NEO.Storage.Put("zero-key", BigInteger.Zero);
             engine.Native.NEO.Storage.Put("string-key", Encoding.UTF8.GetBytes("hello"));
+            engine.Native.NEO.Storage.Put("empty-string-key", ReadOnlyMemory<byte>.Empty);
             engine.Native.NEO.Storage.Put((byte)0x42, BigInteger.One);
             engine.Native.NEO.Storage.Put(new byte[] { 0x43 }, Encoding.UTF8.GetBytes("raw"));
 
@@ -107,6 +109,20 @@ namespace Neo.SmartContract.Testing.UnitTests
             Assert.AreEqual("raw", engine.Native.NEO.Storage.GetString(new byte[] { 0x43 }));
             Assert.AreEqual(BigInteger.Zero, engine.Native.NEO.Storage.GetInteger("missing-key"));
             Assert.AreEqual(string.Empty, engine.Native.NEO.Storage.GetString("missing-key"));
+
+            Assert.IsTrue(engine.Native.NEO.Storage.TryGetInteger("zero-key", out var zeroValue));
+            Assert.AreEqual(BigInteger.Zero, zeroValue);
+            Assert.IsTrue(engine.Native.NEO.Storage.TryGetInteger((byte)0x42, out var byteKeyValue));
+            Assert.AreEqual(BigInteger.One, byteKeyValue);
+            Assert.IsFalse(engine.Native.NEO.Storage.TryGetInteger("missing-key", out var missingInteger));
+            Assert.AreEqual(BigInteger.Zero, missingInteger);
+
+            Assert.IsTrue(engine.Native.NEO.Storage.TryGetString("empty-string-key", out var emptyStringValue));
+            Assert.AreEqual(string.Empty, emptyStringValue);
+            Assert.IsTrue(engine.Native.NEO.Storage.TryGetString(new byte[] { 0x43 }, out var rawKeyValue));
+            Assert.AreEqual("raw", rawKeyValue);
+            Assert.IsFalse(engine.Native.NEO.Storage.TryGetString("missing-key", out var missingString));
+            Assert.AreEqual(string.Empty, missingString);
         }
     }
 }

--- a/tests/Neo.SmartContract.Testing.UnitTests/SmartContractStorageTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/SmartContractStorageTests.cs
@@ -85,5 +85,28 @@ namespace Neo.SmartContract.Testing.UnitTests
             Assert.IsTrue(prefix.ContainsProperty(Convert.ToBase64String(Encoding.UTF8.GetBytes(neoKey))));
             Assert.IsFalse(prefix.ContainsProperty(Convert.ToBase64String(Encoding.UTF8.GetBytes(gasKey))));
         }
+
+        [TestMethod]
+        public void TestTypedReadHelpers()
+        {
+            TestEngine engine = new(true);
+
+            engine.Native.NEO.Storage.Put("integer-key", BigInteger.MinusOne);
+            engine.Native.NEO.Storage.Put("string-key", Encoding.UTF8.GetBytes("hello"));
+            engine.Native.NEO.Storage.Put((byte)0x42, BigInteger.One);
+            engine.Native.NEO.Storage.Put(new byte[] { 0x43 }, Encoding.UTF8.GetBytes("raw"));
+
+            Assert.IsTrue(engine.Native.NEO.Storage.TryGet("integer-key", out var integerValue));
+            CollectionAssert.AreEqual(BigInteger.MinusOne.ToByteArray(), integerValue.ToArray());
+            Assert.IsFalse(engine.Native.NEO.Storage.TryGet("missing-key", out var missingValue));
+            Assert.AreEqual(0, missingValue.Length);
+
+            Assert.AreEqual(BigInteger.MinusOne, engine.Native.NEO.Storage.GetInteger("integer-key"));
+            Assert.AreEqual("hello", engine.Native.NEO.Storage.GetString("string-key"));
+            Assert.AreEqual(BigInteger.One, engine.Native.NEO.Storage.GetInteger((byte)0x42));
+            Assert.AreEqual("raw", engine.Native.NEO.Storage.GetString(new byte[] { 0x43 }));
+            Assert.AreEqual(BigInteger.Zero, engine.Native.NEO.Storage.GetInteger("missing-key"));
+            Assert.AreEqual(string.Empty, engine.Native.NEO.Storage.GetString("missing-key"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add TryGet overloads for smart contract storage entries
- add integer and UTF-8 string read helpers for seeded storage assertions
- cover the helpers with storage unit tests

## Tests
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter TestTypedReadHelpers
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
- dotnet format --no-restore --verify-no-changes --verbosity diagnostic