### PR TITLE
Detect task-like member and local types

### DIFF
--- a/src/Neo.SmartContract.Analyzer/TaskLikeTypeUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/TaskLikeTypeUsageAnalyzer.cs
@@ -39,6 +39,8 @@ public sealed class TaskLikeTypeUsageAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
         context.RegisterSyntaxNodeAction(AnalyzeParameter, SyntaxKind.Parameter);
+        context.RegisterSyntaxNodeAction(AnalyzePropertyDeclaration, SyntaxKind.PropertyDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeVariableDeclaration, SyntaxKind.VariableDeclaration);
     }
 
     private static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
@@ -62,6 +64,28 @@ public sealed class TaskLikeTypeUsageAnalyzer : DiagnosticAnalyzer
 
         var type = context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken)?.Type;
         ReportIfTaskLike(context, parameter.Type.GetLocation(), type);
+    }
+
+    private static void AnalyzePropertyDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not PropertyDeclarationSyntax propertyDeclaration)
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type, context.CancellationToken).Type;
+        ReportIfTaskLike(context, propertyDeclaration.Type.GetLocation(), type);
+    }
+
+    private static void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not VariableDeclarationSyntax variableDeclaration)
+        {
+            return;
+        }
+
+        var type = context.SemanticModel.GetTypeInfo(variableDeclaration.Type, context.CancellationToken).Type;
+        ReportIfTaskLike(context, variableDeclaration.Type.GetLocation(), type);
     }
 
     private static void ReportIfTaskLike(SyntaxNodeAnalysisContext context, Location location, ITypeSymbol? type)

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/TaskLikeTypeUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/TaskLikeTypeUsageAnalyzerUnitTests.cs
@@ -42,4 +42,34 @@ public class TaskLikeTypeUsageAnalyzerUnitTests
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
+
+    [TestMethod]
+    public async Task TaskLikeFieldPropertyAndLocal_ShouldReportDiagnostic()
+    {
+        var test = """
+                   using System.Threading.Tasks;
+
+                   class Test
+                   {
+                       private {|#0:Task<int>|} field = Task.FromResult(1);
+                       public {|#1:ValueTask<int>|} Property { get; set; }
+
+                       public void Run()
+                       {
+                           {|#2:Task|} local = Task.CompletedTask;
+                           {|#3:ValueTask<int>|} value = default;
+                       }
+                   }
+                   """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(0).WithArguments("System.Threading.Tasks.Task<int>"),
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(1).WithArguments("System.Threading.Tasks.ValueTask<int>"),
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(2).WithArguments("System.Threading.Tasks.Task"),
+            VerifyCS.Diagnostic(TaskLikeTypeUsageAnalyzer.DiagnosticId).WithLocation(3).WithArguments("System.Threading.Tasks.ValueTask<int>"),
+        };
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 }


### PR DESCRIPTION
## Summary
- Report task-like type diagnostics for fields, properties, and local variables.
- Keep existing method return and parameter diagnostics unchanged.

## Validation
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter TaskLikeTypeUsageAnalyzerUnitTests --no-restore`
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --no-restore`
- `git diff --check`
