### PR TITLE
Add numeric CreateTruncating support

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.BigInteger.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.BigInteger.cs
@@ -945,6 +945,22 @@ internal partial class MethodConvert
     }
 
     /// <summary>
+    /// Handles the BigInteger.CreateTruncating method by creating a BigInteger without truncation.
+    /// </summary>
+    /// <param name="methodConvert">The method converter instance</param>
+    /// <param name="model">The semantic model</param>
+    /// <param name="symbol">The method symbol</param>
+    /// <param name="instanceExpression">The instance expression (if any)</param>
+    /// <param name="arguments">The method arguments</param>
+    /// <remarks>
+    /// Algorithm: Direct conversion since BigInteger can represent any integer value without truncation
+    /// </remarks>
+    private static void HandleBigIntegerCreateTruncating(MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
+    {
+        methodConvert.PrepareArgumentsForMethod(model, symbol, arguments!);
+    }
+
+    /// <summary>
     /// Handles the BigInteger.Equals method by comparing two BigInteger values for equality.
     /// </summary>
     /// <param name="methodConvert">The method converter instance</param>

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Numeric.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Numeric.cs
@@ -169,6 +169,17 @@ internal partial class MethodConvert
         EmitClampToRangeLegacy(methodConvert);
     }
 
+    private static void HandleNumericCreateTruncating(NumericTypeDescriptor descriptor, MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
+    {
+        methodConvert.PrepareArgumentsForMethod(model, symbol, arguments!);
+
+        methodConvert.Push((BigInteger.One << descriptor.BitSize) - 1);
+        methodConvert.And();
+
+        if (descriptor.IsSigned)
+            EmitSignedRotateResult(methodConvert, descriptor.BitSize);
+    }
+
     private static void HandleNumericRotateLeft(NumericTypeDescriptor descriptor, MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
         using var tempScope = methodConvert.PreserveAnonymousVariables();
@@ -319,6 +330,7 @@ internal partial class MethodConvert
 
         RegisterCreateCheckedHandlers(type, (mc, model, symbol, instanceExpression, arguments) => HandleNumericCreateChecked(descriptor, mc, model, symbol, instanceExpression, arguments));
         RegisterCreateSaturatingHandlers(type, (mc, model, symbol, instanceExpression, arguments) => HandleNumericCreateSaturating(descriptor, mc, model, symbol, instanceExpression, arguments));
+        RegisterCreateTruncatingHandlers(type, (mc, model, symbol, instanceExpression, arguments) => HandleNumericCreateTruncating(descriptor, mc, model, symbol, instanceExpression, arguments));
     }
 
     private static void RegisterNumericMethod(MethodInfo method, SystemCallHandler handler)

--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
@@ -112,6 +112,7 @@ internal partial class MethodConvert
             RegisterNumericHandlers(descriptor);
 
         RegisterCreateCheckedHandlers(typeof(BigInteger), HandleBigIntegerCreatedChecked);
+        RegisterCreateTruncatingHandlers(typeof(BigInteger), HandleBigIntegerCreateTruncating);
 
         // Numeric explicit cast from BigInteger methods
         RegisterHandler((BigInteger b) => (sbyte)b, HandleBigIntegerToSByte);
@@ -283,6 +284,11 @@ internal partial class MethodConvert
     private static void RegisterCreateSaturatingHandlers(Type targetType, SystemCallHandler handler)
     {
         RegisterCreateNumericHandlers("CreateSaturating", targetType, handler);
+    }
+
+    private static void RegisterCreateTruncatingHandlers(Type targetType, SystemCallHandler handler)
+    {
+        RegisterCreateNumericHandlers("CreateTruncating", targetType, handler);
     }
 
     private static void RegisterCreateNumericHandlers(string methodName, Type targetType, SystemCallHandler handler)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NumericCreateTruncating.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NumericCreateTruncating.cs
@@ -1,0 +1,83 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_NumericCreateTruncating
+{
+    [TestMethod]
+    public void NumericCreateTruncating_ReturnsWrappedIntegralValues()
+    {
+        var contract = DeployContract();
+
+        Assert.AreEqual(new BigInteger(byte.CreateTruncating(-1)), contract.ByteFromInt(-1));
+        Assert.AreEqual(new BigInteger(byte.CreateTruncating(256)), contract.ByteFromInt(256));
+        Assert.AreEqual(new BigInteger(sbyte.CreateTruncating(255)), contract.SByteFromInt(255));
+        Assert.AreEqual(new BigInteger(uint.CreateTruncating(-1)), contract.UIntFromInt(-1));
+        Assert.AreEqual(new BigInteger(ulong.CreateTruncating(-1L)), contract.ULongFromLong(-1));
+        Assert.AreEqual(new BigInteger(int.CreateTruncating(new BigInteger(4294967295UL))), contract.IntFromBigInteger(new BigInteger(4294967295UL)));
+        Assert.AreEqual(BigInteger.CreateTruncating(long.MinValue), contract.BigIntegerFromLong(long.MinValue));
+    }
+
+    private static NumericCreateTruncatingContract DeployContract()
+    {
+        var context = TestHelper.CompileSingleContract("""
+            using Neo.SmartContract.Framework;
+            using System.ComponentModel;
+            using System.Numerics;
+
+            public class Contract : SmartContract
+            {
+                [DisplayName("byteFromInt")]
+                public static byte ByteFromInt(int value) => byte.CreateTruncating(value);
+
+                [DisplayName("sByteFromInt")]
+                public static sbyte SByteFromInt(int value) => sbyte.CreateTruncating(value);
+
+                [DisplayName("uIntFromInt")]
+                public static uint UIntFromInt(int value) => uint.CreateTruncating(value);
+
+                [DisplayName("uLongFromLong")]
+                public static ulong ULongFromLong(long value) => ulong.CreateTruncating(value);
+
+                [DisplayName("intFromBigInteger")]
+                public static int IntFromBigInteger(BigInteger value) => int.CreateTruncating(value);
+
+                [DisplayName("bigIntegerFromLong")]
+                public static BigInteger BigIntegerFromLong(long value) => BigInteger.CreateTruncating(value);
+            }
+            """);
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        return engine.Deploy<NumericCreateTruncatingContract>(context.CreateExecutable(), context.CreateManifest());
+    }
+
+    public abstract class NumericCreateTruncatingContract(SmartContractInitialize initialize)
+        : SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("byteFromInt")]
+        public abstract BigInteger? ByteFromInt(BigInteger? value);
+
+        [DisplayName("sByteFromInt")]
+        public abstract BigInteger? SByteFromInt(BigInteger? value);
+
+        [DisplayName("uIntFromInt")]
+        public abstract BigInteger? UIntFromInt(BigInteger? value);
+
+        [DisplayName("uLongFromLong")]
+        public abstract BigInteger? ULongFromLong(BigInteger? value);
+
+        [DisplayName("intFromBigInteger")]
+        public abstract BigInteger? IntFromBigInteger(BigInteger? value);
+
+        [DisplayName("bigIntegerFromLong")]
+        public abstract BigInteger? BigIntegerFromLong(BigInteger? value);
+    }
+}


### PR DESCRIPTION
## Summary
- Register CreateTruncating<TValue> handlers for the supported integral numeric targets and BigInteger.
- Emit wraparound truncation by applying the target bit-width mask and restoring signed results when needed.
- Add a dynamic contract regression test for signed, unsigned, 64-bit, and BigInteger conversions.

## Testing
- NEO_SKIP_TEST_COVERAGE=1 dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_NumericCreateTruncating --no-restore
- NEO_SKIP_TEST_COVERAGE=1 dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~UnitTest_SystemCallDsl|FullyQualifiedName~UnitTest_Integer|FullyQualifiedName~UnitTest_NumericCreateTruncating" --no-restore