### PR TITLE
Reject using statements in contract syntax

### DIFF
--- a/docs/csharp-syntax/UnsupportedFeatures.md
+++ b/docs/csharp-syntax/UnsupportedFeatures.md
@@ -36,6 +36,7 @@ The versioned syntax checklists flag every feature the Neo compiler currently re
 
 - **C# 8 Syntax Checklist**  
   - Range operators on general arrays (`range_on_general_arrays`)
+  - Using declarations (`using_declaration`)
   - Async streams (`async_streams`)
 
 - **C# 9 Syntax Checklist**  

--- a/docs/csharp-syntax/csharp-8.md
+++ b/docs/csharp-syntax/csharp-8.md
@@ -55,11 +55,11 @@ text ??= "neo";
 
 ### using_declaration - Using declarations
 
-Status: supported
+Status: unsupported
 Scope: method
-Notes: Using declarations for contract-compatible IDisposable instances compile and scope the resource to the current block. Roslyn converts using declarations into try/finally disposal code before Neo runs it. This only describes the using-declaration syntax; System.IO stream APIs are not supported in Neo smart contracts.
+Notes: Using declarations and using statements are rejected because Neo compiles C# syntax directly and does not emit deterministic `Dispose` calls for contract execution.
 ```csharp
-using System.IDisposable? scope = null;
+using System.IDisposable scope = null!;
 ```
 
 ### nullable_reference_types - Nullable reference types

--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -2,3 +2,4 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|------------------------------------------------
+NC4059  | Syntax   | Error    | UnsupportedSyntaxAnalyzer (using statements and declarations)

--- a/src/Neo.SmartContract.Analyzer/UnsupportedSyntaxAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/UnsupportedSyntaxAnalyzer.cs
@@ -42,6 +42,7 @@ public sealed class UnsupportedSyntaxAnalyzer : DiagnosticAnalyzer
     public const string Utf8LiteralRuleId = "NC4051";
     public const string FileLocalTypeRuleId = "NC4053";
     public const string RefReadonlyParameterRuleId = "NC4054";
+    public const string UsingStatementRuleId = "NC4059";
 
     private static readonly DiagnosticDescriptor UnsafeCodeRule = CreateDescriptor(
         UnsafeCodeRuleId,
@@ -133,6 +134,11 @@ public sealed class UnsupportedSyntaxAnalyzer : DiagnosticAnalyzer
         "'ref readonly' or 'in' parameters are not supported",
         "'ref readonly' or 'in' parameters are not supported by the Neo compiler.");
 
+    private static readonly DiagnosticDescriptor UsingStatementRule = CreateDescriptor(
+        UsingStatementRuleId,
+        "Using statements are not supported",
+        "Using statements and using declarations are not supported because the Neo compiler does not emit deterministic Dispose calls.");
+
     private static DiagnosticDescriptor CreateDescriptor(string id, string title, string message) =>
         new(id, title, message, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: message);
 
@@ -154,7 +160,8 @@ public sealed class UnsupportedSyntaxAnalyzer : DiagnosticAnalyzer
         ListPatternRule,
         Utf8LiteralRule,
         FileLocalTypeRule,
-        RefReadonlyParameterRule);
+        RefReadonlyParameterRule,
+        UsingStatementRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -250,7 +257,14 @@ public sealed class UnsupportedSyntaxAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeUsingStatement(SyntaxNodeAnalysisContext context)
     {
-        if (context.Node is UsingStatementSyntax usingStatement && !usingStatement.AwaitKeyword.IsKind(SyntaxKind.None))
+        if (context.Node is not UsingStatementSyntax usingStatement)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(UsingStatementRule, usingStatement.UsingKeyword.GetLocation()));
+
+        if (!usingStatement.AwaitKeyword.IsKind(SyntaxKind.None))
         {
             context.ReportDiagnostic(Diagnostic.Create(AwaitExpressionRule, usingStatement.AwaitKeyword.GetLocation()));
         }
@@ -267,6 +281,8 @@ public sealed class UnsupportedSyntaxAnalyzer : DiagnosticAnalyzer
         {
             return;
         }
+
+        context.ReportDiagnostic(Diagnostic.Create(UsingStatementRule, localDeclaration.UsingKeyword.GetLocation()));
 
         var awaitToken = !localDeclaration.AwaitKeyword.IsKind(SyntaxKind.None)
             ? localDeclaration.AwaitKeyword

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/UnsupportedSyntaxAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/UnsupportedSyntaxAnalyzerUnitTests.cs
@@ -256,9 +256,60 @@ public class UnsupportedSyntaxAnalyzerUnitTests
         var expected = new[]
         {
             VerifyCS.Diagnostic(UnsupportedSyntaxAnalyzer.AwaitExpressionRuleId).WithLocation(0),
-            VerifyCS.Diagnostic(UnsupportedSyntaxAnalyzer.AsyncMethodRuleId).WithLocation(1)
+            VerifyCS.Diagnostic(UnsupportedSyntaxAnalyzer.AsyncMethodRuleId).WithLocation(1),
+            VerifyCS.Diagnostic(UnsupportedSyntaxAnalyzer.UsingStatementRuleId).WithSpan(13, 15, 13, 20)
         };
 
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task UsingStatement_IsFlagged()
+    {
+        var test = """
+                   using System;
+
+                   class Disposable : IDisposable
+                   {
+                       public void Dispose() { }
+                   }
+
+                   class Test
+                   {
+                       public void Run()
+                       {
+                           {|#0:using|} (var disposable = new Disposable())
+                           {
+                           }
+                       }
+                   }
+                   """;
+
+        var expected = VerifyCS.Diagnostic(UnsupportedSyntaxAnalyzer.UsingStatementRuleId).WithLocation(0);
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task UsingDeclaration_IsFlagged()
+    {
+        var test = """
+                   using System;
+
+                   class Disposable : IDisposable
+                   {
+                       public void Dispose() { }
+                   }
+
+                   class Test
+                   {
+                       public void Run()
+                       {
+                           {|#0:using|} var disposable = new Disposable();
+                       }
+                   }
+                   """;
+
+        var expected = VerifyCS.Diagnostic(UnsupportedSyntaxAnalyzer.UsingStatementRuleId).WithLocation(0);
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 


### PR DESCRIPTION
## Summary
- Report unsupported syntax diagnostics for using statements and using declarations.
- Update C# 8 syntax docs to mark using declarations unsupported.
- Add analyzer release tracking for NC4059.

## Rationale
The compiler processes C# syntax directly and does not emit deterministic Dispose calls for contract execution. Rejecting the syntax avoids accepting code that appears to follow normal C# resource disposal rules but does not preserve those semantics in Neo contract output.

## Validation
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter UnsupportedSyntaxAnalyzerUnitTests --no-restore`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~SyntaxTests --no-restore`
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --no-restore`
- `git diff --check`