### PR TITLE
Validate contract output base names

### DIFF
--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -436,14 +436,20 @@ namespace Neo.Compiler
                 else
                     Console.WriteLine(diagnostic.ToString());
             }
-            if (context.Success)
-            {
-                string outputFolder = options.Output ?? Path.Combine(folder, "bin", "sc");
-                string baseName = context.ContractName!;
+                if (context.Success)
+                {
+                    string outputFolder = options.Output ?? Path.Combine(folder, "bin", "sc");
+                    string baseName = context.ContractName!;
 
-                NefFile nef;
-                ContractManifest manifest;
-                JToken debugInfo;
+                    if (!IsSafeOutputBaseName(baseName))
+                    {
+                        Console.Error.WriteLine($"Invalid output base name '{baseName}'. The output base name must be a file name and cannot contain directory separators or invalid file name characters.");
+                        return 1;
+                    }
+
+                    NefFile nef;
+                    ContractManifest manifest;
+                    JToken debugInfo;
                 try
                 {
                     (nef, manifest, debugInfo) = context.CreateResults(folder);
@@ -654,6 +660,14 @@ namespace Neo.Compiler
                 Console.Error.WriteLine("Compilation failed.");
                 return 1;
             }
+        }
+
+        private static bool IsSafeOutputBaseName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+            if (value.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) return false;
+            if (value.Contains('/') || value.Contains('\\')) return false;
+            return Path.GetFileName(value) == value;
         }
 
         private static bool TryFileOperation(string operation, string target, Action action)

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -436,20 +436,20 @@ namespace Neo.Compiler
                 else
                     Console.WriteLine(diagnostic.ToString());
             }
-                if (context.Success)
+            if (context.Success)
+            {
+                string outputFolder = options.Output ?? Path.Combine(folder, "bin", "sc");
+                string baseName = context.ContractName!;
+
+                if (!IsSafeOutputBaseName(baseName))
                 {
-                    string outputFolder = options.Output ?? Path.Combine(folder, "bin", "sc");
-                    string baseName = context.ContractName!;
+                    Console.Error.WriteLine($"Invalid output base name '{baseName}'. The output base name must be a file name and cannot contain directory separators or invalid file name characters.");
+                    return 1;
+                }
 
-                    if (!IsSafeOutputBaseName(baseName))
-                    {
-                        Console.Error.WriteLine($"Invalid output base name '{baseName}'. The output base name must be a file name and cannot contain directory separators or invalid file name characters.");
-                        return 1;
-                    }
-
-                    NefFile nef;
-                    ContractManifest manifest;
-                    JToken debugInfo;
+                NefFile nef;
+                ContractManifest manifest;
+                JToken debugInfo;
                 try
                 {
                     (nef, manifest, debugInfo) = context.CreateResults(folder);

--- a/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OutputNameSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OutputNameSecurity.cs
@@ -65,6 +65,29 @@ public class Contract : SmartContract
             Assert.IsFalse(Directory.EnumerateFiles(workspace.ProjectDirectory, "outside-name.*").Any());
         }
 
+        [TestMethod]
+        public void TestBaseNameRejectsEmptyAndInvalidFileNameCharacters()
+        {
+            using var workspace = TempWorkspace.Create();
+            string projectPath = workspace.CreateProject("""
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+
+            string outputPath = Path.Combine(workspace.ProjectDirectory, "out");
+
+            int whitespaceExitCode = Program.Main([projectPath, "--debug", "None", "--base-name", " ", "-o", outputPath]);
+            int invalidCharExitCode = Program.Main([projectPath, "--debug", "None", "--base-name", "bad\0name", "-o", outputPath]);
+
+            Assert.AreEqual(1, whitespaceExitCode);
+            Assert.AreEqual(1, invalidCharExitCode);
+            Assert.IsFalse(Directory.EnumerateFiles(workspace.ProjectDirectory, "*.nef", SearchOption.AllDirectories).Any());
+        }
+
         private sealed class TempWorkspace : IDisposable
         {
             public string Root { get; }

--- a/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OutputNameSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OutputNameSecurity.cs
@@ -1,0 +1,128 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_OutputNameSecurity.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests.Peripheral
+{
+    [TestClass]
+    public class UnitTest_OutputNameSecurity
+    {
+        [TestMethod]
+        public void TestContractDisplayNameCannotEscapeOutputFolder()
+        {
+            using var workspace = TempWorkspace.Create();
+            string projectPath = workspace.CreateProject("""
+using Neo.SmartContract.Framework;
+using System.ComponentModel;
+
+[DisplayName("../outside-name")]
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+
+            string outputPath = Path.Combine(workspace.ProjectDirectory, "out");
+
+            int exitCode = Program.Main([projectPath, "--debug", "None", "-o", outputPath]);
+
+            Assert.AreEqual(1, exitCode);
+            Assert.IsFalse(File.Exists(Path.Combine(workspace.ProjectDirectory, "outside-name.nef")));
+            Assert.IsFalse(Directory.EnumerateFiles(workspace.ProjectDirectory, "outside-name.*").Any());
+        }
+
+        [TestMethod]
+        public void TestBaseNameCannotEscapeOutputFolder()
+        {
+            using var workspace = TempWorkspace.Create();
+            string projectPath = workspace.CreateProject("""
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+
+            string outputPath = Path.Combine(workspace.ProjectDirectory, "out");
+
+            int exitCode = Program.Main([projectPath, "--debug", "None", "--base-name", "../outside-name", "-o", outputPath]);
+
+            Assert.AreEqual(1, exitCode);
+            Assert.IsFalse(File.Exists(Path.Combine(workspace.ProjectDirectory, "outside-name.nef")));
+            Assert.IsFalse(Directory.EnumerateFiles(workspace.ProjectDirectory, "outside-name.*").Any());
+        }
+
+        private sealed class TempWorkspace : IDisposable
+        {
+            public string Root { get; }
+            public string ProjectDirectory { get; }
+
+            private TempWorkspace(string root)
+            {
+                Root = root;
+                ProjectDirectory = Path.Combine(root, "ContractProject");
+                Directory.CreateDirectory(ProjectDirectory);
+            }
+
+            public static TempWorkspace Create()
+            {
+                string root = Path.Combine(Path.GetTempPath(), $"NeoOutputNameSecurity_{Guid.NewGuid():N}");
+                Directory.CreateDirectory(root);
+                return new TempWorkspace(root);
+            }
+
+            public string CreateProject(string source)
+            {
+                string frameworkProject = Path.GetFullPath(Path.Combine(
+                    Directory.GetCurrentDirectory(),
+                    "..", "..", "..", "..", "..",
+                    "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj"));
+
+                string projectPath = Path.Combine(ProjectDirectory, "ContractProject.csproj");
+                File.WriteAllText(projectPath, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{{frameworkProject}}" />
+  </ItemGroup>
+</Project>
+""");
+                File.WriteAllText(Path.Combine(ProjectDirectory, "Contract.cs"), source);
+                return projectPath;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(Root))
+                    {
+                        Directory.Delete(Root, true);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Summary
- Reject output base names that contain path separators or invalid file name characters.
- Add coverage for contract DisplayName and base-name output paths.

Tests
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_OutputNameSecurity --verbosity minimal