### PR TITLE
Add runtime log watcher convenience accessors

### DIFF
--- a/src/Neo.SmartContract.Testing/RuntimeLogWatcher.cs
+++ b/src/Neo.SmartContract.Testing/RuntimeLogWatcher.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Neo.SmartContract.Testing
 {
@@ -26,6 +27,16 @@ namespace Neo.SmartContract.Testing
         /// Captured runtime logs.
         /// </summary>
         public IReadOnlyList<RuntimeLog> Logs => _logs;
+
+        /// <summary>
+        /// Number of captured runtime logs.
+        /// </summary>
+        public int Count => _logs.Count;
+
+        /// <summary>
+        /// Captured runtime log messages.
+        /// </summary>
+        public IReadOnlyList<string> Messages => _logs.Select(log => log.Message).ToArray();
 
         /// <summary>
         /// Clear captured runtime logs.

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using System.Numerics;
 
 namespace Neo.SmartContract.Testing.UnitTests
@@ -108,7 +109,9 @@ namespace Neo.SmartContract.Testing.UnitTests
             var firstSender = ExecuteRuntimeLog(engine, "first");
             var secondSender = ExecuteRuntimeLog(engine, "second");
 
+            Assert.AreEqual(2, watcher.Count);
             Assert.AreEqual(2, watcher.Logs.Count);
+            CollectionAssert.AreEqual(new[] { "first", "second" }, watcher.Messages.ToArray());
             Assert.AreEqual(firstSender, watcher.Logs[0].Sender);
             Assert.AreEqual("first", watcher.Logs[0].Message);
             Assert.AreEqual(secondSender, watcher.Logs[1].Sender);
@@ -116,11 +119,14 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             watcher.Reset();
 
+            Assert.AreEqual(0, watcher.Count);
             Assert.AreEqual(0, watcher.Logs.Count);
+            Assert.AreEqual(0, watcher.Messages.Count);
 
             watcher.Dispose();
             ExecuteRuntimeLog(engine, "ignored");
 
+            Assert.AreEqual(0, watcher.Count);
             Assert.AreEqual(0, watcher.Logs.Count);
         }
 


### PR DESCRIPTION
## Summary
- add Count and Messages accessors to RuntimeLogWatcher
- keep existing Logs behavior unchanged
- cover the convenience accessors in the runtime log watcher test

## Tests
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter CreateRuntimeLogWatcherTracksLogs
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj
- dotnet format --no-restore --verify-no-changes --verbosity diagnostic