### PR TITLE
Fail the example build when nccs fails

### DIFF
--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -48,7 +48,7 @@
 
     <Target Name="ExecuteBeforeBuild" BeforeTargets="PreBuildEvent"
             Condition="'$(IsTestProject)' != 'true' AND '$(MSBuildProjectName)' != 'TestContract' AND '$(DisableArtifactGeneration)' != 'true'">
-        <Exec Command="nccs &quot;$(MSBuildProjectFile)&quot;" ContinueOnError="true"/>
+        <Exec Command="nccs &quot;$(MSBuildProjectFile)&quot;"/>
     </Target>
 
     <!-- Smart Contract Artifact Generation Target -->
@@ -67,8 +67,7 @@
         <MakeDir Directories="$(TestingArtifactsDir)" Condition="Exists('$(UnitTestProjectDir)') AND !Exists('$(TestingArtifactsDir)')" />
         
         <!-- Use nccs to generate artifacts for unit tests -->
-        <Exec Command="nccs &quot;$(MSBuildProjectFile)&quot; --base-name &quot;$(ArtifactClassName)&quot; --output &quot;$(TestingArtifactsDir)&quot; --generate-artifacts Source" 
-              ContinueOnError="true" 
+        <Exec Command="nccs &quot;$(MSBuildProjectFile)&quot; --base-name &quot;$(ArtifactClassName)&quot; --output &quot;$(TestingArtifactsDir)&quot; --generate-artifacts Source"
               Condition="Exists('$(UnitTestProjectDir)')" />
     </Target>
 


### PR DESCRIPTION
## Problem

The example build runs **both** `nccs` invocations with `ContinueOnError="true"` — the pre-build contract compile and the post-build artifact generation:

```xml
<Exec Command="nccs &quot;$(MSBuildProjectFile)&quot;" ContinueOnError="true"/>
```

A contract that fails to compile therefore still produces a **green build** against the stale committed artifacts, and its unit tests run against an *old* contract — the canonical silent-failure anti-pattern (arguably worse than missing artifacts, because the tests pass).

## Fix

Drop `ContinueOnError` from both invocations so a non-zero `nccs` exit fails the build. The shipped `neocontract` templates already invoke `nccs` fail-closed (`templates/*/[Contract].csproj`), so this only aligns the **examples'** build infrastructure with them.

## Verification

`dotnet build examples/neo-contract-examples.sln` still completes with **0 errors** (all example contracts compile).