### PR TITLE
docs: fix broken example links in the getting-started guide

### DIFF
--- a/guidance/GETTING-STARTED-GUIDE.md
+++ b/guidance/GETTING-STARTED-GUIDE.md
@@ -668,11 +668,11 @@ public class ProxyContract : SmartContract
 ### Learn More
 
 1. **Token Standards**
-   - [NEP-17 Token Tutorial](../examples/04-token-standards/README.md#nep-17-fungible-token)
-   - [NEP-11 NFT Tutorial](../examples/04-token-standards/README.md#nep-11-non-fungible-token)
+   - [NEP-17 Token Tutorial](../examples/Example.SmartContract.NEP17/README.md)
+   - [NEP-11 NFT Tutorial](../examples/Example.SmartContract.NFT/README.md)
 
 2. **Advanced Topics**
-   - [Oracle Integration](../examples/03-advanced/README.md#oracle)
+   - [Oracle Integration](../examples/Example.SmartContract.Oracle/README.md)
    - [Security Best Practices](../docs/security/security-best-practices.md)
 
 3. **Tools and Resources**


### PR DESCRIPTION
## Problem

The getting-started guide linked to example folders that do not exist:

- `../examples/04-token-standards/README.md`
- `../examples/03-advanced/README.md`

The examples live in per-contract folders (`Example.SmartContract.*`), so these tutorial links were dead.

## Fix

Repoint the tutorials at the actual example READMEs:

- NEP-17 → `Example.SmartContract.NEP17/README.md`
- NEP-11 → `Example.SmartContract.NFT/README.md`
- Oracle → `Example.SmartContract.Oracle/README.md`

Verified that every local link in the guide now resolves to an existing file.