### PR TITLE
Avoid ByteString enumeration in character helpers

### DIFF
--- a/src/Neo.SmartContract.Framework/ByteString.Extension.cs
+++ b/src/Neo.SmartContract.Framework/ByteString.Extension.cs
@@ -22,8 +22,9 @@ public static class ByteStringExtension
     /// <returns>True if is number</returns>
     public static bool IsNumber(this ByteString byteString)
     {
-        foreach (var value in byteString)
+        for (int i = 0; i < byteString.Length; i++)
         {
+            byte value = byteString[i];
             if (value is < 48 or > 57)
                 return false;
         }
@@ -37,8 +38,9 @@ public static class ByteStringExtension
     /// <returns>True if is Alpha character</returns>
     public static bool IsLowerAlphabet(this ByteString byteString)
     {
-        foreach (var value in byteString)
+        for (int i = 0; i < byteString.Length; i++)
         {
+            byte value = byteString[i];
             if (value is < 97 or > 122)
                 return false;
         }
@@ -52,8 +54,9 @@ public static class ByteStringExtension
     /// <returns>True if is Alpha character</returns>
     public static bool IsUpperAlphabet(this ByteString byteString)
     {
-        foreach (var value in byteString)
+        for (int i = 0; i < byteString.Length; i++)
         {
+            byte value = byteString[i];
             if (value is < 65 or > 90)
                 return false;
         }
@@ -67,8 +70,9 @@ public static class ByteStringExtension
     /// <returns>True if is Alpha character</returns>
     public static bool IsAlphabet(this ByteString byteString)
     {
-        foreach (var value in byteString)
+        for (int i = 0; i < byteString.Length; i++)
         {
+            byte value = byteString[i];
             if (!((value >= 65 && value <= 90) || (value >= 97 && value <= 122)))
                 return false;
         }

--- a/tests/Neo.SmartContract.Framework.TestContracts/Contract_Regex.cs
+++ b/tests/Neo.SmartContract.Framework.TestContracts/Contract_Regex.cs
@@ -45,12 +45,32 @@ namespace Neo.SmartContract.Framework.UnitTests.TestClasses
 
         public static bool TestLowerAlphabetOnly()
         {
-            return ((ByteString)"abcdefghijklmnopqrstuvwxyz").IsAlphabet();
+            return ((ByteString)"abcdefghijklmnopqrstuvwxyz").IsLowerAlphabet();
         }
 
         public static bool TestUpperAlphabetOnly()
         {
-            return ((ByteString)"ABCDEFGHIJKLMNOPQRSTUVWXYZ").IsAlphabet();
+            return ((ByteString)"ABCDEFGHIJKLMNOPQRSTUVWXYZ").IsUpperAlphabet();
+        }
+
+        public static bool TestNumberRejectsNonDigit()
+        {
+            return ((ByteString)"0123456789A").IsNumber();
+        }
+
+        public static bool TestAlphabetRejectsNumber()
+        {
+            return ((ByteString)"ABCxyz1").IsAlphabet();
+        }
+
+        public static bool TestLowerAlphabetRejectsUpper()
+        {
+            return ((ByteString)"abcZ").IsLowerAlphabet();
+        }
+
+        public static bool TestUpperAlphabetRejectsLower()
+        {
+            return ((ByteString)"ABCz").IsUpperAlphabet();
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/ByteStringExtensionSourceTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ByteStringExtensionSourceTest.cs
@@ -1,0 +1,30 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ByteStringExtensionSourceTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+[TestClass]
+public class ByteStringExtensionSourceTest
+{
+    [TestMethod]
+    public void CharacterClassHelpers_DoNotUseByteStringEnumeration()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        var sourcePath = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "ByteString.Extension.cs");
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.IsFalse(source.Contains("foreach", StringComparison.Ordinal));
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/ByteStringExtensionSourceTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/ByteStringExtensionSourceTest.cs
@@ -9,9 +9,12 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Neo.SmartContract.Framework.UnitTests;
 
@@ -24,7 +27,25 @@ public class ByteStringExtensionSourceTest
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         var sourcePath = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "ByteString.Extension.cs");
         var source = File.ReadAllText(sourcePath);
+        var root = CSharpSyntaxTree.ParseText(source).GetRoot();
 
-        Assert.IsFalse(source.Contains("foreach", StringComparison.Ordinal));
+        string[] helperNames =
+        [
+            "IsNumber",
+            "IsLowerAlphabet",
+            "IsUpperAlphabet",
+            "IsAlphabet"
+        ];
+
+        foreach (var helperName in helperNames)
+        {
+            var helper = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Single(method => method.Identifier.Text == helperName);
+
+            Assert.IsFalse(
+                helper.DescendantNodes().OfType<ForEachStatementSyntax>().Any(),
+                $"{helperName} should use index access instead of ByteString enumeration.");
+        }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/RegexTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/RegexTest.cs
@@ -50,6 +50,8 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             Assert.IsTrue(Contract.TestNumberOnly());
             AssertGasConsumed(1044270);
+            Assert.IsFalse(Contract.TestNumberRejectsNonDigit());
+            AssertGasConsumed(1047270);
         }
 
         [TestMethod]
@@ -57,10 +59,26 @@ namespace Neo.SmartContract.Framework.UnitTests
         {
             Assert.IsTrue(Contract.TestAlphabetOnly());
             AssertGasConsumed(1238610);
+            Assert.IsFalse(Contract.TestAlphabetRejectsNumber());
+            AssertGasConsumed(1032720);
+        }
+
+        [TestMethod]
+        public void TestLowerAlphabetOnly()
+        {
             Assert.IsTrue(Contract.TestLowerAlphabetOnly());
-            AssertGasConsumed(1128630);
+            AssertGasConsumed(1111470);
+            Assert.IsFalse(Contract.TestLowerAlphabetRejectsUpper());
+            AssertGasConsumed(1017630);
+        }
+
+        [TestMethod]
+        public void TestUpperAlphabetOnly()
+        {
             Assert.IsTrue(Contract.TestUpperAlphabetOnly());
-            AssertGasConsumed(1112250);
+            AssertGasConsumed(1111470);
+            Assert.IsFalse(Contract.TestUpperAlphabetRejectsLower());
+            AssertGasConsumed(1017870);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/RegexTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/RegexTest.cs
@@ -49,18 +49,18 @@ namespace Neo.SmartContract.Framework.UnitTests
         public void TestNumberOnly()
         {
             Assert.IsTrue(Contract.TestNumberOnly());
-            AssertGasConsumed(1036470);
+            AssertGasConsumed(1044270);
         }
 
         [TestMethod]
         public void TestAlphabetOnly()
         {
             Assert.IsTrue(Contract.TestAlphabetOnly());
-            AssertGasConsumed(1198050);
+            AssertGasConsumed(1238610);
             Assert.IsTrue(Contract.TestLowerAlphabetOnly());
-            AssertGasConsumed(1108350);
+            AssertGasConsumed(1128630);
             Assert.IsTrue(Contract.TestUpperAlphabetOnly());
-            AssertGasConsumed(1091970);
+            AssertGasConsumed(1112250);
         }
     }
 }

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Regex.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Regex.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Regex"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testStartWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testIndexOf"",""parameters"":[],""returntype"":""Integer"",""offset"":34,""safe"":false},{""name"":""testEndWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":62,""safe"":false},{""name"":""testContains"",""parameters"":[],""returntype"":""Boolean"",""offset"":164,""safe"":false},{""name"":""testNumberOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":195,""safe"":false},{""name"":""testAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":254,""safe"":false},{""name"":""testLowerAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":371,""safe"":false},{""name"":""testUpperAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":402,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""memorySearch""]}],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Regex"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testStartWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testIndexOf"",""parameters"":[],""returntype"":""Integer"",""offset"":34,""safe"":false},{""name"":""testEndWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":62,""safe"":false},{""name"":""testContains"",""parameters"":[],""returntype"":""Boolean"",""offset"":164,""safe"":false},{""name"":""testNumberOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":195,""safe"":false},{""name"":""testAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":299,""safe"":false},{""name"":""testLowerAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":461,""safe"":false},{""name"":""testUpperAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":495,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""memorySearch""]}],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALA7znO4OTpJcbCoGp54UQN2G/OrAxtZW1vcnlTZWFyY2gCAAEPwO85zuDk6SXGwqBqeeFEDdhvzqwMbWVtb3J5U2VhcmNoAwABDwAA/bEBDAVIZWxsbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAALGqQAwBbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAAEAMBVdvcmxkDAtIZWxsbyBXb3JsZDQDQFcBAnnKEJcmBAhAeMp5yp9KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcGgQtSYECUBoeXg3AQBos0AMAmxsDAtIZWxsbyBXb3JsZDQDQFcAAnl4NwAAD5hADAowMTIzNDU2Nzg5NANAVwUBeEpwynEQciIcaGrOc2t0bAAwtSYFCCIGbAA5tyYECUBqnHJqaTDkCEAMNEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo0A0BXBAF4SnDKcRByIixoas5zawBBuCQFCSIGawBatiYFCCIPawBhuCQFCSIGawB6tiQECUBqnHJqaTDUCEAMGmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6NKhADBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjSJQIQKo8c=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALA7znO4OTpJcbCoGp54UQN2G/OrAxtZW1vcnlTZWFyY2gCAAEPwO85zuDk6SXGwqBqeeFEDdhvzqwMbWVtb3J5U2VhcmNoAwABDwAA/RECDAVIZWxsbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAALGqQAwBbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAAEAMBVdvcmxkDAtIZWxsbyBXb3JsZDQDQFcBAnnKEJcmBAhAeMp5yp9KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcGgQtSYECUBoeXg3AQBos0AMAmxsDAtIZWxsbyBXb3JsZDQDQFcAAnl4NwAAD5hADAowMTIzNDU2Nzg5NANAVwMBEHAiTHhoznFpcmoAMLUmBQgiBmoAObcmBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSyCEAMNEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo0A0BXAgEQcCJceGjOcWkAQbgkBQkiBmkAWrYmBQgiD2kAYbgkBQkiBmkAerYkBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSiCEAMGmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6NXv///9ADBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjVZ////QBDgoR8=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -79,9 +79,9 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DBphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejSoQA==
+    /// Script: DBphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejV7////QA==
     /// PUSHDATA1 6162636465666768696A6B6C6D6E6F707172737475767778797A 'abcdefghijklmnopqrstuvwxyz' [8 datoshi]
