### PR TITLE
Fix: `ECPoint.IsValid` should return false if not valid type or null

### DIFF
--- a/src/Neo.SmartContract.Framework/ECPoint.cs
+++ b/src/Neo.SmartContract.Framework/ECPoint.cs
@@ -17,15 +17,22 @@ namespace Neo.SmartContract.Framework
 {
     public abstract class ECPoint : ByteString
     {
+        /// <summary>
+        /// Checks if the value is valid.
+        /// It returns true if the value is a 33 bytes compressed public key, false otherwise.
+        /// It only checks the length and type, not the actual validity of the public key.
+        /// </summary>
         public extern bool IsValid
         {
             [OpCode(OpCode.DUP)]
-            [OpCode(OpCode.ISTYPE, "0x28")] //ByteString
-            [OpCode(OpCode.SWAP)]
-            [OpCode(OpCode.SIZE)]
+            [OpCode(OpCode.ISTYPE, "0x28")] // ByteString
+            [OpCode(OpCode.JMPIF, "06")]    // Jump to SIZE
+            [OpCode(OpCode.DROP)]
+            [OpCode(OpCode.PUSHF)]          // Push false if is not a ByteString
+            [OpCode(OpCode.JMP, "06")]      // Jump to the end
+            [OpCode(OpCode.SIZE)]           // Get the size of the ByteString
             [OpCode(OpCode.PUSHINT8, "21")] // 0x21 == 33 bytes expected array size
-            [OpCode(OpCode.NUMEQUAL)]
-            [OpCode(OpCode.BOOLAND)]
+            [OpCode(OpCode.NUMEQUAL)]       // Check if the size is 33 bytes
             get;
         }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Types_ECPoint.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Types_ECPoint.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Types_ECPoint(Neo.SmartContract.Testing.SmartCont
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Types_ECPoint"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""isValid"",""parameters"":[{""name"":""point"",""type"":""PublicKey""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""ecpoint2String"",""parameters"":[],""returntype"":""String"",""offset"":14,""safe"":false},{""name"":""ecpointReturn"",""parameters"":[],""returntype"":""PublicKey"",""offset"":50,""safe"":false},{""name"":""ecpoint2ByteArray"",""parameters"":[],""returntype"":""Any"",""offset"":86,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Types_ECPoint"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""isValid"",""parameters"":[{""name"":""point"",""type"":""PublicKey""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""ecpoint2String"",""parameters"":[],""returntype"":""String"",""offset"":17,""safe"":false},{""name"":""ecpointReturn"",""parameters"":[],""returntype"":""PublicKey"",""offset"":53,""safe"":false},{""name"":""ecpoint2ByteArray"",""parameters"":[],""returntype"":""Any"",""offset"":89,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.9.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHxXAAF4StkoUMoAIbOrQAwhAkcA2y6Q2fAsT5/IYqusqScl+VtP3cyNf/pThpPs9GOpQAwhAkcA2y6Q2fAsT5/IYqusqScl+VtP3cyNf/pThpPs9GOpQAwhAkcA2y6Q2fAsT5/IYqusqScl+VtP3cyNf/pThpPs9GOp2zBAoqDnkA==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH9XAAF4StkoJAVFCUDKACGzQAwhAkcA2y6Q2fAsT5/IYqusqScl+VtP3cyNf/pThpPs9GOpQAwhAkcA2y6Q2fAsT5/IYqusqScl+VtP3cyNf/pThpPs9GOpQAwhAkcA2y6Q2fAsT5/IYqusqScl+VtP3cyNf/pThpPs9GOp2zBAPg6a2w==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -62,16 +62,18 @@ public abstract class Contract_Types_ECPoint(Neo.SmartContract.Testing.SmartCont
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeErZKFDKACGzq0A=
+    /// Script: VwABeErZKCQFRQlAygAhs0A=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
     /// ISTYPE 28 'ByteString' [2 datoshi]
-    /// SWAP [2 datoshi]
+    /// JMPIF 05 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHF [1 datoshi]
+    /// RET [0 datoshi]
     /// SIZE [4 datoshi]
     /// PUSHINT8 21 [1 datoshi]
     /// NUMEQUAL [8 datoshi]
-    /// BOOLAND [8 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("isValid")]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types_ECPoint.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Types_ECPoint.cs
@@ -12,7 +12,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Extensions;
 using Neo.SmartContract.Testing;
-using Neo.SmartContract.Testing.Exceptions;
 using Neo.SmartContract.Testing.Interpreters;
 using Neo.SmartContract.Testing.InvalidTypes;
 
@@ -25,13 +24,13 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void ECPoint_test()
         {
             Assert.IsFalse(Contract.IsValid(InvalidECPoint.InvalidLength));
-            AssertGasConsumed(1048050);
+            AssertGasConsumed(1047810);
             Assert.IsFalse(Contract.IsValid(InvalidECPoint.InvalidType));
-            AssertGasConsumed(1047840);
-            Assert.ThrowsException<TestException>(() => Contract.IsValid(InvalidECPoint.Null));
-            AssertGasConsumed(1047330);
+            AssertGasConsumed(1047300);
+            Assert.IsFalse(Contract.IsValid(InvalidECPoint.Null));
+            AssertGasConsumed(1047300);
             Assert.IsTrue(Contract.IsValid(Cryptography.ECC.ECPoint.Parse("024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9", Cryptography.ECC.ECCurve.Secp256r1)));
-            AssertGasConsumed(1048050);
+            AssertGasConsumed(1047810);
 
             Engine.StringInterpreter = new HexStringInterpreter();
 


### PR DESCRIPTION

`ECPoint.IsValid` should return false rather than execution failure if the value is null or invalid type.
