### PR TITLE
Fix: Div operation shouldn't throw exception in unchecked context

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
@@ -284,8 +284,7 @@ internal partial class MethodConvert
         bool isBoolean = itemType == VM.Types.StackItemType.Boolean;
         bool isString = itemType == VM.Types.StackItemType.ByteString;
 
-        var opText = operatorToken.ValueText;
-        var (opcode, checkResult) = opText switch
+        var (opcode, checkResult) = operatorToken.ValueText switch
         {
             "+=" => isString ? (OpCode.CAT, false) : (OpCode.ADD, true),
             "-=" => (OpCode.SUB, true),
@@ -298,8 +297,7 @@ internal partial class MethodConvert
             "|=" => isBoolean ? (OpCode.BOOLOR, false) : (OpCode.OR, true),
             "<<=" => (OpCode.SHL, true),
             ">>=" => (OpCode.SHR, true),
-            _ => throw CompilationException.UnsupportedSyntax(operatorToken,
-                $"Complex assignment operator '{opText}' is not supported. Supported operators are: +=, -=, *=, /=, %=, &=, |=, ^=, <<=, and >>=.")
+            _ => throw CompilationException.UnsupportedSyntax(operatorToken, $"Complex assignment operator '{operatorToken.ValueText}' is not supported. Supported operators are: +=, -=, *=, /=, %=, &=, |=, ^=, <<=, and >>=.")
         };
 
         AddInstruction(opcode);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
@@ -284,7 +284,8 @@ internal partial class MethodConvert
         bool isBoolean = itemType == VM.Types.StackItemType.Boolean;
         bool isString = itemType == VM.Types.StackItemType.ByteString;
 
-        var (opcode, checkResult) = operatorToken.ValueText switch
+        var opText = operatorToken.ValueText;
+        var (opcode, checkResult) = opText switch
         {
             "+=" => isString ? (OpCode.CAT, false) : (OpCode.ADD, true),
             "-=" => (OpCode.SUB, true),
@@ -297,13 +298,9 @@ internal partial class MethodConvert
             "|=" => isBoolean ? (OpCode.BOOLOR, false) : (OpCode.OR, true),
             "<<=" => (OpCode.SHL, true),
             ">>=" => (OpCode.SHR, true),
-            _ => throw CompilationException.UnsupportedSyntax(operatorToken, $"Complex assignment operator '{operatorToken.ValueText}' is not supported. Supported operators are: +=, -=, *=, /=, %=, &=, |=, ^=, <<=, and >>=.")
+            _ => throw CompilationException.UnsupportedSyntax(operatorToken,
+                $"Complex assignment operator '{opText}' is not supported. Supported operators are: +=, -=, *=, /=, %=, &=, |=, ^=, <<=, and >>=.")
         };
