### PR TITLE
Annotate nullable contract lookups

### DIFF
--- a/src/Neo.SmartContract.Framework/Native/ContractManagement.cs
+++ b/src/Neo.SmartContract.Framework/Native/ContractManagement.cs
@@ -35,7 +35,7 @@ namespace Neo.SmartContract.Framework.Native
         /// The execution will fail if the 'hash' is null.
         /// </para>
         /// </summary>
-        public static extern Contract GetContract(UInt160 hash);
+        public static extern Contract? GetContract(UInt160 hash);
 
         /// <summary>
         /// Checks if the contract with the specified hash exists.
@@ -51,7 +51,7 @@ namespace Neo.SmartContract.Framework.Native
         /// Gets the contract by the specified id, null if not found.
         /// CallFlags requirement: CallFlags.ReadStates.
         /// </summary>
-        public static extern Contract GetContractById(int id);
+        public static extern Contract? GetContractById(int id);
 
         /// <summary>
         /// Gets hashes of all non native deployed contracts.

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NullableFrameworkAnnotations.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NullableFrameworkAnnotations.cs
@@ -1,0 +1,51 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_NullableFrameworkAnnotations.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using System;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_NullableFrameworkAnnotations
+{
+    [TestMethod]
+    public void ContractLookupWithoutNullCheck_ReportsNullableDereference()
+    {
+        var context = TestHelper.CompileSingleContract("""
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+
+public class Contract : SmartContract
+{
+    public static string GetName(UInt160 hash)
+    {
+        return ContractManagement.GetContract(hash).Manifest.Name;
+    }
+
+    public static string GetNameById(int id)
+    {
+        return ContractManagement.GetContractById(id).Manifest.Name;
+    }
+}
+""");
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+        var nullableDereferenceWarnings = context.Diagnostics.Count(d => d.Id == "CS8602");
+        Assert.IsTrue(
+            nullableDereferenceWarnings >= 2,
+            $"Expected a nullable dereference warning for unchecked contract lookup.\n{string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString()))}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Mark `ContractManagement.GetContract` and `GetContractById` as nullable return APIs.
- Add a compiler regression test that verifies unchecked contract lookup dereferences produce nullable warnings.

## Motivation
The framework documentation already states that these lookups return null when no contract is found. The C# signatures should expose that contract to nullable analysis so developers get a normal C# warning before dereferencing the result without a null check.

## Validation
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_NullableFrameworkAnnotations.ContractLookupWithoutNullCheck_ReportsNullableDereference" --no-restore`
- `dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj --filter "FullyQualifiedName~ContractTest|FullyQualifiedName~BlockchainTest" --no-restore`
