### PR TITLE
Revert "Make testing syscall registration idempotent"

### DIFF
--- a/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
@@ -37,11 +37,6 @@ namespace Neo.SmartContract.Testing
         /// </summary>
         static TestingApplicationEngine()
         {
-            RegisterTestingSyscall();
-        }
-
-        private static void RegisterTestingSyscall()
-        {
             var items = typeof(ApplicationEngine)
                 .GetField("services", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
                 .GetValue(null) as Dictionary<uint, InteropDescriptor>;
@@ -55,7 +50,7 @@ namespace Neo.SmartContract.Testing
                 RequiredCallFlags = CallFlags.None,
             };
 
-            items?.TryAdd(descriptor.Hash, descriptor);
+            items?.Add(descriptor.Hash, descriptor);
         }
 
         /// <summary>

--- a/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/TestEngineTests.cs
@@ -25,7 +25,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Reflection;
 
 namespace Neo.SmartContract.Testing.UnitTests
 {
@@ -108,17 +107,6 @@ namespace Neo.SmartContract.Testing.UnitTests
 
             engine.OnGetCallingScriptHash = (current, expected) => UInt160.Parse("0x0000000000000000000000000000000000000001");
             Assert.AreEqual("0x0000000000000000000000000000000000000001", engine.Execute(script).ConvertTo(typeof(UInt160))!.ToString());
-        }
-
-        [TestMethod]
-        public void TestingSyscallRegistrationIsIdempotent()
-        {
-            var engineType = typeof(TestEngine).Assembly.GetType("Neo.SmartContract.Testing.TestingApplicationEngine")!;
-            var registerMethod = engineType.GetMethod("RegisterTestingSyscall", BindingFlags.Static | BindingFlags.NonPublic);
-
-            Assert.IsNotNull(registerMethod);
-            registerMethod.Invoke(null, null);
-            registerMethod.Invoke(null, null);
         }
 
         [TestMethod]


### PR DESCRIPTION
Reverts neo-project/neo-devpack-dotnet#1663