### PR TITLE
Detect unsupported numeric property types

### DIFF
--- a/src/Neo.SmartContract.Analyzer/DecimalUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DecimalUsageAnalyzer.cs
@@ -95,7 +95,7 @@ namespace Neo.SmartContract.Analyzer
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().First();
+            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().FirstOrDefault();
             if (declaration is null) return;
 
             context.RegisterCodeFix(

--- a/src/Neo.SmartContract.Analyzer/DecimalUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DecimalUsageAnalyzer.cs
@@ -60,6 +60,13 @@ namespace Neo.SmartContract.Analyzer
                     Rule,
                     static type => new object?[] { type.SpecialType.ToString(), type.ToString() }),
                 SyntaxKind.Parameter);
+            context.RegisterSyntaxNodeAction(
+                static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzePropertyDeclaration(
+                    context,
+                    SpecialType.System_Decimal,
+                    Rule,
+                    static type => new object?[] { type.SpecialType.ToString(), type.ToString() }),
+                SyntaxKind.PropertyDeclaration);
         }
 
         private static void AnalyzeOperation(OperationAnalysisContext context)

--- a/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
@@ -94,7 +94,7 @@ namespace Neo.SmartContract.Analyzer
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().First();
+            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().FirstOrDefault();
             if (declaration is null) return;
 
             context.RegisterCodeFix(

--- a/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
@@ -61,6 +61,13 @@ namespace Neo.SmartContract.Analyzer
                     Rule,
                     static type => new object?[] { type.ToString() }),
                 SyntaxKind.Parameter);
+            context.RegisterSyntaxNodeAction(
+                static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzePropertyDeclaration(
+                    context,
+                    SpecialType.System_Double,
+                    Rule,
+                    static type => new object?[] { type.ToString() }),
+                SyntaxKind.PropertyDeclaration);
         }
 
         private static void AnalyzeOperation(OperationAnalysisContext context)

--- a/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
@@ -94,7 +94,7 @@ namespace Neo.SmartContract.Analyzer
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().First();
+            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().FirstOrDefault();
             if (declaration is null) return;
 
             context.RegisterCodeFix(

--- a/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
@@ -61,6 +61,13 @@ namespace Neo.SmartContract.Analyzer
                     Rule,
                     static type => new object?[] { type.ToString() }),
                 SyntaxKind.Parameter);
+            context.RegisterSyntaxNodeAction(
+                static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzePropertyDeclaration(
+                    context,
+                    SpecialType.System_Single,
+                    Rule,
+                    static type => new object?[] { type.ToString() }),
+                SyntaxKind.PropertyDeclaration);
         }
 
         private static void AnalyzeOperation(OperationAnalysisContext context)

--- a/src/Neo.SmartContract.Analyzer/UnsupportedTypeUsageAnalyzerHelpers.cs
+++ b/src/Neo.SmartContract.Analyzer/UnsupportedTypeUsageAnalyzerHelpers.cs
@@ -45,6 +45,18 @@ internal static class UnsupportedTypeUsageAnalyzerHelpers
         ReportIfUnsupportedType(context, parameter.Type.GetLocation(), type, specialType, rule, getMessageArgs);
     }
 
+    internal static void AnalyzePropertyDeclaration(
+        SyntaxNodeAnalysisContext context,
+        SpecialType specialType,
+        DiagnosticDescriptor rule,
+        Func<ITypeSymbol, object?[]> getMessageArgs)
+    {
+        if (context.Node is not PropertyDeclarationSyntax propertyDeclaration) return;
+
+        var type = (context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken) as IPropertySymbol)?.Type;
+        ReportIfUnsupportedType(context, propertyDeclaration.Type.GetLocation(), type, specialType, rule, getMessageArgs);
+    }
+
     private static void ReportIfUnsupportedType(
         SyntaxNodeAnalysisContext context,
         Location location,

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs
@@ -146,5 +146,23 @@ namespace Neo.SmartContract.Analyzer.UnitTests
 
             await VerifyCS.VerifyAnalyzerAsync(test, returnDiagnostic, parameterDiagnostic);
         }
+
+        [TestMethod]
+        public async Task DecimalProperty_ShouldReportDiagnostic()
+        {
+            var test = """
+
+                       class TestClass
+                       {
+                           public {|#0:decimal|} Value { get; set; }
+                       }
+                       """;
+
+            var propertyDiagnostic = VerifyCS.Diagnostic(DecimalUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("System_Decimal", "decimal");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, propertyDiagnostic);
+        }
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
@@ -141,5 +141,24 @@ namespace Neo.SmartContract.Analyzer.UnitTests
             await Verifier.VerifyAnalyzerAsync(test, returnDiagnostic, parameterDiagnostic).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public async Task DoubleUsageAnalyzer_Property_ShouldReportDiagnostic()
+        {
+            const string test = """
+
+                                public class TestClass
+                                {
+                                    public {|#0:double|} Value { get; set; }
+                                }
+
+                                """;
+
+            var propertyDiagnostic = Verifier.Diagnostic(DoubleUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("double");
+
+            await Verifier.VerifyAnalyzerAsync(test, propertyDiagnostic).ConfigureAwait(false);
+        }
+
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
@@ -141,5 +141,24 @@ namespace Neo.SmartContract.Analyzer.UnitTests
             await Verifier.VerifyAnalyzerAsync(test, returnDiagnostic, parameterDiagnostic).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public async Task FloatUsageAnalyzer_Property_ShouldReportDiagnostic()
+        {
+            const string test = """
+
+                                public class TestClass
+                                {
+                                    public {|#0:float|} Value { get; set; }
+                                }
+
+                                """;
+
+            var propertyDiagnostic = Verifier.Diagnostic(FloatUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("float");
+
+            await Verifier.VerifyAnalyzerAsync(test, propertyDiagnostic).ConfigureAwait(false);
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- Report unsupported type diagnostics for float, double, and decimal property declarations.
- Reuse the unsupported type helper for property symbols.
- Add analyzer coverage for unsupported numeric property types.
- Avoid offering numeric variable code fixes when the diagnostic is on a property type.

## Rationale
Unsupported numeric types were already reported for method signatures and local declarations, but property declarations could remain undiagnosed. Properties can be part of a contract-facing API, so reporting them early gives developers a clearer and more consistent error.

The existing numeric code fixes only rewrite variable declarations. When a diagnostic is reported on a property type, the providers now return without registering an unrelated fix.

## Validation
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --filter "FullyQualifiedName~FloatUsageAnalyzerUnitTest|FullyQualifiedName~DoubleUsageAnalyzerUnitTest|FullyQualifiedName~DecimalUsageAnalyzerUnitTests" --no-restore`
- `dotnet test tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj --no-restore`
- `git diff --check`