### PR TITLE
Fix: char.ToUpperInvariant and char.ToLowerInvariant

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Char.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Char.cs
@@ -536,7 +536,7 @@ internal partial class MethodConvert
     }
 
     /// <summary>
-    /// Handles the char.ToLowerInvariant method to check if a character is lowercase (invariant culture).
+    /// Handles the char.ToLowerInvariant method to convert an uppercase character to lowercase.
     /// Only ASCII characters are supported.
     /// </summary>
     /// <param name="methodConvert">The method converter instance</param>
@@ -545,17 +545,24 @@ internal partial class MethodConvert
     /// <param name="instanceExpression">The instance expression (if any)</param>
     /// <param name="arguments">The method arguments</param>
     /// <remarks>
-    /// Algorithm: Checks if character is within lowercase range (a-z) using invariant culture
+    /// Algorithm: Converts uppercase letters (A-Z) to lowercase (a-z), leaves other characters unchanged
     /// </remarks>
     private static void HandleCharToLowerInvariant(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        if (arguments is not null)
+            methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
         methodConvert.Dup();                                       // Duplicate character for range check
-        methodConvert.Within((ushort)'a', (ushort)'z');            // Check if within lowercase range
+        methodConvert.Within((ushort)'A', (ushort)'Z');            // Check if within uppercase range
+        var endTarget = new JumpTarget();
+        methodConvert.JumpIfFalse(endTarget);                      // Jump if not uppercase
+        methodConvert.Push(32);                                    // Push 32 (difference between uppercase and lowercase for ASCII)
+        methodConvert.Add();                                       // Add 32 to get lowercase for ASCII
+        endTarget.Instruction = methodConvert.Nop();               // End target
     }
 
     /// <summary>
-    /// Handles the char.ToUpperInvariant method to check if a character is uppercase (invariant culture).
+    /// Handles the char.ToUpperInvariant method to convert a lowercase character to uppercase.
     /// Only ASCII characters are supported.
     /// </summary>
     /// <param name="methodConvert">The method converter instance</param>
@@ -564,13 +571,20 @@ internal partial class MethodConvert
     /// <param name="instanceExpression">The instance expression (if any)</param>
     /// <param name="arguments">The method arguments</param>
     /// <remarks>
-    /// Algorithm: Checks if character is within lowercase range (a-z) using invariant culture
+    /// Algorithm: Converts lowercase letters (a-z) to uppercase (A-Z), leaves other characters unchanged
     /// </remarks>
     private static void HandleCharToUpperInvariant(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
+        if (arguments is not null)
+            methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
         methodConvert.Dup();                                       // Duplicate character for range check
         methodConvert.Within((ushort)'a', (ushort)'z');            // Check if within lowercase range
+        var endTarget = new JumpTarget();
+        methodConvert.JumpIfFalse(endTarget);                      // Jump if not lowercase
+        methodConvert.Push(32);                                    // Push 32 (difference between uppercase and lowercase for ASCII)
+        methodConvert.Sub();                                       // Subtract 32 to get uppercase for ASCII
+        endTarget.Instruction = methodConvert.Nop();               // End target
     }
 
     /// <summary>

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Char.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Char.cs
@@ -53,6 +53,16 @@ public class Contract_Char : SmartContract.Framework.SmartContract
         return char.ToUpper(c);
     }
 