-    /// CALL A8 [512 datoshi]
+    /// CALL_L 7BFFFFFF [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testLowerAlphabetOnly")]
@@ -116,9 +116,9 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjSJQA==
+    /// Script: DBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjVZ////QA==
     /// PUSHDATA1 4142434445464748494A4B4C4D4E4F505152535455565758595A 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' [8 datoshi]
-    /// CALL 89 [512 datoshi]
+    /// CALL_L 59FFFFFF [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testUpperAlphabetOnly")]

--- a/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Regex.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/TestingArtifacts/Contract_Regex.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Regex"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testStartWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testIndexOf"",""parameters"":[],""returntype"":""Integer"",""offset"":34,""safe"":false},{""name"":""testEndWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":62,""safe"":false},{""name"":""testContains"",""parameters"":[],""returntype"":""Boolean"",""offset"":164,""safe"":false},{""name"":""testNumberOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":195,""safe"":false},{""name"":""testAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":299,""safe"":false},{""name"":""testLowerAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":461,""safe"":false},{""name"":""testUpperAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":495,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""memorySearch""]}],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Regex"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testStartWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testIndexOf"",""parameters"":[],""returntype"":""Integer"",""offset"":34,""safe"":false},{""name"":""testEndWith"",""parameters"":[],""returntype"":""Boolean"",""offset"":62,""safe"":false},{""name"":""testContains"",""parameters"":[],""returntype"":""Boolean"",""offset"":164,""safe"":false},{""name"":""testNumberOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":195,""safe"":false},{""name"":""testAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":299,""safe"":false},{""name"":""testLowerAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":461,""safe"":false},{""name"":""testUpperAlphabetOnly"",""parameters"":[],""returntype"":""Boolean"",""offset"":581,""safe"":false},{""name"":""testNumberRejectsNonDigit"",""parameters"":[],""returntype"":""Boolean"",""offset"":701,""safe"":false},{""name"":""testAlphabetRejectsNumber"",""parameters"":[],""returntype"":""Boolean"",""offset"":720,""safe"":false},{""name"":""testLowerAlphabetRejectsUpper"",""parameters"":[],""returntype"":""Boolean"",""offset"":735,""safe"":false},{""name"":""testUpperAlphabetRejectsLower"",""parameters"":[],""returntype"":""Boolean"",""offset"":747,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""memorySearch""]}],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALA7znO4OTpJcbCoGp54UQN2G/OrAxtZW1vcnlTZWFyY2gCAAEPwO85zuDk6SXGwqBqeeFEDdhvzqwMbWVtb3J5U2VhcmNoAwABDwAA/RECDAVIZWxsbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAALGqQAwBbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAAEAMBVdvcmxkDAtIZWxsbyBXb3JsZDQDQFcBAnnKEJcmBAhAeMp5yp9KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcGgQtSYECUBoeXg3AQBos0AMAmxsDAtIZWxsbyBXb3JsZDQDQFcAAnl4NwAAD5hADAowMTIzNDU2Nzg5NANAVwMBEHAiTHhoznFpcmoAMLUmBQgiBmoAObcmBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSyCEAMNEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo0A0BXAgEQcCJceGjOcWkAQbgkBQkiBmkAWrYmBQgiD2kAYbgkBQkiBmkAerYkBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSiCEAMGmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6NXv///9ADBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjVZ////QBDgoR8=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALA7znO4OTpJcbCoGp54UQN2G/OrAxtZW1vcnlTZWFyY2gCAAEPwO85zuDk6SXGwqBqeeFEDdhvzqwMbWVtb3J5U2VhcmNoAwABDwAA/fcCDAVIZWxsbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAALGqQAwBbwwLSGVsbG8gV29ybGQ0A0BXAAJ5eDcAAEAMBVdvcmxkDAtIZWxsbyBXb3JsZDQDQFcBAnnKEJcmBAhAeMp5yp9KAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfcGgQtSYECUBoeXg3AQBos0AMAmxsDAtIZWxsbyBXb3JsZDQDQFcAAnl4NwAAD5hADAowMTIzNDU2Nzg5NANAVwMBEHAiTHhoznFpcmoAMLUmBQgiBmoAObcmBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSyCEAMNEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo0A0BXAgEQcCJceGjOcWkAQbgkBQkiBmkAWrYmBQgiD2kAYbgkBQkiBmkAerYkBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSiCEAMGmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6NANAVwMBEHAiTHhoznFpcmoAYbUmBQgiBmoAercmBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSyCEAMGkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaNANAVwMBEHAiTHhoznFpcmoAQbUmBQgiBmoAWrcmBAlAaEqcSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3BFaHjKtSSyCEAMCzAxMjM0NTY3ODlBNQj+//9ADAdBQkN4eXoxNYv+//9ADARhYmNaNQf///9ADARBQkN6NXP///9AWesstQ==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -35,6 +35,18 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
     /// </remarks>
     [DisplayName("testAlphabetOnly")]
     public abstract bool? TestAlphabetOnly();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: DAdBQkN4eXoxNYv+//9A
