### PR TITLE
Honor Compile Remove items

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -23,6 +23,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -455,24 +456,23 @@ namespace Neo.Compiler
             ExtractVersionInfo(document, Path.GetDirectoryName(csproj)!);
 
             var remove = document.Root!.Elements("ItemGroup").Elements("Compile").Attributes("Remove")
-                .Select(p => p.Value.Contains('*') ? p.Value : Path.GetFullPath(p.Value)).ToArray();
+                .SelectMany(p => SplitItemSpec(p.Value))
+                .Select(p => CompileRemovePattern.Create(folder, p))
+                .ToArray();
             var sourceFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            if (!remove.Contains("*.cs"))
+            var obj = Path.Combine(folder, "obj");
+            var binSc = Path.Combine(folder, "bin");
+            foreach (var entry in Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories)
+                  .Where(p => !IsInDirectory(p, obj) && !IsInDirectory(p, binSc))
+                  .Select(Path.GetFullPath))
             {
-                var obj = Path.Combine(folder, "obj");
-                var binSc = Path.Combine(folder, "bin");
-                foreach (var entry in Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories)
-                      .Where(p => !p.StartsWith(obj) && !p.StartsWith(binSc))
-                      .Select(u => u))
-                //.GroupBy(Path.GetFileName)
-                //.Select(g => g.First()))
-                {
-                    if (!remove.Contains(entry)) sourceFiles.Add(entry);
-                }
+                if (!remove.Any(pattern => pattern.IsMatch(entry))) sourceFiles.Add(entry);
             }
 
-            sourceFiles.UnionWith(document.Root!.Elements("ItemGroup").Elements("Compile").Attributes("Include").Select(p => Path.GetFullPath(p.Value, folder)));
+            sourceFiles.UnionWith(document.Root!.Elements("ItemGroup").Elements("Compile").Attributes("Include")
+                .SelectMany(p => SplitItemSpec(p.Value))
+                .Select(p => Path.GetFullPath(p, folder)));
             var assets = (JObject)JToken.Parse(File.ReadAllBytes(assetsPath))!;
             List<MetadataReference> references = new(CommonReferences);
             CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, deterministic: true, nullableContextOptions: Options.Nullable, allowUnsafe: false);
@@ -483,6 +483,95 @@ namespace Neo.Compiler
             }
             IEnumerable<SyntaxTree> syntaxTrees = sourceFiles.OrderBy(p => p).Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), options: Options.GetParseOptions(), path: p));
             return CSharpCompilation.Create(assets["project"]!["restore"]!["projectName"]!.GetString(), syntaxTrees, references, compilationOptions);
+        }
+
+        private static IEnumerable<string> SplitItemSpec(string value)
+        {
+            return value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        private static bool IsInDirectory(string path, string directory)
+        {
+            string relative = Path.GetRelativePath(directory, path);
+            return relative != "." && relative != ".." && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) && !Path.IsPathRooted(relative);
+        }
+
+        private sealed class CompileRemovePattern
+        {
+            private readonly string _projectFolder;
+            private readonly string? _fullPath;
+            private readonly Regex? _relativeRegex;
+
+            private CompileRemovePattern(string projectFolder, string? fullPath, Regex? relativeRegex)
+            {
+                _projectFolder = projectFolder;
+                _fullPath = fullPath;
+                _relativeRegex = relativeRegex;
+            }
+
+            public static CompileRemovePattern Create(string projectFolder, string pattern)
+            {
+                if (pattern.IndexOfAny(['*', '?']) < 0)
+                {
+                    return new CompileRemovePattern(projectFolder, NormalizePath(Path.GetFullPath(pattern, projectFolder)), null);
+                }
+
+                string normalizedPattern = NormalizeRelativePattern(pattern);
+                var regex = new Regex("^" + WildcardToRegex(normalizedPattern) + "$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                return new CompileRemovePattern(projectFolder, null, regex);
+            }
+
+            public bool IsMatch(string fullPath)
+            {
+                string normalizedFullPath = NormalizePath(fullPath);
+                if (_fullPath is not null) return string.Equals(normalizedFullPath, _fullPath, StringComparison.OrdinalIgnoreCase);
+
+                string relativePath = NormalizeRelativePattern(Path.GetRelativePath(_projectFolder, fullPath));
+                return _relativeRegex!.IsMatch(relativePath);
+            }
+
+            private static string NormalizePath(string path) => Path.GetFullPath(path).Replace('\\', '/');
+
+            private static string NormalizeRelativePattern(string pattern) => pattern.Replace('\\', '/');
+
+            private static string WildcardToRegex(string pattern)
+            {
+                var builder = new StringBuilder();
+                for (int i = 0; i < pattern.Length; i++)
+                {
+                    char current = pattern[i];
+                    if (current == '*')
+                    {
+                        if (i + 1 < pattern.Length && pattern[i + 1] == '*')
+                        {
+                            i++;
+                            if (i + 1 < pattern.Length && pattern[i + 1] == '/')
+                            {
+                                i++;
+                                builder.Append("(?:.*/)?");
+                            }
+                            else
+                            {
+                                builder.Append(".*");
+                            }
+                        }
+                        else
+                        {
+                            builder.Append("[^/]*");
+                        }
+                    }
+                    else if (current == '?')
+                    {
+                        builder.Append("[^/]");
+                    }
+                    else
+                    {
+                        builder.Append(Regex.Escape(current.ToString()));
+                    }
+                }
+
+                return builder.ToString();
+            }
         }
 
         private MetadataReference? GetReference(string name, JObject package, JObject assets, string folder, CSharpCompilationOptions compilationOptions)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
@@ -100,6 +100,64 @@ public class BetaContract : SmartContract
     }
 
     [TestMethod]
