### PR TITLE
Escape template metadata values

### DIFF
--- a/src/Neo.Compiler.CSharp/TemplateManager.cs
+++ b/src/Neo.Compiler.CSharp/TemplateManager.cs
@@ -29,6 +29,14 @@ namespace Neo.Compiler
 
     public class TemplateManager
     {
+        private static readonly HashSet<string> CSharpStringTokens = new(StringComparer.Ordinal)
+        {
+            "{{Author}}",
+            "{{Email}}",
+            "{{Description}}",
+            "{{Version}}"
+        };
+
         private readonly Dictionary<ContractTemplate, TemplateInfo> templates;
 
         public TemplateManager()
@@ -127,7 +135,10 @@ namespace Neo.Compiler
             foreach (var file in templateInfo.Files)
             {
                 string fileName = ReplaceTokens(file.Key, replacements);
-                string fileContent = ReplaceTokens(file.Value, replacements);
+                string fileContent = ReplaceTokens(
+                    file.Value,
+                    replacements,
+                    Path.GetExtension(fileName).Equals(".cs", StringComparison.OrdinalIgnoreCase));
                 string filePath = Path.Combine(projectPath, fileName);
 
                 File.WriteAllText(filePath, fileContent);
@@ -141,13 +152,42 @@ namespace Neo.Compiler
             Console.WriteLine($"  dotnet run --project src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -- {Path.Combine(projectPath, projectName + ".csproj")}");
         }
 
-        private string ReplaceTokens(string content, Dictionary<string, string> replacements)
+        private string ReplaceTokens(string content, Dictionary<string, string> replacements, bool escapeCSharpStringTokens = false)
         {
             foreach (var replacement in replacements)
             {
-                content = content.Replace(replacement.Key, replacement.Value);
+                var value = escapeCSharpStringTokens && CSharpStringTokens.Contains(replacement.Key)
+                    ? EscapeCSharpStringLiteralValue(replacement.Value)
+                    : replacement.Value;
+                content = content.Replace(replacement.Key, value);
             }
             return content;
+        }
+
+        private static string EscapeCSharpStringLiteralValue(string value)
+        {
+            var builder = new StringBuilder(value.Length);
+
+            foreach (var ch in value)
+            {
+                builder.Append(ch switch
+                {
+                    '\\' => @"\\",
+                    '"' => "\\\"",
+                    '\0' => @"\0",
+                    '\a' => @"\a",
+                    '\b' => @"\b",
+                    '\f' => @"\f",
+                    '\n' => @"\n",
+                    '\r' => @"\r",
+                    '\t' => @"\t",
+                    '\v' => @"\v",
+                    _ when char.IsControl(ch) => $"\\u{(int)ch:x4}",
+                    _ => ch.ToString()
+                });
+            }
+
+            return builder.ToString();
         }
 
         public IEnumerable<(ContractTemplate template, string name, string description)> GetAvailableTemplates()

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -197,6 +198,44 @@ namespace Neo.Compiler.CSharp.UnitTests
             StringAssert.Contains(csContent, "[ContractAuthor(\"Jane \\\"JJ\\\" Doe\", \"jane\\\\mail@example.com\")]");
             StringAssert.Contains(csContent, "[ContractDescription(\"Line one\\nLine two \\\"quoted\\\"\")]");
             StringAssert.Contains(csContent, "[ContractVersion(\"1.0\\\"beta\")]");
+        }
+
+        [TestMethod]
+        public void TestMetadataReplacementsEscapeControlCharacters()
+        {
+            string projectName = "EscapedControlMetadata";
+            var customReplacements = new Dictionary<string, string>
+            {
+                { "{{Author}}", "A\0\a\b\f\r\t\v\u001fZ" },
+                { "{{Email}}", "test@example.com" },
+                { "{{Description}}", "Control characters" },
+                { "{{Version}}", "1.0.0" }
+            };
+
+            _templateManager.GenerateContract(ContractTemplate.Basic, projectName, _testOutputPath, customReplacements);
+
+            string csFilePath = Path.Combine(_testOutputPath, projectName, $"{projectName}.cs");
+            string csContent = File.ReadAllText(csFilePath);
+            var diagnostics = CSharpSyntaxTree.ParseText(csContent).GetDiagnostics().ToArray();
+
+            Assert.AreEqual(0, diagnostics.Length, string.Join("\n", diagnostics.Select(u => u.ToString())));
+            StringAssert.Contains(csContent, "[ContractAuthor(\"A\\0\\a\\b\\f\\r\\t\\v\\u001fZ\", \"test@example.com\")]");
+        }
+
+        [TestMethod]
+        public void TestReplaceTokensCanLeaveCSharpStringTokensUnescaped()
+        {
+            var replaceTokens = typeof(TemplateManager).GetMethod("ReplaceTokens", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("Unable to locate ReplaceTokens method.");
+
+            var result = (string)replaceTokens.Invoke(_templateManager, new object[]
+            {
+                "{{Author}}",
+                new Dictionary<string, string> { { "{{Author}}", "Jane \"JJ\" Doe" } },
+                false
+            })!;
+
+            Assert.AreEqual("Jane \"JJ\" Doe", result);
         }
 
         [TestMethod]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_TemplateManager.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.CodeAnalysis.CSharp;
 using Neo.Compiler;
 using System;
 using System.Collections.Generic;
@@ -172,6 +173,30 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsTrue(csContent.Contains("Custom Description"));
             Assert.IsTrue(csContent.Contains("John Doe"));
             Assert.IsTrue(csContent.Contains("john@example.com"));
+        }
+
+        [TestMethod]
+        public void TestMetadataReplacementsAreEscapedInGeneratedSource()
+        {
+            string projectName = "EscapedMetadata";
+            var customReplacements = new Dictionary<string, string>
+            {
+                { "{{Author}}", "Jane \"JJ\" Doe" },
+                { "{{Email}}", "jane\\mail@example.com" },
+                { "{{Description}}", "Line one\nLine two \"quoted\"" },
+                { "{{Version}}", "1.0\"beta" }
+            };
+
+            _templateManager.GenerateContract(ContractTemplate.Basic, projectName, _testOutputPath, customReplacements);
+
+            string csFilePath = Path.Combine(_testOutputPath, projectName, $"{projectName}.cs");
+            string csContent = File.ReadAllText(csFilePath);
+            var diagnostics = CSharpSyntaxTree.ParseText(csContent).GetDiagnostics().ToArray();
+
+            Assert.AreEqual(0, diagnostics.Length, string.Join("\n", diagnostics.Select(u => u.ToString())));
+            StringAssert.Contains(csContent, "[ContractAuthor(\"Jane \\\"JJ\\\" Doe\", \"jane\\\\mail@example.com\")]");
+            StringAssert.Contains(csContent, "[ContractDescription(\"Line one\\nLine two \\\"quoted\\\"\")]");
+            StringAssert.Contains(csContent, "[ContractVersion(\"1.0\\\"beta\")]");
         }
 
         [TestMethod]


### PR DESCRIPTION
Summary
- Escape metadata replacement values before inserting them into generated C# templates.
- Cover quotes, backslashes, and newline values in template metadata.

Tests
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_TemplateManager --verbosity minimal