### PR TITLE
Fix Dockerfile source copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /source
 COPY *.sln .
 COPY src/ ./src/
 COPY tests/ ./tests/
-COPY neo/ ./neo/
 
 # Restore dependencies
 RUN dotnet restore


### PR DESCRIPTION
## Summary
- Remove the stale `COPY neo/ ./neo/` line from the Docker build context.
- Keep the existing restore, build, and publish flow unchanged.

## Test Plan
- `docker build --target build -t neo-devpack-dotnet-dockerfile-check --build-arg HTTP_PROXY= --build-arg HTTPS_PROXY= --build-arg ALL_PROXY= --build-arg http_proxy= --build-arg https_proxy= --build-arg all_proxy= .`