### PR TITLE
Map BitOperations RotateLeft, RotateRight and LeadingZeroCount

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Register.cs
@@ -638,6 +638,21 @@ internal partial class MethodConvert
             (mc, model, symbol, instanceExpression, arguments) => HandleNumericPopCount(uintDescriptor, mc, model, symbol, instanceExpression, arguments));
         RegisterHandler((ulong value) => BitOperations.PopCount(value),
             (mc, model, symbol, instanceExpression, arguments) => HandleNumericPopCount(ulongDescriptor, mc, model, symbol, instanceExpression, arguments));
+
+        RegisterHandler((uint value) => BitOperations.LeadingZeroCount(value),
+            (mc, model, symbol, instanceExpression, arguments) => HandleNumericLeadingZeroCount(uintDescriptor, mc, model, symbol, instanceExpression, arguments));
+        RegisterHandler((ulong value) => BitOperations.LeadingZeroCount(value),
+            (mc, model, symbol, instanceExpression, arguments) => HandleNumericLeadingZeroCount(ulongDescriptor, mc, model, symbol, instanceExpression, arguments));
+
+        RegisterHandler((uint value, int offset) => BitOperations.RotateLeft(value, offset),
+            (mc, model, symbol, instanceExpression, arguments) => HandleNumericRotateLeft(uintDescriptor, mc, model, symbol, instanceExpression, arguments));
+        RegisterHandler((ulong value, int offset) => BitOperations.RotateLeft(value, offset),
+            (mc, model, symbol, instanceExpression, arguments) => HandleNumericRotateLeft(ulongDescriptor, mc, model, symbol, instanceExpression, arguments));
+
+        RegisterHandler((uint value, int offset) => BitOperations.RotateRight(value, offset),
+            (mc, model, symbol, instanceExpression, arguments) => HandleNumericRotateRight(uintDescriptor, mc, model, symbol, instanceExpression, arguments));
+        RegisterHandler((ulong value, int offset) => BitOperations.RotateRight(value, offset),
+            (mc, model, symbol, instanceExpression, arguments) => HandleNumericRotateRight(ulongDescriptor, mc, model, symbol, instanceExpression, arguments));
     }
 
     private static void RegisterEnumHandlers()

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_BitOperations.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_BitOperations.cs
@@ -34,4 +34,34 @@ public class Contract_BitOperations : SmartContract.Framework.SmartContract
     {
         return BitOperations.PopCount(value);
     }