-
-        if (operatorToken.ValueText == "/=")
-        {
-            CheckDivideOverflow(type);
-        }
 
         AddInstruction(opcode);
         if (opcode == OpCode.XOR && isBoolean)

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_DivisionOverflow.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_DivisionOverflow.cs
@@ -13,12 +13,12 @@ public abstract class Contract_DivisionOverflow(Neo.SmartContract.Testing.SmartC
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_DivisionOverflow"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""divideCheckedInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""divideUncheckedInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":20,""safe"":false},{""name"":""divideAssignUncheckedInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":40,""safe"":false},{""name"":""divideCheckedInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":108,""safe"":false},{""name"":""divideUncheckedInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":132,""safe"":false},{""name"":""divideAssignUncheckedInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":156,""safe"":false},{""name"":""divideCheckedBigInteger"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":256,""safe"":false},{""name"":""divideUncheckedBigInteger"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":263,""safe"":false},{""name"":""divideCheckedUInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":270,""safe"":false},{""name"":""divideCheckedUInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":277,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_DivisionOverflow"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""divideCheckedInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""divideUncheckedInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":20,""safe"":false},{""name"":""divideAssignUncheckedInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":40,""safe"":false},{""name"":""divideCheckedInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":95,""safe"":false},{""name"":""divideUncheckedInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":119,""safe"":false},{""name"":""divideAssignUncheckedInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":143,""safe"":false},{""name"":""divideCheckedBigInteger"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":226,""safe"":false},{""name"":""divideUncheckedBigInteger"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":233,""safe"":false},{""name"":""divideCheckedUInt32"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":240,""safe"":false},{""name"":""divideCheckedUInt64"",""parameters"":[{""name"":""a"",""type"":""Integer""},{""name"":""b"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":247,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0cAVcAAnh5Sg8qC0sCAAAAgCoDOqFAVwACeHlKDyoLSwIAAACAKgM6oUBXAAJ4eUoPKgtLAgAAAIAqAzqhSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn4B4QFcAAnh5Sg8qD0sDAAAAAAAAAIAqAzqhQFcAAnh5Sg8qD0sDAAAAAAAAAIAqAzqhQFcAAnh5Sg8qD0sDAAAAAAAAAIAqAzqhSgMAAAAAAAAAgC4EIg5KA/////////9/MjIE//////////8AAAAAAAAAAJFKA/////////9/MhQEAAAAAAAAAAABAAAAAAAAAJ+AeEBXAAJ4eaFAVwACeHmhQFcAAnh5oUBXAAJ4eaFAr1Q+hA==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3+AFcAAnh5Sg8qC0sCAAAAgCoDOqFAVwACeHlKDyoLSwIAAACAKgM6oUBXAAJ4eaFKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfgHhAVwACeHlKDyoPSwMAAAAAAAAAgCoDOqFAVwACeHlKDyoPSwMAAAAAAAAAgCoDOqFAVwACeHmhSgMAAAAAAAAAgC4EIg5KA/////////9/MjIE//////////8AAAAAAAAAAJFKA/////////9/MhQEAAAAAAAAAAABAAAAAAAAAJ+AeEBXAAJ4eaFAVwACeHmhQFcAAnh5oUBXAAJ4eaFAYcKZaw==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -28,17 +28,10 @@ public abstract class Contract_DivisionOverflow(Neo.SmartContract.Testing.SmartC
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwACeHlKDyoLSwIAAACAKgM6oUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ+AeEA=
+    /// Script: VwACeHmhSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn4B4QA==
     /// INITSLOT 0002 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// LDARG1 [2 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHM1 [1 datoshi]
-    /// JMPNE 0B [2 datoshi]
-    /// OVER [2 datoshi]
-    /// PUSHINT32 00000080 [1 datoshi]
-    /// JMPNE 03 [2 datoshi]
-    /// THROW [512 datoshi]
     /// DIV [8 datoshi]
     /// DUP [2 datoshi]
     /// PUSHINT32 00000080 [1 datoshi]
@@ -65,17 +58,10 @@ public abstract class Contract_DivisionOverflow(Neo.SmartContract.Testing.SmartC
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwACeHlKDyoPSwMAAAAAAAAAgCoDOqFKAwAAAAAAAACALgQiDkoD/////////38yMgT//////////wAAAAAAAAAAkUoD/////////38yFAQAAAAAAAAAAAEAAAAAAAAAn4B4QA==
+    /// Script: VwACeHmhSgMAAAAAAAAAgC4EIg5KA/////////9/MjIE//////////8AAAAAAAAAAJFKA/////////9/MhQEAAAAAAAAAAABAAAAAAAAAJ+AeEA=
     /// INITSLOT 0002 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// LDARG1 [2 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHM1 [1 datoshi]
-    /// JMPNE 0F [2 datoshi]
-    /// OVER [2 datoshi]
-    /// PUSHINT64 0000000000000080 [1 datoshi]
-    /// JMPNE 03 [2 datoshi]
-    /// THROW [512 datoshi]
     /// DIV [8 datoshi]
     /// DUP [2 datoshi]
     /// PUSHINT64 0000000000000080 [1 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MemberAccess.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MemberAccess.cs
@@ -13,12 +13,12 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MemberAccess"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testMain"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""testComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":59,""safe"":false},{""name"":""testStaticComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":346,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":428,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""itoa""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MemberAccess"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testMain"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""testComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":59,""safe"":false},{""name"":""testStaticComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":330,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":412,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""itoa""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARpdG9hAQABDwAA/bMBVwEAFQwFaGVsbG8QE8BwaBDONwAAQc/nR5YMA21zZ0HP50eWaBHOQc/nR5ZoNAhBz+dHlkBXAAEMAEBXAQAVDAVoZWxsbxATwHBoNYMAAAAPlzloShDOD0oPKgtLAgAAAIAqAzqhSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn05QEFHQEZc5aDRtEJc5aDWlAAAADAZoZWxsbzKXOWhKEc4MAjMzi9soThFQ0AwIaGVsbG8yMzOXOUBXAAF4ShDOnUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OUBBR0EBXAAF4ShLOeBLOk0oCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OElDQQFcAAXhKEc4MATKL2yhOEVDQQBBgWBCXOVicSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn2BYEZc5WQmXOVkIrGFZCJc5WQiT2yBhWQmXOUBWAhNgCWFAgA7IvQ==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARpdG9hAQABDwAA/aMBVwEAFQwFaGVsbG8QE8BwaBDONwAAQc/nR5YMA21zZ0HP50eWaBHOQc/nR5ZoNAhBz+dHlkBXAAEMAEBXAQAVDAVoZWxsbxATwHBoNHMPlzloShDOD6FKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfTlAQUdARlzloNG0QlzloNaUAAAAMBmhlbGxvMpc5aEoRzgwCMzOL2yhOEVDQDAhoZWxsbzIzM5c5QFcAAXhKEM6dSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn05QEFHQQFcAAXhKEs54Es6TSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn04SUNBAVwABeEoRzgwBMovbKE4RUNBAEGBYEJc5WJxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfYFgRlzlZCZc5WQisYVkIlzlZCJPbIGFZCZc5QFYCE2AJYUD9Z5N3").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -28,7 +28,7 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAFQwFaGVsbG8QE8BwaDWDAAAAD5c5aEoQzg9KDyoLSwIAAACAKgM6oUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OUBBR0BGXOWg0bRCXOWg1pQAAAAwGaGVsbG8ylzloShHODAIzM4vbKE4RUNAMCGhlbGxvMjMzlzlA
+    /// Script: VwEAFQwFaGVsbG8QE8BwaDRzD5c5aEoQzg+hSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn05QEFHQEZc5aDRtEJc5aDWlAAAADAZoZWxsbzKXOWhKEc4MAjMzi9soThFQ0AwIaGVsbG8yMzOXOUA=
     /// INITSLOT 0100 [64 datoshi]
     /// PUSH5 [1 datoshi]
     /// PUSHDATA1 68656C6C6F 'hello' [8 datoshi]
@@ -37,7 +37,7 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
     /// PACK [2048 datoshi]
     /// STLOC0 [2 datoshi]
     /// LDLOC0 [2 datoshi]
-    /// CALL_L 83000000 [512 datoshi]
+    /// CALL 73 [512 datoshi]
     /// PUSHM1 [1 datoshi]
     /// EQUAL [32 datoshi]
     /// ASSERT [1 datoshi]
@@ -46,13 +46,6 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
     /// PUSH0 [1 datoshi]
     /// PICKITEM [64 datoshi]
     /// PUSHM1 [1 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHM1 [1 datoshi]
-    /// JMPNE 0B [2 datoshi]
-    /// OVER [2 datoshi]
-    /// PUSHINT32 00000080 [1 datoshi]
-    /// JMPNE 03 [2 datoshi]
-    /// THROW [512 datoshi]
     /// DIV [8 datoshi]
     /// DUP [2 datoshi]
     /// PUSHINT32 00000080 [1 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DivisionOverflow.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DivisionOverflow.cs
@@ -72,16 +72,20 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         /// <summary>
-        /// Test: int.MinValue /= -1 in unchecked context should throw.
+        /// Test: int.MinValue /= -1 in unchecked context shouldn't throw.
         /// Compound division should align with binary division.
         /// </summary>
         [TestMethod]
-        public void Test_DivideAssignUncheckedInt32_Overflow_ShouldThrow()
+        public void Test_DivideAssignUncheckedInt32_ShouldWork()
         {
-            Assert.ThrowsException<TestException>(() =>
+            var r1 = Contract.DivideAssignUncheckedInt32(int.MinValue, -1);
+            Assert.AreEqual(int.MinValue, r1);
+
+            unchecked
             {
-                Contract.DivideAssignUncheckedInt32(int.MinValue, -1);
-            });
+                int r2 = int.MinValue / -1;
+                Assert.AreEqual(int.MinValue, r2); // Should work in unchecked context
+            }
         }
 
         #endregion
@@ -124,16 +128,20 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         /// <summary>
-        /// Test: long.MinValue /= -1 in unchecked context should throw.
+        /// Test: long.MinValue /= -1 in unchecked context shouldn't throw.
         /// Compound division should align with binary division.
         /// </summary>
         [TestMethod]
-        public void Test_DivideAssignUncheckedInt64_Overflow_ShouldThrow()
+        public void Test_DivideAssignUncheckedInt64_ShouldWork()
         {
-            Assert.ThrowsException<TestException>(() =>
+            var r1 = Contract.DivideAssignUncheckedInt64(long.MinValue, -1);
+            Assert.AreEqual(long.MinValue, r1);
+
+            unchecked
             {
-                Contract.DivideAssignUncheckedInt64(long.MinValue, -1);
-            });
+                long r2 = long.MinValue / -1;
+                Assert.AreEqual(long.MinValue, r2); // Should work in unchecked context
+            }
         }
 
         #endregion

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MemberAccess.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MemberAccess.cs
@@ -38,7 +38,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ComplexAssignment()
         {
             Contract.TestComplexAssignment();
-            AssertGasConsumed(2964720);
+            AssertGasConsumed(2964420);
         }
 
         [TestMethod]


### PR DESCRIPTION

Div operation shouldn't throw exception in unchecked context,
and overflow already checked in `EnsureIntegerInRange` for `/=` in checked context.