+    /// PUSHDATA1 41424378797A31 'ABCxyz1' [8 datoshi]
+    /// CALL_L 8BFEFFFF [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testAlphabetRejectsNumber")]
+    public abstract bool? TestAlphabetRejectsNumber();
 
     /// <summary>
     /// Unsafe method
@@ -79,13 +91,25 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DBphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejV7////QA==
+    /// Script: DBphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejQDQA==
     /// PUSHDATA1 6162636465666768696A6B6C6D6E6F707172737475767778797A 'abcdefghijklmnopqrstuvwxyz' [8 datoshi]
-    /// CALL_L 7BFFFFFF [512 datoshi]
+    /// CALL 03 [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testLowerAlphabetOnly")]
     public abstract bool? TestLowerAlphabetOnly();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: DARhYmNaNQf///9A
+    /// PUSHDATA1 6162635A 'abcZ' [8 datoshi]
+    /// CALL_L 07FFFFFF [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testLowerAlphabetRejectsUpper")]
+    public abstract bool? TestLowerAlphabetRejectsUpper();
 
     /// <summary>
     /// Unsafe method
@@ -98,6 +122,18 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
     /// </remarks>
     [DisplayName("testNumberOnly")]
     public abstract bool? TestNumberOnly();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: DAswMTIzNDU2Nzg5QTUI/v//QA==
+    /// PUSHDATA1 3031323334353637383941 '0123456789A' [8 datoshi]
+    /// CALL_L 08FEFFFF [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testNumberRejectsNonDigit")]
+    public abstract bool? TestNumberRejectsNonDigit();
 
     /// <summary>
     /// Unsafe method
@@ -116,13 +152,25 @@ public abstract class Contract_Regex(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: DBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjVZ////QA==
+    /// Script: DBpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjQDQA==
     /// PUSHDATA1 4142434445464748494A4B4C4D4E4F505152535455565758595A 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' [8 datoshi]
-    /// CALL_L 59FFFFFF [512 datoshi]
+    /// CALL 03 [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testUpperAlphabetOnly")]
     public abstract bool? TestUpperAlphabetOnly();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: DARBQkN6NXP///9A
+    /// PUSHDATA1 4142437A 'ABCz' [8 datoshi]
+    /// CALL_L 73FFFFFF [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testUpperAlphabetRejectsLower")]
+    public abstract bool? TestUpperAlphabetRejectsLower();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
- Rewrite ByteString character classification helpers to use `Length` and index access.
- Add a regression check to keep these helpers away from unsupported enumeration.
- Update the generated Regex artifact and gas expectations.

## Test Plan
- `dotnet test tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj --filter "CharacterClassHelpers_DoNotUseByteStringEnumeration|Regex" --no-restore -v minimal`