### PR TITLE
Fix: remove  unnecessary overflow checking for AND, OR, XOR

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
@@ -291,10 +291,9 @@ internal partial class MethodConvert
             "*=" => (OpCode.MUL, true),
             "/=" => (OpCode.DIV, true),
             "%=" => (OpCode.MOD, true),
-            "&=" => isBoolean ? (OpCode.BOOLAND, false) : (OpCode.AND, true),
-            "^=" when !isBoolean => (OpCode.XOR, true),
-            "^=" when isBoolean => (OpCode.XOR, false),
-            "|=" => isBoolean ? (OpCode.BOOLOR, false) : (OpCode.OR, true),
+            "&=" => isBoolean ? (OpCode.BOOLAND, false) : (OpCode.AND, false),
+            "^=" => (OpCode.XOR, false),
+            "|=" => isBoolean ? (OpCode.BOOLOR, false) : (OpCode.OR, false),
             "<<=" => (OpCode.SHL, true),
             ">>=" => (OpCode.SHR, false),
             _ => throw CompilationException.UnsupportedSyntax(operatorToken, $"Complex assignment operator '{operatorToken.ValueText}' is not supported. Supported operators are: +=, -=, *=, /=, %=, &=, |=, ^=, <<=, and >>=.")

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_ComplexAssign.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_ComplexAssign.cs
@@ -137,6 +137,42 @@ namespace Neo.Compiler.CSharp.TestContracts
             return (value1, value2);
         }
 
