### PR TITLE
Fix: char.IsSymbol

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Char.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Char.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -277,7 +279,7 @@ internal partial class MethodConvert
     /// <param name="instanceExpression">The instance expression (if any)</param>
     /// <param name="arguments">The method arguments</param>
     /// <remarks>
-    /// Algorithm: Checks if character is within ASCII symbol ranges: $%&'()*+ <=> >?@ [\]^_` {|}~
+    /// Algorithm: Checks if character is within ASCII symbol ranges: "<$+<=>^`|~>"
     /// </remarks>
     private static void HandleCharIsSymbol(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol,
         ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
@@ -285,19 +287,16 @@ internal partial class MethodConvert
         if (arguments is not null)
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
         var endTarget = new JumpTarget();
+        var bits = BigInteger.Parse("50000001400000007000081000000000", NumberStyles.AllowHexSpecifier);
         methodConvert.Dup();                                       // Duplicate character for multiple checks
-        methodConvert.Within((ushort)'$', (ushort)'+');            // Check if within range $%&'()*+
-        methodConvert.JumpIfTrue(endTarget);                       // Jump if found symbol
-        methodConvert.Dup();                                       // Duplicate character for next check
-        methodConvert.Within((ushort)'<', (ushort)'=');            // Check if within range <=>
-        methodConvert.JumpIfTrue(endTarget);                       // Jump if found symbol
-        methodConvert.Dup();                                       // Duplicate character for next check
-        methodConvert.Within((ushort)'>', (ushort)'@');            // Check if within range >?@
-        methodConvert.JumpIfTrue(endTarget);                       // Jump if found symbol
-        methodConvert.Dup();                                       // Duplicate character for next check
-        methodConvert.Within((ushort)'[', (ushort)'`');            // Check if within range [\]^_`
-        methodConvert.JumpIfTrue(endTarget);                       // Jump if found symbol
-        methodConvert.Within((ushort)'{', (ushort)'~');            // Check if within range {|}~
+        methodConvert.Push(127);                                   // Push 127 for comparison
+        methodConvert.JumpIfGreater(endTarget);                    // Only ASCII characters are checked
+        methodConvert.Push(bits);                                  // Push bits for comparison
+        methodConvert.Push1();                                     // Push 1 for AND with bits
+        methodConvert.Rot();                                       // v | bits | 1 ->  bits | 1 | v
+        methodConvert.ShL();                                       // bits | 1 | v -> bbit | (1 << v)
+        methodConvert.And();                                       // bits | (1 << v) -> bits & (1 << v)
+        methodConvert.Nz();                                        // Check if bits & (1 << v) is not zero
         endTarget.Instruction = methodConvert.Nop();               // End target
     }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Char.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Char"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testCharIsDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testCharIsLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testCharIsWhiteSpace"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""testCharIsLetterOrDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testCharIsAsciiLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":68,""safe"":false},{""name"":""testCharIsLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":86,""safe"":false},{""name"":""testCharToLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":96,""safe"":false},{""name"":""testCharIsUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":112,""safe"":false},{""name"":""testCharToUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":122,""safe"":false},{""name"":""testCharToUpperInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":138,""safe"":false},{""name"":""testCharToLowerInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":154,""safe"":false},{""name"":""testCharGetNumericValue"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":170,""safe"":false},{""name"":""testCharIsPunctuation"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":189,""safe"":false},{""name"":""testCharIsSymbol"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":223,""safe"":false},{""name"":""testCharIsControl"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":265,""safe"":false},{""name"":""testCharIsSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":283,""safe"":false},{""name"":""testCharIsHighSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":313,""safe"":false},{""name"":""testCharIsLowSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":329,""safe"":false},{""name"":""testCharIsBetween"",""parameters"":[{""name"":""c"",""type"":""Integer""},{""name"":""lower"",""type"":""Integer""},{""name"":""upper"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":345,""safe"":false},{""name"":""testCharParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":364,""safe"":false},{""name"":""testCharTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Array"",""offset"":383,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":420,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Char"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testCharIsDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testCharIsLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testCharIsWhiteSpace"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""testCharIsLetterOrDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testCharIsAsciiLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":68,""safe"":false},{""name"":""testCharIsLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":86,""safe"":false},{""name"":""testCharToLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":96,""safe"":false},{""name"":""testCharIsUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":112,""safe"":false},{""name"":""testCharToUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":122,""safe"":false},{""name"":""testCharToUpperInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":138,""safe"":false},{""name"":""testCharToLowerInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":154,""safe"":false},{""name"":""testCharGetNumericValue"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":170,""safe"":false},{""name"":""testCharIsPunctuation"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":189,""safe"":false},{""name"":""testCharIsSymbol"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":223,""safe"":false},{""name"":""testCharIsControl"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":255,""safe"":false},{""name"":""testCharIsSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":273,""safe"":false},{""name"":""testCharIsHighSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":303,""safe"":false},{""name"":""testCharIsLowSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":319,""safe"":false},{""name"":""testCharIsBetween"",""parameters"":[{""name"":""c"",""type"":""Integer""},{""name"":""lower"",""type"":""Integer""},{""name"":""upper"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":335,""safe"":false},{""name"":""testCharParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":354,""safe"":false},{""name"":""testCharTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Array"",""offset"":373,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":410,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2nAVcAAXgAMAA6u0BXAAF4SgBBAFu7UABhAHu7rEBXAAF4Shkeu1AAILOsQFcAAXhKADAAOrskD0oAQQBbuyQHAGEAe7tAVwABeEoAQQBbu1AAYQB7u6xAVwABeABhAHu7QFcAAXhKAEEAW7smBQAgnkBXAAF4AEEAW7tAVwABeEoAYQB7uyYFACCfQFcAAXhKAGEAe7smBQAgn0BXAAF4SgBBAFu7JgUAIJ5AVwABeEoAMAA6uyQFRQ9AADCfQFcAAXhKACEAMLskF0oAOgBBuyQPSgBbAGG7JAcAewB/u0BXAAF4SgAkACy7JB9KADwAPrskF0oAPgBBuyQPSgBbAGG7JAcAewB/u0BXAAF4ShAAILtQAH8BoAC7rEBXAAF4SgIA2AAAAgDcAAC7UAIA3AAAAgDgAAC7rEBXAAF4AgDYAAACANwAALtAVwABeAIA3AAAAgDgAAC7QFcAA3p5eEpRuEomBlNFRUBFtUBXAAF4StgmAzpKyhGzJAM6EM5AVwEBEEpheFBFStgkDkrKEbMmCBDOYAgiBkUQYAlYYXBZaBK/QFYCQJkJw/w=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2dAVcAAXgAMAA6u0BXAAF4SgBBAFu7UABhAHu7rEBXAAF4Shkeu1AAILOsQFcAAXhKADAAOrskD0oAQQBbuyQHAGEAe7tAVwABeEoAQQBbu1AAYQB7u6xAVwABeABhAHu7QFcAAXhKAEEAW7smBQAgnkBXAAF4AEEAW7tAVwABeEoAYQB7uyYFACCfQFcAAXhKAGEAe7smBQAgn0BXAAF4SgBBAFu7JgUAIJ5AVwABeEoAMAA6uyQFRQ9AADCfQFcAAXhKACEAMLskF0oAOgBBuyQPSgBbAGG7JAcAewB/u0BXAAF4SgB/LBgEAAAAABAIAHAAAABAAQAAUBFRqJGxQFcAAXhKEAAgu1AAfwGgALusQFcAAXhKAgDYAAACANwAALtQAgDcAAACAOAAALusQFcAAXgCANgAAAIA3AAAu0BXAAF4AgDcAAACAOAAALtAVwADenl4SlG4SiYGU0VFQEW1QFcAAXhK2CYDOkrKEbMkAzoQzkBXAQEQSmF4UEVK2CQOSsoRsyYIEM5gCCIGRRBgCVhhcFloEr9AVgJAhmuy5Q==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -274,32 +274,18 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeEoAJAAsuyQfSgA8AD67JBdKAD4AQbskD0oAWwBhuyQHAHsAf7tA
+    /// Script: VwABeEoAfywYBAAAAAAQCABwAAAAQAEAAFARUaiRsUA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
-    /// PUSHINT8 24 [1 datoshi]
-    /// PUSHINT8 2C [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 1F [2 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHINT8 3C [1 datoshi]
-    /// PUSHINT8 3E [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 17 [2 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHINT8 3E [1 datoshi]
-    /// PUSHINT8 41 [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 0F [2 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHINT8 5B [1 datoshi]
-    /// PUSHINT8 61 [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 07 [2 datoshi]
-    /// PUSHINT8 7B [1 datoshi]
     /// PUSHINT8 7F [1 datoshi]
-    /// WITHIN [8 datoshi]
+    /// JMPGT 18 [2 datoshi]
+    /// PUSHINT128 00000000100800700000004001000050 [4 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// ROT [2 datoshi]
+    /// SHL [8 datoshi]
+    /// AND [8 datoshi]
+    /// NZ [4 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testCharIsSymbol")]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
@@ -14,6 +14,7 @@ using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.Exceptions;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Text;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -73,6 +74,12 @@ namespace Neo.Compiler.CSharp.UnitTests
             AssertGasConsumed(1047450);
             Assert.IsFalse(Contract.TestCharIsPunctuation('a'));
             AssertGasConsumed(1048590);
+
+            for (char c = '\0'; c < 128; c++)
+            {
+                Assert.AreEqual(char.IsSymbol(c), Contract.TestCharIsSymbol(c), $"IsSymbol failed for '{c}'");
+                AssertGasConsumed(1047450);
+            }
 
             Assert.IsTrue(Contract.TestCharIsSymbol('$'));
             AssertGasConsumed(1047450);


### PR DESCRIPTION

The `char.IsSymbol` in C# standard library  returns `true` if the char value is one of 
```
<$+<=>^`|~>  (for ASCII)
```
But the current implementation returns `true` if the char value is one of:
```
$%&'()*+ <=> >?@ [\]^_` {|}~ (for ASCII).
```


The fixed implementation has less opcodes, and the same behavior as  C# standard library (for ASCII).