### PR TITLE
Clarify C# 8 index range syntax support

### DIFF
--- a/docs/csharp-syntax/UnsupportedFeatures.md
+++ b/docs/csharp-syntax/UnsupportedFeatures.md
@@ -35,7 +35,7 @@ The versioned syntax checklists flag every feature the Neo compiler currently re
   - `ref` argument targeting span element (`ref_argument_span_element`)
 
 - **C# 8 Syntax Checklist**  
-  - Index and range operators (`index_and_range`)
+  - Range operators on general arrays (`range_on_general_arrays`)
   - Async streams (`async_streams`)
 
 - **C# 9 Syntax Checklist**  

--- a/docs/csharp-syntax/csharp-8.md
+++ b/docs/csharp-syntax/csharp-8.md
@@ -18,14 +18,28 @@ int squared = value switch
 };
 ```
 
-### index_and_range - Index and range operators
+### index_and_range_byte_string - Index and range operators for byte arrays and strings
+
+Status: supported
+Scope: method
+Notes: From-end index access and ranges are supported for `byte[]` and `string` values. Neo lowers ranges to VM substring operations, so this support is intentionally limited to byte strings and strings.
+```csharp
+byte[] values = { 1, 2, 3, 4 };
+byte last = values[^1];
+byte[] slice = values[1..3];
+
+string text = "neo";
+char first = text[0];
+string tail = text[1..];
+```
+
+### range_on_general_arrays - Range operators on general arrays
 
 Status: unsupported
 Scope: method
-Notes: The ^ and .. operators are not recognized by the Neo compiler. Roslyn would translate the `^` and `..` operators into range helper calls, but Neo lacks support for the generated IL.
+Notes: From-end indexing works for arrays, but slicing arrays other than `byte[]` is rejected because Neo range lowering only supports byte strings and strings.
 ```csharp
 int[] values = { 1, 2, 3, 4 };
-int last = values[^1];
 int[] slice = values[1..3];
 ```
 


### PR DESCRIPTION
## Summary
- Clarify that C# 8 index and range support is available for byte arrays and strings.
- Keep general array slicing documented as unsupported.
- Update the unsupported feature summary to match the versioned syntax probes.

## Validation
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~SyntaxTests --no-restore`