+        public static int TestAndAssign(int value, int shift)
+        {
+            value &= shift;
+            return value;
+        }
+
+        public static int TestOrAssign(int value, int shift)
+        {
+            value |= shift;
+            return value;
+        }
+
+        public static int TestXorAssign(int value, int shift)
+        {
+            value ^= shift;
+            return value;
+        }
+
+        public static bool TestBoolXorAssign(bool left, bool right)
+        {
+            left ^= right;
+            return left;
+        }
+
+        public static bool TestBoolAndAssign(bool left, bool right)
+        {
+            left &= right;
+            return left;
+        }
+
+        public static bool TestBoolOrAssign(bool left, bool right)
+        {
+            left |= right;
+            return left;
+        }
+
         public class TestClass
         {
             public byte Property = 7;

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_ComplexAssign.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_ComplexAssign.cs
@@ -13,16 +13,113 @@ public abstract class Contract_ComplexAssign(Neo.SmartContract.Testing.SmartCont
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_ComplexAssign"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unitTest_Add_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":0,""safe"":false},{""name"":""unitTest_Add_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":66,""safe"":false},{""name"":""unitTest_Sub_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":170,""safe"":false},{""name"":""unitTest_Sub_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":228,""safe"":false},{""name"":""unitTest_Mul_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":324,""safe"":false},{""name"":""unitTest_Mul_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":392,""safe"":false},{""name"":""unitTest_Left_Shift_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":498,""safe"":false},{""name"":""unitTest_Left_Shift_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":566,""safe"":false},{""name"":""unitTest_Right_Shift_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":672,""safe"":false},{""name"":""unitTest_Right_Shift_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":696,""safe"":false},{""name"":""unitTest_Member_Element_Complex_Assign"",""parameters"":[],""returntype"":""Void"",""offset"":720,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_ComplexAssign"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""unitTest_Add_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":0,""safe"":false},{""name"":""unitTest_Add_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":66,""safe"":false},{""name"":""unitTest_Sub_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":170,""safe"":false},{""name"":""unitTest_Sub_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":228,""safe"":false},{""name"":""unitTest_Mul_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":324,""safe"":false},{""name"":""unitTest_Mul_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":392,""safe"":false},{""name"":""unitTest_Left_Shift_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":498,""safe"":false},{""name"":""unitTest_Left_Shift_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":566,""safe"":false},{""name"":""unitTest_Right_Shift_Assign_Checked"",""parameters"":[],""returntype"":""Array"",""offset"":672,""safe"":false},{""name"":""unitTest_Right_Shift_Assign_UnChecked"",""parameters"":[],""returntype"":""Array"",""offset"":696,""safe"":false},{""name"":""testAndAssign"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":720,""safe"":false},{""name"":""testOrAssign"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":729,""safe"":false},{""name"":""testXorAssign"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":738,""safe"":false},{""name"":""testBoolXorAssign"",""parameters"":[{""name"":""left"",""type"":""Boolean""},{""name"":""right"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":747,""safe"":false},{""name"":""testBoolAndAssign"",""parameters"":[{""name"":""left"",""type"":""Boolean""},{""name"":""right"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":758,""safe"":false},{""name"":""testBoolOrAssign"",""parameters"":[{""name"":""left"",""type"":""Boolean""},{""name"":""right"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":767,""safe"":false},{""name"":""unitTest_Member_Element_Complex_Assign"",""parameters"":[],""returntype"":""Void"",""offset"":776,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0nA1cCAAP/////AAAAAHAC////f3FonEoQLgM6SgP/////AAAAADIDOnBpnEoCAAAAgC4DOkoC////fzIDOnFpaBK/QFcCAAP/////AAAAAHAC////f3FonEoQLgQiDkoD/////wAAAAAyDAP/////AAAAAJFwaZxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcWloEr9AVwIAEHACAAAAgHFonUoQLgM6SgP/////AAAAADIDOnBpnUoCAAAAgC4DOkoC////fzIDOnFpaBK/QFcCABBwAgAAAIBxaJ1KEC4EIg5KA/////8AAAAAMgwD/////wAAAACRcGmdSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FpaBK/QFcCAAP/////AAAAAHAC////f3FoEqBKEC4DOkoD/////wAAAAAyAzpwaRKgSgIAAACALgM6SgL///9/MgM6cWloEr9AVwIAA/////8AAAAAcAL///9/cWgSoEoQLgQiDkoD/////wAAAAAyDAP/////AAAAAJFwaRKgSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FpaBK/QFcCAAP/////AAAAAHAC////f3FoEahKEC4DOkoD/////wAAAAAyAzpwaRGoSgIAAACALgM6SgL///9/MgM6cWloEr9AVwIAA/////8AAAAAcAL///9/cWgRqEoQLgQiDkoD/////wAAAAAyDAP/////AAAAAJFwaRGoSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FpaBK/QFcCABBwAgAAAIBxaBGpcGkRqXFpaBK/QFcCABBwAgAAAIBxaBGpcGkRqXFpaBK/QFcBAAwEAAECA9swFxLAcGhKEM4TokoQLgQiCEoB/wAyBgH/AJFOEFDQRWgQzhGXOWgRzhNLS84UkUoQLgQiCEoB/wAyBgH/AJFKVFPQRWgRzhDOEJc5QL55Q4k=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP1PA1cCAAP/////AAAAAHAC////f3FonEoQLgM6SgP/////AAAAADIDOnBpnEoCAAAAgC4DOkoC////fzIDOnFpaBK/QFcCAAP/////AAAAAHAC////f3FonEoQLgQiDkoD/////wAAAAAyDAP/////AAAAAJFwaZxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcWloEr9AVwIAEHACAAAAgHFonUoQLgM6SgP/////AAAAADIDOnBpnUoCAAAAgC4DOkoC////fzIDOnFpaBK/QFcCABBwAgAAAIBxaJ1KEC4EIg5KA/////8AAAAAMgwD/////wAAAACRcGmdSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FpaBK/QFcCAAP/////AAAAAHAC////f3FoEqBKEC4DOkoD/////wAAAAAyAzpwaRKgSgIAAACALgM6SgL///9/MgM6cWloEr9AVwIAA/////8AAAAAcAL///9/cWgSoEoQLgQiDkoD/////wAAAAAyDAP/////AAAAAJFwaRKgSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FpaBK/QFcCAAP/////AAAAAHAC////f3FoEahKEC4DOkoD/////wAAAAAyAzpwaRGoSgIAAACALgM6SgL///9/MgM6cWloEr9AVwIAA/////8AAAAAcAL///9/cWgRqEoQLgQiDkoD/////wAAAAAyDAP/////AAAAAJFwaRGoSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FpaBK/QFcCABBwAgAAAIBxaBGpcGkRqXFpaBK/QFcCABBwAgAAAIBxaBGpcGkRqXFpaBK/QFcAAnh5kYB4QFcAAnh5koB4QFcAAnh5k4B4QFcAAnh5k9sggHhAVwACeHmrgHhAVwACeHmsgHhAVwEADAQAAQID2zAXEsBwaEoQzhOiShAuBCIISgH/ADIGAf8AkU4QUNBFaBDOEZc5aBHOE0tLzhSRSlRT0EVoEc4QzhCXOUBpLpO/").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
     #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHmRgHhA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// AND [8 datoshi]
+    /// STARG0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testAndAssign")]
+    public abstract BigInteger? TestAndAssign(BigInteger? value, BigInteger? shift);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHmrgHhA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// BOOLAND [8 datoshi]
+    /// STARG0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testBoolAndAssign")]
+    public abstract bool? TestBoolAndAssign(bool? left, bool? right);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHmsgHhA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// BOOLOR [8 datoshi]
+    /// STARG0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testBoolOrAssign")]
+    public abstract bool? TestBoolOrAssign(bool? left, bool? right);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHmT2yCAeEA=
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// XOR [8 datoshi]
+    /// CONVERT 20 'Boolean' [8192 datoshi]
+    /// STARG0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testBoolXorAssign")]
+    public abstract bool? TestBoolXorAssign(bool? left, bool? right);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHmSgHhA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// OR [8 datoshi]
+    /// STARG0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testOrAssign")]
+    public abstract BigInteger? TestOrAssign(BigInteger? value, BigInteger? shift);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHmTgHhA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// XOR [8 datoshi]
+    /// STARG0 [2 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testXorAssign")]
+    public abstract BigInteger? TestXorAssign(BigInteger? value, BigInteger? shift);
 
     /// <summary>
     /// Unsafe method
@@ -210,7 +307,7 @@ public abstract class Contract_ComplexAssign(Neo.SmartContract.Testing.SmartCont
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEADAQAAQID2zAXEsBwaEoQzhOiShAuBCIISgH/ADIGAf8AkU4QUNBFaBDOEZc5aBHOE0tLzhSRShAuBCIISgH/ADIGAf8AkUpUU9BFaBHOEM4QlzlA
+    /// Script: VwEADAQAAQID2zAXEsBwaEoQzhOiShAuBCIISgH/ADIGAf8AkU4QUNBFaBDOEZc5aBHOE0tLzhSRSlRT0EVoEc4QzhCXOUA=
     /// INITSLOT 0100 [64 datoshi]
     /// PUSHDATA1 00010203 [8 datoshi]
     /// CONVERT 30 'Buffer' [8192 datoshi]
@@ -252,15 +349,6 @@ public abstract class Contract_ComplexAssign(Neo.SmartContract.Testing.SmartCont
     /// OVER [2 datoshi]
     /// PICKITEM [64 datoshi]
     /// PUSH4 [1 datoshi]
-    /// AND [8 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSH0 [1 datoshi]
-    /// JMPGE 04 [2 datoshi]
-    /// JMP 08 [2 datoshi]
-    /// DUP [2 datoshi]
-    /// PUSHINT16 FF00 [1 datoshi]
-    /// JMPLE 06 [2 datoshi]
-    /// PUSHINT16 FF00 [1 datoshi]
     /// AND [8 datoshi]
     /// DUP [2 datoshi]
     /// REVERSE4 [2 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MemberAccess.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_MemberAccess.cs
@@ -13,12 +13,12 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MemberAccess"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testMain"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""testComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":59,""safe"":false},{""name"":""testStaticComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":346,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":428,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""itoa""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_MemberAccess"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testMain"",""parameters"":[],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""testComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":59,""safe"":false},{""name"":""testStaticComplexAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":294,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":376,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""itoa""]}],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARpdG9hAQABDwAA/bMBVwEAFQwFaGVsbG8QE8BwaBDONwAAQc/nR5YMA21zZ0HP50eWaBHOQc/nR5ZoNAhBz+dHlkBXAAEMAEBXAQAVDAVoZWxsbxATwHBoNYMAAAAPlzloShDOD0oPKgtLAgAAAIAqAzqhSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn05QEFHQEZc5aDRtEJc5aDWlAAAADAZoZWxsbzKXOWhKEc4MAjMzi9soThFQ0AwIaGVsbG8yMzOXOUBXAAF4ShDOnUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OUBBR0EBXAAF4ShLOeBLOk0oCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OElDQQFcAAXhKEc4MATKL2yhOEVDQQBBgWBCXOVicSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn2BYEZc5WQmXOVkIrGFZCJc5WQiT2yBhWQmXOUBWAhNgCWFAgA7IvQ==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARpdG9hAQABDwAA/X8BVwEAFQwFaGVsbG8QE8BwaBDONwAAQc/nR5YMA21zZ0HP50eWaBHOQc/nR5ZoNAhBz+dHlkBXAAEMAEBXAQAVDAVoZWxsbxATwHBoNH0PlzloShDOD0oPKgtLAgAAAIAqAzqhSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn05QEFHQEZc5aDRqEJc5aDR0DAZoZWxsbzKXOWhKEc4MAjMzi9soThFQ0AwIaGVsbG8yMzOXOUBXAAF4ShDOnUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OUBBR0EBXAAF4ShLOeBLOk04SUNBAVwABeEoRzgwBMovbKE4RUNBAEGBYEJc5WJxKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfYFgRlzlZCZc5WQisYVkIlzlZCJPbIGFZCZc5QFYCE2AJYUBMJg4o").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -28,7 +28,7 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAFQwFaGVsbG8QE8BwaDWDAAAAD5c5aEoQzg9KDyoLSwIAAACAKgM6oUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OUBBR0BGXOWg0bRCXOWg1pQAAAAwGaGVsbG8ylzloShHODAIzM4vbKE4RUNAMCGhlbGxvMjMzlzlA
+    /// Script: VwEAFQwFaGVsbG8QE8BwaDR9D5c5aEoQzg9KDyoLSwIAAACAKgM6oUoCAAAAgC4EIgpKAv///38yHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9OUBBR0BGXOWg0ahCXOWg0dAwGaGVsbG8ylzloShHODAIzM4vbKE4RUNAMCGhlbGxvMjMzlzlA
     /// INITSLOT 0100 [64 datoshi]
     /// PUSH5 [1 datoshi]
     /// PUSHDATA1 68656C6C6F 'hello' [8 datoshi]
@@ -37,7 +37,7 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
     /// PACK [2048 datoshi]
     /// STLOC0 [2 datoshi]
     /// LDLOC0 [2 datoshi]
-    /// CALL_L 83000000 [512 datoshi]
+    /// CALL 7D [512 datoshi]
     /// PUSHM1 [1 datoshi]
     /// EQUAL [32 datoshi]
     /// ASSERT [1 datoshi]
@@ -77,12 +77,12 @@ public abstract class Contract_MemberAccess(Neo.SmartContract.Testing.SmartContr
     /// EQUAL [32 datoshi]
     /// ASSERT [1 datoshi]
     /// LDLOC0 [2 datoshi]
-    /// CALL 6D [512 datoshi]
+    /// CALL 6A [512 datoshi]
     /// PUSH0 [1 datoshi]
     /// EQUAL [32 datoshi]
     /// ASSERT [1 datoshi]
     /// LDLOC0 [2 datoshi]
-    /// CALL_L A5000000 [512 datoshi]
+    /// CALL 74 [512 datoshi]
     /// PUSHDATA1 68656C6C6F32 'hello2' [8 datoshi]
     /// EQUAL [32 datoshi]
     /// ASSERT [1 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract_ComplexAssign.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Contract_ComplexAssign.cs
@@ -107,7 +107,67 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_Member_Element_Complex_Assign()
         {
             Contract.UnitTest_Member_Element_Complex_Assign();
-            AssertGasConsumed(1800780);
+            AssertGasConsumed(1800480);
+        }
+
+        [TestMethod]
+        public void Test_AndAssign()
+        {
+            Assert.AreEqual(0, Contract.TestAndAssign(1, 2));
+            AssertGasConsumed(1047480);
+        }
+
+        [TestMethod]
+        public void Test_OrAssign()
+        {
+            Assert.AreEqual(3, Contract.TestOrAssign(1, 2));
+            AssertGasConsumed(1047480);
+        }
+
+        [TestMethod]
+        public void Test_XorAssign()
+        {
+            Assert.AreEqual(3, Contract.TestXorAssign(1, 2));
+            AssertGasConsumed(1047480);
+        }
+
+        [TestMethod]
+        public void Test_BoolXorAssign()
+        {
+            Assert.AreEqual(true, Contract.TestBoolXorAssign(true, false));
+            AssertGasConsumed(1293240);
+
+            Assert.AreEqual(false, Contract.TestBoolXorAssign(false, false));
+            AssertGasConsumed(1293240);
+
+            Assert.AreEqual(false, Contract.TestBoolXorAssign(true, true));
+            AssertGasConsumed(1293240);
+        }
+
+        [TestMethod]
+        public void Test_BoolAndAssign()
+        {
+            Assert.AreEqual(false, Contract.TestBoolAndAssign(true, false));
+            AssertGasConsumed(1047480);
+
+            Assert.AreEqual(false, Contract.TestBoolAndAssign(false, false));
+            AssertGasConsumed(1047480);
+
+            Assert.AreEqual(true, Contract.TestBoolAndAssign(true, true));
+            AssertGasConsumed(1047480);
+        }
+
+        [TestMethod]
+        public void Test_BoolOrAssign()
+        {
+            Assert.AreEqual(true, Contract.TestBoolOrAssign(true, false));
+            AssertGasConsumed(1047480);
+
+            Assert.AreEqual(false, Contract.TestBoolOrAssign(false, false));
+            AssertGasConsumed(1047480);
+
+            Assert.AreEqual(true, Contract.TestBoolOrAssign(true, true));
+            AssertGasConsumed(1047480);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MemberAccess.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_MemberAccess.cs
@@ -38,7 +38,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void Test_ComplexAssignment()
         {
             Contract.TestComplexAssignment();
-            AssertGasConsumed(2964720);
+            AssertGasConsumed(2964420);
         }
 
         [TestMethod]


### PR DESCRIPTION

 Remove unnecessary overflow checking for AND, OR, XOR for less GAS consumption.

Because no overflow for AND, OR and XOR.