### PR TITLE
Fix nullable char ToString conversion

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Nullable.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Nullable.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Neo.SmartContract.Native;
 using Neo.VM;
+using Neo.VM.Types;
 
 namespace Neo.Compiler;
 
@@ -446,12 +447,21 @@ internal partial class MethodConvert
         methodConvert.Dup();                                       // Duplicate value for null check
         methodConvert.IsNull();                                    // Check if value is null
         methodConvert.JumpIfTrue(endTarget);                       // Jump if null
-        methodConvert.CallContractMethod(NativeContract.StdLib.Hash, "itoa", 1, true);
+        if (IsNullableChar(symbol.ContainingType))
+            methodConvert.ChangeType(StackItemType.ByteString);
+        else
+            methodConvert.CallContractMethod(NativeContract.StdLib.Hash, "itoa", 1, true);
         methodConvert.JumpAlwaysLong(endTarget2);                   // Jump to end
         endTarget.Instruction = methodConvert.Nop();               // Null case target
         methodConvert.Drop();                                      // Drop null value
         methodConvert.Push("");                                    // Push empty string
         endTarget2.Instruction = methodConvert.Nop();              // End target
+    }
+
+    private static bool IsNullableChar(INamedTypeSymbol type)
+    {
+        return type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
+               type.TypeArguments is [{ SpecialType: SpecialType.System_Char }];
     }
 
     /// <summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NullableToString.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NullableToString.cs
@@ -60,6 +60,36 @@ public class UnitTest_NullableToString
         Assert.AreEqual(1, receiverLoads, $"Nullable<T>.ToString() should leave only the string result on the stack.\n{methodBlock}");
     }
 
+    [TestMethod]
+    public void NullableCharToString_UsesCharacterText()
+    {
+        const string source = """
+            using Neo.SmartContract.Framework;
+            using System.ComponentModel;
+
+            public class Contract : SmartContract
+            {
+                [DisplayName("direct")]
+                public static string Direct(char? value) => value.ToString();
+
+                [DisplayName("withSuffix")]
+                public static string WithSuffix(char? value) => value.ToString() + "|done";
+            }
+            """;
+
+        var context = TestHelper.CompileSingleContract(source);
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<NullableCharToStringContract>(context.CreateExecutable(), context.CreateManifest());
+
+        Assert.AreEqual("A", contract.Direct('A'));
+        Assert.AreEqual("", contract.Direct(null));
+        Assert.AreEqual("A|done", contract.WithSuffix('A'));
+        Assert.AreEqual("|done", contract.WithSuffix(null));
+    }
+
     private static string ExtractMethodBlock(string assembly, string methodSignature)
     {
         var normalized = assembly.Replace("\r\n", "\n", StringComparison.Ordinal);
@@ -82,5 +112,15 @@ public class UnitTest_NullableToString
 
         [DisplayName("withSuffix")]
         public abstract string? WithSuffix(BigInteger? value);
+    }
+
+    public abstract class NullableCharToStringContract(SmartContractInitialize initialize)
+        : SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("direct")]
+        public abstract string? Direct(char? value);
+
+        [DisplayName("withSuffix")]
+        public abstract string? WithSuffix(char? value);
     }
 }


### PR DESCRIPTION
## Summary
- make `char?.ToString()` return character text instead of the numeric code point
- keep null nullable values returning an empty string
- add VM regression coverage for direct and concatenated nullable char strings

## Testing
- `NEO_SKIP_TEST_COVERAGE=1 dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName=Neo.Compiler.CSharp.UnitTests.UnitTest_NullableToString.NullableCharToString_UsesCharacterText"`
- `NEO_SKIP_TEST_COVERAGE=1 dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_NullableToString"`
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj`