### PR TITLE
Fix: numeric promotions in `CheckShiftOverflow`

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/AssignmentExpression.ComplexAssignment.cs
@@ -298,7 +298,7 @@ internal partial class MethodConvert
         }
         else if (operatorToken.ValueText == "<<=")
         {
-            CheckShiftOverflow(model, type);
+            CheckShiftOverflow(type, false);
         }
 
         AddInstruction(opcode);

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
@@ -103,7 +103,7 @@ internal partial class MethodConvert
         }
         else if (expression.OperatorToken.ValueText == "<<")
         {
-            CheckShiftOverflow(model, model.GetTypeInfo(expression.Left).Type);
+            CheckShiftOverflow(model.GetTypeInfo(expression.Left).Type, true);
         }
         AddInstruction(opcode);
 
@@ -177,9 +177,9 @@ internal partial class MethodConvert
     /// Checks for left shift overflow in checked context.
     /// Validates that the shift amount is non-negative and within the bit width of the left operand type.
     /// </summary>
-    /// <param name="model">The semantic model.</param>
-    /// <param name="expression">The binary expression containing the shift operation.</param>
-    private void CheckShiftOverflow(SemanticModel model, ITypeSymbol? leftType)
+    /// <param name="leftType">The left type of the shift operation.</param>
+    /// <param name="promotedIfSmall">Whether to promote the left type to int if it is a small integer type(less than 32-bits).</param>
+    private void CheckShiftOverflow(ITypeSymbol? leftType, bool promotedIfSmall)
     {
         // Only check overflow in checked context
         if (!_checkedStack.Peek()) return;
@@ -195,8 +195,9 @@ internal partial class MethodConvert
         // Note: In NEO, BigInteger is Int256 (256-bit integer)
         var maxShift = leftType.Name switch
         {
-            "SByte" or "Byte" => 8,
-            "Int16" or "UInt16" or "Char" => 16,
+            // Integer types that less than 32-bits, it will be promoted to int except compound-assignment operator.
+            "SByte" or "Byte" => promotedIfSmall ? 32 : 8,
+            "Int16" or "UInt16" or "Char" => promotedIfSmall ? 32 : 16,
             "Int32" or "UInt32" => 32,
             "Int64" or "UInt64" => 64,
             "BigInteger" => 256, // In NEO, BigInteger is Int256

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_shift.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_shift.cs
@@ -58,6 +58,11 @@ namespace Neo.Compiler.CSharp.TestContracts
             return checked(value << shift);
         }
 
+        public static int ShiftLeftCheckedShort(short value, int shift)
+        {
+            return checked(value << shift);
+        }
+
         // BigInteger shift (no limit)
         public static System.Numerics.BigInteger ShiftLeftBigInteger(System.Numerics.BigInteger value, int shift)
         {

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_shift.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_shift.cs
@@ -13,12 +13,12 @@ public abstract class Contract_shift(Neo.SmartContract.Testing.SmartContractInit
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_shift"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testShift"",""parameters"":[],""returntype"":""Array"",""offset"":0,""safe"":false},{""name"":""testShiftBigInt"",""parameters"":[],""returntype"":""Array"",""offset"":65,""safe"":false},{""name"":""shiftLeftChecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":94,""safe"":false},{""name"":""shiftLeftUnchecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":130,""safe"":false},{""name"":""shiftLeftCheckedLong"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":183,""safe"":false},{""name"":""shiftLeftCheckedByte"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":227,""safe"":false},{""name"":""shiftLeftBigInteger"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":262,""safe"":false},{""name"":""shiftRightChecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":269,""safe"":false},{""name"":""shiftRightUnchecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":278,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_shift"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testShift"",""parameters"":[],""returntype"":""Array"",""offset"":0,""safe"":false},{""name"":""testShiftBigInt"",""parameters"":[],""returntype"":""Array"",""offset"":65,""safe"":false},{""name"":""shiftLeftChecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":94,""safe"":false},{""name"":""shiftLeftUnchecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":130,""safe"":false},{""name"":""shiftLeftCheckedLong"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":183,""safe"":false},{""name"":""shiftLeftCheckedByte"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":227,""safe"":false},{""name"":""shiftLeftCheckedShort"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":263,""safe"":false},{""name"":""shiftLeftBigInteger"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":299,""safe"":false},{""name"":""shiftRightChecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":306,""safe"":false},{""name"":""shiftRightUnchecked"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""shift"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":315,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0fAVcDABhwaBGoSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FoEalyaWpQEsBAVwUAGHBoEKhxaBGocmgRqXNoEql0aWprbFQUwEBXAAJ4eUoQLgM6SgAgMAM6qEoCAAAAgC4DOkoC////fzIDOkBXAAJ4eahKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfQFcAAnh5ShAuAzpKAEAwAzqoSgMAAAAAAAAAgC4DOkoD/////////38yAzpAVwACeHlKEC4DOkoYMAM6qEoCAAAAgC4DOkoC////fzIDOkBXAAJ4eahAVwACeHmpSoBAVwACeHmpSoBAwQOkJQ==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP1EAVcDABhwaBGoSgIAAACALgQiCkoC////fzIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn3FoEalyaWpQEsBAVwUAGHBoEKhxaBGocmgRqXNoEql0aWprbFQUwEBXAAJ4eUoQLgM6SgAgMAM6qEoCAAAAgC4DOkoC////fzIDOkBXAAJ4eahKAgAAAIAuBCIKSgL///9/Mh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfQFcAAnh5ShAuAzpKAEAwAzqoSgMAAAAAAAAAgC4DOkoD/////////38yAzpAVwACeHlKEC4DOkoAIDADOqhKAgAAAIAuAzpKAv///38yAzpAVwACeHlKEC4DOkoAIDADOqhKAgAAAIAuAzpKAv///38yAzpAVwACeHmoQFcAAnh5qUqAQFcAAnh5qUqAQMnhTNI=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -72,7 +72,7 @@ public abstract class Contract_shift(Neo.SmartContract.Testing.SmartContractInit
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwACeHlKEC4DOkoYMAM6qEoCAAAAgC4DOkoC////fzIDOkA=
+    /// Script: VwACeHlKEC4DOkoAIDADOqhKAgAAAIAuAzpKAv///38yAzpA
     /// INITSLOT 0002 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// LDARG1 [2 datoshi]
@@ -81,7 +81,7 @@ public abstract class Contract_shift(Neo.SmartContract.Testing.SmartContractInit
     /// JMPGE 03 [2 datoshi]
     /// THROW [512 datoshi]
     /// DUP [2 datoshi]
-    /// PUSH8 [1 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
     /// JMPLT 03 [2 datoshi]
     /// THROW [512 datoshi]
     /// SHL [8 datoshi]
@@ -127,6 +127,36 @@ public abstract class Contract_shift(Neo.SmartContract.Testing.SmartContractInit
     /// </remarks>
     [DisplayName("shiftLeftCheckedLong")]
     public abstract BigInteger? ShiftLeftCheckedLong(BigInteger? value, BigInteger? shift);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwACeHlKEC4DOkoAIDADOqhKAgAAAIAuAzpKAv///38yAzpA
+    /// INITSLOT 0002 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// JMPGE 03 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
+    /// JMPLT 03 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// SHL [8 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 00000080 [1 datoshi]
+    /// JMPGE 03 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT32 FFFFFF7F [1 datoshi]
+    /// JMPLE 03 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("shiftLeftCheckedShort")]
+    public abstract BigInteger? ShiftLeftCheckedShort(BigInteger? value, BigInteger? shift);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Shift.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Shift.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Exceptions;
 using System.Linq;
 using System.Numerics;
 
@@ -47,5 +48,25 @@ public class UnitTest_Shift : DebugAndTestBase<Contract_shift>
     {
         Assert.AreEqual(0, Contract.ShiftRightUnchecked(8, 4));
         AssertGasConsumed(1047480);
+    }
+
+    [TestMethod]
+    public void Test_ShiftLeftCheckedByte()
+    {
+        Assert.AreEqual(128, Contract.ShiftLeftCheckedByte(8, 4));
+        AssertGasConsumed(1047960);
+
+        Assert.ThrowsException<TestException>(() => Contract.ShiftLeftCheckedByte(8, 33));
+        AssertGasConsumed(1062780);
+    }
+
+    [TestMethod]
+    public void Test_ShiftLeftCheckedShort()
+    {
+        Assert.AreEqual(128, Contract.ShiftLeftCheckedShort(8, 4));
+        AssertGasConsumed(1047960);
+
+        Assert.ThrowsException<TestException>(() => Contract.ShiftLeftCheckedShort(8, 33));
+        AssertGasConsumed(1062780);
     }
 }


### PR DESCRIPTION

Integer types that less than 32-bits, it will be promoted to int in numeric operations except compound-assignment.