+
+    public static int LeadingZeroCountUInt(uint value)
+    {
+        return BitOperations.LeadingZeroCount(value);
+    }
+
+    public static int LeadingZeroCountULong(ulong value)
+    {
+        return BitOperations.LeadingZeroCount(value);
+    }
+
+    public static uint RotateLeftUInt(uint value, int offset)
+    {
+        return BitOperations.RotateLeft(value, offset);
+    }
+
+    public static ulong RotateLeftULong(ulong value, int offset)
+    {
+        return BitOperations.RotateLeft(value, offset);
+    }
+
+    public static uint RotateRightUInt(uint value, int offset)
+    {
+        return BitOperations.RotateRight(value, offset);
+    }
+
+    public static ulong RotateRightULong(ulong value, int offset)
+    {
+        return BitOperations.RotateRight(value, offset);
+    }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_BitOperations.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_BitOperations.cs
@@ -13,16 +13,68 @@ public abstract class Contract_BitOperations(Neo.SmartContract.Testing.SmartCont
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_BitOperations"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""log2UInt"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""log2ULong"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":24,""safe"":false},{""name"":""popCountUInt"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":48,""safe"":false},{""name"":""popCountULong"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":80,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_BitOperations"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""log2UInt"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""log2ULong"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":24,""safe"":false},{""name"":""popCountUInt"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":48,""safe"":false},{""name"":""popCountULong"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":80,""safe"":false},{""name"":""leadingZeroCountUInt"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":120,""safe"":false},{""name"":""leadingZeroCountULong"",""parameters"":[{""name"":""value"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":142,""safe"":false},{""name"":""rotateLeftUInt"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""offset"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":164,""safe"":false},{""name"":""rotateLeftULong"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""offset"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":231,""safe"":false},{""name"":""rotateRightUInt"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""offset"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":330,""safe"":false},{""name"":""rotateRightULong"",""parameters"":[{""name"":""value"",""type"":""Integer""},{""name"":""offset"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":387,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHhXAAF4ShAuAzpKECgMEJxLS6kQLPtGnUBXAAF4ShAuAzpKECgMEJxLS6kQLPtGnUBXAAF4A/////8AAAAAkRBQShAoDEoRkVGeUBGpIvRFQFcAAXgE//////////8AAAAAAAAAAJEQUEoQKAxKEZFRnlARqSL0RUCtmbH7").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3UAVcAAXhKEC4DOkoQKAwQnEtLqRAs+0adQFcAAXhKEC4DOkoQKAwQnEtLqRAs+0adQFcAAXgD/////wAAAACREFBKECgMShGRUZ5QEaki9EVAVwABeAT//////////wAAAAAAAAAAkRBQShAoDEoRkVGeUBGpIvRFQFcAAXgQUEoQKAgRqVCcIvdFACBQn0BXAAF4EFBKECgIEalQnCL3RQBAUJ9AVwICeHlwcWkD/////wAAAACRaAAfkagD/////wAAAACRaQP/////AAAAAJEAIGgAH5GfAB+RqZID/////wAAAACRQFcCAnh5cHFpBP//////////AAAAAAAAAACRaAA/kagE//////////8AAAAAAAAAAJFpBP//////////AAAAAAAAAACRAEBoAD+RnwA/kamSBP//////////AAAAAAAAAACRQFcCAnh5cHFpA/////8AAAAAkWgAH5GpaQP/////AAAAAJEAIGgAH5GfAB+RqJID/////wAAAACRQFcCAnh5cHFpBP//////////AAAAAAAAAACRaAA/kalpBP//////////AAAAAAAAAACRAEBoAD+RnwA/kaiSBP//////////AAAAAAAAAACRQNe4Cf8=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
     #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeBBQShAoCBGpUJwi90UAIFCfQA==
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// SWAP [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// JMPEQ 08 [2 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// SHR [8 datoshi]
+    /// SWAP [2 datoshi]
+    /// INC [4 datoshi]
+    /// JMP F7 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
+    /// SWAP [2 datoshi]
+    /// SUB [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("leadingZeroCountUInt")]
+    public abstract BigInteger? LeadingZeroCountUInt(BigInteger? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwABeBBQShAoCBGpUJwi90UAQFCfQA==
+    /// INITSLOT 0001 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// SWAP [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// JMPEQ 08 [2 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// SHR [8 datoshi]
+    /// SWAP [2 datoshi]
+    /// INC [4 datoshi]
+    /// JMP F7 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// PUSHINT8 40 [1 datoshi]
+    /// SWAP [2 datoshi]
+    /// SUB [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("leadingZeroCountULong")]
+    public abstract BigInteger? LeadingZeroCountULong(BigInteger? value);
 
     /// <summary>
     /// Unsafe method
@@ -137,6 +189,154 @@ public abstract class Contract_BitOperations(Neo.SmartContract.Testing.SmartCont
     /// </remarks>
     [DisplayName("popCountULong")]
     public abstract BigInteger? PopCountULong(BigInteger? value);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwICeHlwcWkD/////wAAAACRaAAfkagD/////wAAAACRaQP/////AAAAAJEAIGgAH5GfAB+RqZID/////wAAAACRQA==
+    /// INITSLOT 0202 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 1F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHL [8 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 1F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SUB [8 datoshi]
+    /// PUSHINT8 1F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHR [8 datoshi]
+    /// OR [8 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("rotateLeftUInt")]
+    public abstract BigInteger? RotateLeftUInt(BigInteger? value, BigInteger? offset);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwICeHlwcWkE//////////8AAAAAAAAAAJFoAD+RqAT//////////wAAAAAAAAAAkWkE//////////8AAAAAAAAAAJEAQGgAP5GfAD+RqZIE//////////8AAAAAAAAAAJFA
+    /// INITSLOT 0202 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 3F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHL [8 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// PUSHINT8 40 [1 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 3F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SUB [8 datoshi]
+    /// PUSHINT8 3F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHR [8 datoshi]
+    /// OR [8 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("rotateLeftULong")]
+    public abstract BigInteger? RotateLeftULong(BigInteger? value, BigInteger? offset);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwICeHlwcWkD/////wAAAACRaAAfkalpA/////8AAAAAkQAgaAAfkZ8AH5GokgP/////AAAAAJFA
+    /// INITSLOT 0202 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 1F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHR [8 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// PUSHINT8 20 [1 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 1F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SUB [8 datoshi]
+    /// PUSHINT8 1F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHL [8 datoshi]
+    /// OR [8 datoshi]
+    /// PUSHINT64 FFFFFFFF00000000 [1 datoshi]
+    /// AND [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("rotateRightUInt")]
+    public abstract BigInteger? RotateRightUInt(BigInteger? value, BigInteger? offset);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwICeHlwcWkE//////////8AAAAAAAAAAJFoAD+RqWkE//////////8AAAAAAAAAAJEAQGgAP5GfAD+RqJIE//////////8AAAAAAAAAAJFA
+    /// INITSLOT 0202 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// LDARG1 [2 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// STLOC1 [2 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 3F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHR [8 datoshi]
+    /// LDLOC1 [2 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// PUSHINT8 40 [1 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSHINT8 3F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SUB [8 datoshi]
+    /// PUSHINT8 3F [1 datoshi]
+    /// AND [8 datoshi]
+    /// SHL [8 datoshi]
+    /// OR [8 datoshi]
+    /// PUSHINT128 FFFFFFFFFFFFFFFF0000000000000000 [4 datoshi]
+    /// AND [8 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("rotateRightULong")]
+    public abstract BigInteger? RotateRightULong(BigInteger? value, BigInteger? offset);
 
     #endregion
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BitOperations.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_BitOperations.cs
@@ -57,5 +57,57 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(BitOperations.PopCount(0xAAAAAAAAAAAAAAAAUL), Contract.PopCountULong(0xAAAAAAAAAAAAAAAAUL));
             Assert.AreEqual(BitOperations.PopCount(0x5555555555555555UL), Contract.PopCountULong(0x5555555555555555UL));
         }
+
+        [TestMethod]
+        public void TestLeadingZeroCountUInt()
+        {
+            Assert.AreEqual(BitOperations.LeadingZeroCount(0U), Contract.LeadingZeroCountUInt(0U));
+            Assert.AreEqual(BitOperations.LeadingZeroCount(1U), Contract.LeadingZeroCountUInt(1U));
+            Assert.AreEqual(BitOperations.LeadingZeroCount(0x00FF00FFU), Contract.LeadingZeroCountUInt(0x00FF00FFU));
+            Assert.AreEqual(BitOperations.LeadingZeroCount(uint.MaxValue), Contract.LeadingZeroCountUInt(uint.MaxValue));
+        }
+
+        [TestMethod]
+        public void TestLeadingZeroCountULong()
+        {
+            Assert.AreEqual(BitOperations.LeadingZeroCount(0UL), Contract.LeadingZeroCountULong(0UL));
+            Assert.AreEqual(BitOperations.LeadingZeroCount(1UL), Contract.LeadingZeroCountULong(1UL));
+            Assert.AreEqual(BitOperations.LeadingZeroCount(0x00FF00FF00FF00FFUL), Contract.LeadingZeroCountULong(0x00FF00FF00FF00FFUL));
+            Assert.AreEqual(BitOperations.LeadingZeroCount(ulong.MaxValue), Contract.LeadingZeroCountULong(ulong.MaxValue));
+        }
+
+        [TestMethod]
+        public void TestRotateLeftUInt()
+        {
+            Assert.AreEqual(BitOperations.RotateLeft(0x12345678U, 8), Contract.RotateLeftUInt(0x12345678U, 8));
+            Assert.AreEqual(BitOperations.RotateLeft(1U, 31), Contract.RotateLeftUInt(1U, 31));
+            Assert.AreEqual(BitOperations.RotateLeft(uint.MaxValue, 5), Contract.RotateLeftUInt(uint.MaxValue, 5));
+            Assert.AreEqual(BitOperations.RotateLeft(0x80000001U, 1), Contract.RotateLeftUInt(0x80000001U, 1));
+        }
+
+        [TestMethod]
+        public void TestRotateLeftULong()
+        {
+            Assert.AreEqual(BitOperations.RotateLeft(0x123456789ABCDEF0UL, 16), Contract.RotateLeftULong(0x123456789ABCDEF0UL, 16));
+            Assert.AreEqual(BitOperations.RotateLeft(1UL, 63), Contract.RotateLeftULong(1UL, 63));
+            Assert.AreEqual(BitOperations.RotateLeft(ulong.MaxValue, 7), Contract.RotateLeftULong(ulong.MaxValue, 7));
+        }
+
+        [TestMethod]
+        public void TestRotateRightUInt()
+        {
+            Assert.AreEqual(BitOperations.RotateRight(0x12345678U, 8), Contract.RotateRightUInt(0x12345678U, 8));
+            Assert.AreEqual(BitOperations.RotateRight(1U, 1), Contract.RotateRightUInt(1U, 1));
+            Assert.AreEqual(BitOperations.RotateRight(uint.MaxValue, 5), Contract.RotateRightUInt(uint.MaxValue, 5));
+            Assert.AreEqual(BitOperations.RotateRight(0x80000001U, 1), Contract.RotateRightUInt(0x80000001U, 1));
+        }
+
+        [TestMethod]
+        public void TestRotateRightULong()
+        {
+            Assert.AreEqual(BitOperations.RotateRight(0x123456789ABCDEF0UL, 16), Contract.RotateRightULong(0x123456789ABCDEF0UL, 16));
+            Assert.AreEqual(BitOperations.RotateRight(1UL, 1), Contract.RotateRightULong(1UL, 1));
+            Assert.AreEqual(BitOperations.RotateRight(ulong.MaxValue, 7), Contract.RotateRightULong(ulong.MaxValue, 7));
+        }
     }
 }


### PR DESCRIPTION
## Problem

`RegisterBitOperationsHandlers` only mapped `BitOperations.Log2` and `BitOperations.PopCount`. As a result `BitOperations.RotateLeft`, `BitOperations.RotateRight` and `BitOperations.LeadingZeroCount` failed to compile — even though the codegen helpers (`HandleNumericRotateLeft` / `HandleNumericRotateRight` / `HandleNumericLeadingZeroCount`) already exist and are exercised by the type-static equivalents (`int.RotateLeft`, `uint.LeadingZeroCount`, ...) via `RegisterNumericHandlers`.

## Fix

Register the `uint` and `ulong` overloads of `LeadingZeroCount`, `RotateLeft` and `RotateRight` against those existing handlers. No new codegen — this only wires up the already-tested helpers for the `BitOperations` entry points.

## Tests

Added six methods to `Contract_BitOperations` and matching tests to `UnitTest_BitOperations` that compare the compiled result against the real `System.Numerics.BitOperations` implementation (covering edge cases: 0, 1, MaxValue, alternating bit patterns, and full-width rotations). Refreshed the regenerated artifact.

## Verification

Full local run, all green: `Neo.Compiler.CSharp.UnitTests` (1289, +6 new). Purely additive builtin registration, so no existing contract's codegen changes (only the `Contract_BitOperations` artifact gained the new methods).