+    public void GetCompilation_HonorsRelativeCompileRemove()
+    {
+        using var project = TempContractProject.Create("""
+  <ItemGroup>
+    <Compile Remove="Excluded.cs" />
+  </ItemGroup>
+""");
+        project.WriteSource("Contract.cs", """
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+        project.WriteSource("Excluded.cs", """
+public class Excluded
+{
+}
+""");
+
+        var compilation = new CompilationEngine(new CompilationOptions()).GetCompilation(project.ProjectFile);
+
+        CollectionAssert.DoesNotContain(
+            compilation.SyntaxTrees.Select(tree => Path.GetFileName(tree.FilePath)).ToArray(),
+            "Excluded.cs");
+    }
+
+    [TestMethod]
+    public void GetCompilation_HonorsWildcardCompileRemove()
+    {
+        using var project = TempContractProject.Create("""
+  <ItemGroup>
+    <Compile Remove="Excluded*.cs" />
+  </ItemGroup>
+""");
+        project.WriteSource("Contract.cs", """
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+        project.WriteSource("ExcludedOne.cs", """
+public class ExcludedOne
+{
+}
+""");
+
+        var compilation = new CompilationEngine(new CompilationOptions()).GetCompilation(project.ProjectFile);
+
+        CollectionAssert.DoesNotContain(
+            compilation.SyntaxTrees.Select(tree => Path.GetFileName(tree.FilePath)).ToArray(),
+            "ExcludedOne.cs");
+    }
+
+    [TestMethod]
     public void UnsupportedDependencyAssetTypeIncludesContext()
     {
         const string dependencyName = "bad.asset/1.0.0";
@@ -139,5 +197,51 @@ public class BetaContract : SmartContract
         var innerException = (NotSupportedException)exception.InnerException!;
         StringAssert.Contains(innerException.Message, assetType);
         StringAssert.Contains(innerException.Message, dependencyName);
+    }
+
+    private sealed class TempContractProject : IDisposable
+    {
+        public string ProjectDirectory { get; }
+        public string ProjectFile { get; }
+
+        private TempContractProject(string projectDirectory, string projectFile)
+        {
+            ProjectDirectory = projectDirectory;
+            ProjectFile = projectFile;
+        }
+
+        public static TempContractProject Create(string extraProjectItems)
+        {
+            var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempFolder);
+            var projectFile = Path.Combine(tempFolder, "ContractProject.csproj");
+            var repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            File.WriteAllText(projectFile, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{{frameworkProject}}" />
+  </ItemGroup>
+{{extraProjectItems}}
+</Project>
+""");
+
+            return new TempContractProject(tempFolder, projectFile);
+        }
+
+        public void WriteSource(string name, string source)
+        {
+            File.WriteAllText(Path.Combine(ProjectDirectory, name), source);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(ProjectDirectory, recursive: true);
+        }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReference.cs
@@ -158,6 +158,106 @@ public class ExcludedOne
     }
 
     [TestMethod]
+    public void GetCompilation_HonorsSemicolonSeparatedCompileItems()
+    {
+        using var project = TempContractProject.Create("""
+  <ItemGroup>
+    <Compile Remove="*.cs" />
+    <Compile Include="IncludedOne.cs;IncludedTwo.cs" />
+  </ItemGroup>
+""");
+        project.WriteSource("IncludedOne.cs", """
+using Neo.SmartContract.Framework;
+
+public class IncludedOne : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+        project.WriteSource("IncludedTwo.cs", """
+public class IncludedTwo
+{
+}
+""");
+        project.WriteSource("Excluded.cs", """
+public class Excluded
+{
+}
+""");
+
+        var compilation = new CompilationEngine(new CompilationOptions()).GetCompilation(project.ProjectFile);
+        var sourceFileNames = compilation.SyntaxTrees.Select(tree => Path.GetFileName(tree.FilePath)).ToArray();
+
+        CollectionAssert.Contains(sourceFileNames, "IncludedOne.cs");
+        CollectionAssert.Contains(sourceFileNames, "IncludedTwo.cs");
+        CollectionAssert.DoesNotContain(sourceFileNames, "Excluded.cs");
+    }
+
+    [TestMethod]
+    public void GetCompilation_HonorsRecursiveAndQuestionWildcardCompileRemove()
+    {
+        using var project = TempContractProject.Create("""
+  <ItemGroup>
+    <Compile Remove="**/Excluded?.cs;Nested/**.cs" />
+  </ItemGroup>
+""");
+        project.WriteSource("Contract.cs", """
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+        project.WriteSource(Path.Combine("Deep", "Excluded1.cs"), """
+public class Excluded1
+{
+}
+""");
+        project.WriteSource(Path.Combine("Nested", "Generated.cs"), """
+public class Generated
+{
+}
+""");
+
+        var compilation = new CompilationEngine(new CompilationOptions()).GetCompilation(project.ProjectFile);
+        var sourceFileNames = compilation.SyntaxTrees.Select(tree => Path.GetFileName(tree.FilePath)).ToArray();
+
+        CollectionAssert.DoesNotContain(sourceFileNames, "Excluded1.cs");
+        CollectionAssert.DoesNotContain(sourceFileNames, "Generated.cs");
+    }
+
+    [TestMethod]
+    public void GetCompilation_SkipsGeneratedOutputFolders()
+    {
+        using var project = TempContractProject.Create("");
+        project.WriteSource("Contract.cs", """
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+    public static int Main() => 1;
+}
+""");
+        project.WriteSource(Path.Combine("obj", "Generated.cs"), """
+public class ObjGenerated
+{
+}
+""");
+        project.WriteSource(Path.Combine("bin", "sc", "Generated.cs"), """
+public class BinGenerated
+{
+}
+""");
+
+        var compilation = new CompilationEngine(new CompilationOptions()).GetCompilation(project.ProjectFile);
+        var sourcePaths = compilation.SyntaxTrees.Select(tree => tree.FilePath).ToArray();
+
+        Assert.IsFalse(sourcePaths.Any(path => path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)));
+        Assert.IsFalse(sourcePaths.Any(path => path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}sc{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
     public void UnsupportedDependencyAssetTypeIncludesContext()
     {
         const string dependencyName = "bad.asset/1.0.0";
@@ -236,7 +336,13 @@ public class ExcludedOne
 
         public void WriteSource(string name, string source)
         {
-            File.WriteAllText(Path.Combine(ProjectDirectory, name), source);
+            var path = Path.Combine(ProjectDirectory, name);
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(path, source);
         }
 
         public void Dispose()


### PR DESCRIPTION
Summary
- Apply Compile Remove entries when loading project source files.
- Support relative paths and wildcard remove patterns.

Tests
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~GetCompilation_HonorsRelativeCompileRemove|FullyQualifiedName~GetCompilation_HonorsWildcardCompileRemove" --verbosity minimal