+    public static char TestCharToUpperInvariant(char c)
+    {
+        return char.ToUpperInvariant(c);
+    }
+
+    public static char TestCharToLowerInvariant(char c)
+    {
+        return char.ToLowerInvariant(c);
+    }
+
     public static int TestCharGetNumericValue(char c)
     {
         return (int)char.GetNumericValue(c);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Char.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Char"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testCharIsDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testCharIsLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testCharIsWhiteSpace"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""testCharIsLetterOrDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testCharIsLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":68,""safe"":false},{""name"":""testCharToLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":78,""safe"":false},{""name"":""testCharIsUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":94,""safe"":false},{""name"":""testCharToUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":104,""safe"":false},{""name"":""testCharGetNumericValue"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":120,""safe"":false},{""name"":""testCharIsPunctuation"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":139,""safe"":false},{""name"":""testCharIsSymbol"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":173,""safe"":false},{""name"":""testCharIsControl"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":215,""safe"":false},{""name"":""testCharIsSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":233,""safe"":false},{""name"":""testCharIsHighSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":263,""safe"":false},{""name"":""testCharIsLowSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":279,""safe"":false},{""name"":""testCharIsBetween"",""parameters"":[{""name"":""c"",""type"":""Integer""},{""name"":""lower"",""type"":""Integer""},{""name"":""upper"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":295,""safe"":false},{""name"":""testCharParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":314,""safe"":false},{""name"":""testCharTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Array"",""offset"":333,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":370,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Char"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testCharIsDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testCharIsLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testCharIsWhiteSpace"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""testCharIsLetterOrDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testCharIsLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":68,""safe"":false},{""name"":""testCharToLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":78,""safe"":false},{""name"":""testCharIsUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":94,""safe"":false},{""name"":""testCharToUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":104,""safe"":false},{""name"":""testCharToUpperInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":120,""safe"":false},{""name"":""testCharToLowerInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":136,""safe"":false},{""name"":""testCharGetNumericValue"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":152,""safe"":false},{""name"":""testCharIsPunctuation"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":171,""safe"":false},{""name"":""testCharIsSymbol"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":205,""safe"":false},{""name"":""testCharIsControl"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":247,""safe"":false},{""name"":""testCharIsSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":265,""safe"":false},{""name"":""testCharIsHighSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":295,""safe"":false},{""name"":""testCharIsLowSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":311,""safe"":false},{""name"":""testCharIsBetween"",""parameters"":[{""name"":""c"",""type"":""Integer""},{""name"":""lower"",""type"":""Integer""},{""name"":""upper"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":327,""safe"":false},{""name"":""testCharParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":346,""safe"":false},{""name"":""testCharTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Array"",""offset"":365,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":402,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP11AVcAAXgAMAA6u0BXAAF4SgBBAFu7UABhAHu7rEBXAAF4Shkeu1AAILOsQFcAAXhKADAAOrskD0oAQQBbuyQHAGEAe7tAVwABeABhAHu7QFcAAXhKAEEAW7smBQAgnkBXAAF4AEEAW7tAVwABeEoAYQB7uyYFACCfQFcAAXhKADAAOrskBUUPQAAwn0BXAAF4SgAhADC7JBdKADoAQbskD0oAWwBhuyQHAHsAf7tAVwABeEoAJAAsuyQfSgA8AD67JBdKAD4AQbskD0oAWwBhuyQHAHsAf7tAVwABeEoQACC7UAB/AaAAu6xAVwABeEoCANgAAAIA3AAAu1ACANwAAAIA4AAAu6xAVwABeAIA2AAAAgDcAAC7QFcAAXgCANwAAAIA4AAAu0BXAAN6eXhKUbhKJgZTRUVARbVAVwABeErYJgM6SsoRsyQDOhDOQFcBARBKYXhQRUrYJA5KyhGzJggQzmAIIgZFEGAJWGFwWWgSv0BWAkBL3OCm").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2VAVcAAXgAMAA6u0BXAAF4SgBBAFu7UABhAHu7rEBXAAF4Shkeu1AAILOsQFcAAXhKADAAOrskD0oAQQBbuyQHAGEAe7tAVwABeABhAHu7QFcAAXhKAEEAW7smBQAgnkBXAAF4AEEAW7tAVwABeEoAYQB7uyYFACCfQFcAAXhKAGEAe7smBQAgn0BXAAF4SgBBAFu7JgUAIJ5AVwABeEoAMAA6uyQFRQ9AADCfQFcAAXhKACEAMLskF0oAOgBBuyQPSgBbAGG7JAcAewB/u0BXAAF4SgAkACy7JB9KADwAPrskF0oAPgBBuyQPSgBbAGG7JAcAewB/u0BXAAF4ShAAILtQAH8BoAC7rEBXAAF4SgIA2AAAAgDcAAC7UAIA3AAAAgDgAAC7rEBXAAF4AgDYAAACANwAALtAVwABeAIA3AAAAgDgAAC7QFcAA3p5eEpRuEomBlNFRUBFtUBXAAF4StgmAzpKyhGzJAM6EM5AVwEBEEpheFBFStgkDkrKEbMmCBDOYAgiBkUQYAlYYXBZaBK/QFYCQGlxDLM=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -366,6 +366,25 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
+    /// Script: VwABeEoAQQBbuyYFACCeQA==
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT8 41 [1 datoshi]
+    /// PUSHINT8 5B [1 datoshi]
+    /// WITHIN [8 datoshi]
+    /// JMPIFNOT 05 [2 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
+    /// ADD [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testCharToLowerInvariant")]
+    public abstract BigInteger? TestCharToLowerInvariant(BigInteger? c);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
     /// Script: VwABeEoAYQB7uyYFACCfQA==
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
@@ -380,6 +399,25 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
     /// </remarks>
     [DisplayName("testCharToUpper")]
     public abstract BigInteger? TestCharToUpper(BigInteger? c);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeEoAYQB7uyYFACCfQA==
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT8 61 [1 datoshi]
+    /// PUSHINT8 7B [1 datoshi]
+    /// WITHIN [8 datoshi]
+    /// JMPIFNOT 05 [2 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
+    /// SUB [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testCharToUpperInvariant")]
+    public abstract BigInteger? TestCharToUpperInvariant(BigInteger? c);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
@@ -136,6 +136,32 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         [TestMethod]
+        public void TestCharToUpperInvariant()
+        {
+            Assert.AreEqual('A', Contract.TestCharToUpperInvariant('a'));
+            AssertGasConsumed(1047990);
+            Assert.AreEqual('A', Contract.TestCharToUpperInvariant('A'));
+            AssertGasConsumed(1047450);
+            Assert.AreEqual(' ', Contract.TestCharToUpperInvariant(' '));
+            AssertGasConsumed(1047450);
+            Assert.AreEqual('1', Contract.TestCharToUpperInvariant('1'));
+            AssertGasConsumed(1047450);
+        }
+
+        [TestMethod]
+        public void TestCharToLowerInvariant()
+        {
+            Assert.AreEqual('a', Contract.TestCharToLowerInvariant('A'));
+            AssertGasConsumed(1047990);
+            Assert.AreEqual('a', Contract.TestCharToLowerInvariant('a'));
+            AssertGasConsumed(1047450);
+            Assert.AreEqual(' ', Contract.TestCharToLowerInvariant(' '));
+            AssertGasConsumed(1047450);
+            Assert.AreEqual('1', Contract.TestCharToLowerInvariant('1'));
+            AssertGasConsumed(1047450);
+        }
+
+        [TestMethod]
         public void TestCharIsLetterOrDigit()
         {
             Assert.IsTrue(Contract.TestCharIsLetterOrDigit('a'));


### PR DESCRIPTION

The implementations of  char.ToUpperInvariant and char.ToLowerInvariant are wrong.

These two methods implemented as `char.IsUpper` and `char.IsLower`.