### PR TITLE
Enforce the [Safe] ABI flag against contract-state mutation

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.SafeMethodAnalysis.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.SafeMethodAnalysis.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CompilationContext.SafeMethodAnalysis.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Compiler.ABI;
+using Neo.SmartContract;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+
+namespace Neo.Compiler
+{
+    public partial class CompilationContext
+    {
+        // Interop services that mutate persistent contract storage. A method that can reach any
+        // of these is not read-only and therefore cannot honestly carry the [Safe] ABI flag.
+        private static readonly uint[] StorageWriteSyscalls =
+        {
+            ApplicationEngine.System_Storage_Put.Hash,
+            ApplicationEngine.System_Storage_Delete.Hash,
+            ApplicationEngine.System_Storage_Local_Put.Hash,
+            ApplicationEngine.System_Storage_Local_Delete.Hash,
+        };
+
+        /// <summary>
+        /// Verifies that every exported method marked <c>[Safe]</c> is free of contract-state
+        /// mutation. The manifest's <c>safe</c> flag tells wallets, explorers and dApps that a
+        /// method is read-only and can be invoked without a signature prompt, so a Safe method
+        /// that writes storage advertises a false on-chain guarantee — the direct analog of a
+        /// Solidity <c>view</c> function performing an <c>SSTORE</c>, which solc rejects at
+        /// compile time.
+        /// </summary>
+        /// <remarks>
+        /// Detection is sound (no false positives) over the statically-resolvable intra-contract
+        /// call graph: a violation is reported when a Safe method, or any method transitively
+        /// reachable from it through direct calls, emits a <c>System.Storage.Put</c> /
+        /// <c>System.Storage.Delete</c> syscall. Writes reachable only through virtual dispatch,
+        /// dynamic (CALLA) invocations, or another contract (a cross-contract call carrying the
+        /// <c>WriteStates</c> flag) are out of scope here — they require interprocedural /
+        /// cross-contract dataflow and may be added later. <c>Runtime.Notify</c> is intentionally
+        /// not treated as a mutation: emitting an event does not change contract state.
+        /// </remarks>
+        private IEnumerable<CompilationException> GetSafeMethodViolations()
+        {
+            foreach (AbiMethod method in _methodsExported)
+            {
+                if (!method.Safe) continue;
+                if (!_methodsConverted.TryGetValue(method.Symbol, out MethodConvert? entry)) continue;
+                if (!TryFindReachableStorageWrite(entry!, out MethodConvert? writer)) continue;
+
+                string detail = ReferenceEquals(writer, entry)
+                    ? "writes to contract storage"
+                    : $"reaches a contract-storage write through '{writer!.Symbol.Name}'";
+                yield return new CompilationException(method.Symbol, DiagnosticId.SafeMethodStateMutation,
+                    $"Method '{method.Symbol.Name}' is marked [Safe] but {detail}. " +
+                    "A Safe method must not modify contract state; remove the [Safe] attribute or the state mutation.");
+            }
+        }
+
+        /// <summary>
+        /// Performs a depth-first walk of the intra-contract call graph starting at
+        /// <paramref name="entry"/> and reports the first method found that directly emits a
+        /// storage-write syscall (the entry method itself is checked first).
+        /// </summary>
+        private static bool TryFindReachableStorageWrite(MethodConvert entry, out MethodConvert? writer)
+        {
+            HashSet<MethodConvert> visited = new() { entry };
+            Stack<MethodConvert> pending = new();
+            pending.Push(entry);
+            while (pending.Count > 0)
+            {
+                MethodConvert current = pending.Pop();
+                if (WritesStorageDirectly(current))
+                {
+                    writer = current;
+                    return true;
+                }
+                foreach (MethodConvert callee in current.Callees)
+                    if (visited.Add(callee))
+                        pending.Push(callee);
+            }
+            writer = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when the method's own emitted instructions contain a
+        /// storage-write syscall (which also covers writes pulled in by inline expansion).
+        /// </summary>
+        private static bool WritesStorageDirectly(MethodConvert method)
+        {
+            foreach (Instruction instruction in method.Instructions)
+            {
+                if (instruction.OpCode != OpCode.SYSCALL || instruction.Operand is not { Length: 4 })
+                    continue;
+                uint token = BitConverter.ToUInt32(instruction.Operand, 0);
+                if (Array.IndexOf(StorageWriteSyscalls, token) >= 0)
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
@@ -34,7 +34,7 @@ using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
 namespace Neo.Compiler
 {
-    public class CompilationContext
+    public partial class CompilationContext
     {
         private readonly CompilationEngine _engine;
         private readonly INamedTypeSymbol _targetContract;
@@ -177,6 +177,14 @@ namespace Neo.Compiler
                 // disabled, we still prefer short-form jumps when the target is within range.
                 BasicOptimizer.CompressJumps(instructions);
                 instructions.RebuildOperands();
+            }
+            if (Success)
+            {
+                // A method advertised as [Safe] promises wallets and dApps it is read-only and can
+                // be invoked without a signature prompt. Verify that promise: fail the build when a
+                // Safe method mutates contract state, so the manifest cannot ship a false guarantee.
+                foreach (CompilationException violation in GetSafeMethodViolations())
+                    _diagnostics.Add(violation.Diagnostic);
             }
             if (Success && _supportedStandards.Count > 0)
             {

--- a/src/Neo.Compiler.CSharp/Diagnostic/DiagnosticId.cs
+++ b/src/Neo.Compiler.CSharp/Diagnostic/DiagnosticId.cs
@@ -40,6 +40,7 @@ namespace Neo.Compiler
         public const string InvalidType = "NC3008";
         public const string InvalidArgument = "NC3009";
         public const string SafeSetter = "NC3010";
+        public const string SafeMethodStateMutation = "NC3011";
         public const string FileOperationFailed = "NC4001";
         public const string UnexpectedCompilerError = "NC5001";
     }

--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/CallHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/CallHelpers.cs
@@ -623,6 +623,9 @@ internal partial class MethodConvert
 
     private void EmitCall(MethodConvert target)
     {
+        // Record the static call edge so post-codegen analyses (such as [Safe]-flag
+        // verification) can follow the intra-contract call graph.
+        _callees.Add(target);
         if (target._inline && !_context.Options.NoInline)
             EmitInlineInstructions(target);
         else

--- a/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/MethodConvert.cs
@@ -53,6 +53,7 @@ namespace Neo.Compiler
         private int _localsCount;
         private readonly Stack<List<ILocalSymbol>> _blockSymbols = new();
         private readonly List<Instruction> _instructions = new();
+        private readonly HashSet<MethodConvert> _callees = new();
         private readonly JumpTarget _startTarget = new();
         private readonly Dictionary<ILabelSymbol, JumpTarget> _labels = new(SymbolEqualityComparer.Default);
         private readonly Stack<JumpTarget> _continueTargets = new();
@@ -72,6 +73,15 @@ namespace Neo.Compiler
         public IMethodSymbol Symbol { get; }
         public SyntaxNode? SyntaxNode { get; private set; }
         public IReadOnlyList<Instruction> Instructions => _instructions;
+
+        /// <summary>
+        /// The set of in-contract methods this method directly calls through a statically
+        /// resolvable CALL (or inline expansion). Used to follow the intra-contract call graph
+        /// when verifying the <c>[Safe]</c> ABI flag. Virtual/dynamic (CALLA) dispatch and
+        /// cross-contract (CALLT) calls are not represented here.
+        /// </summary>
+        public IReadOnlyCollection<MethodConvert> Callees => _callees;
+
         public IReadOnlyList<(ILocalSymbol Symbol, byte SlotIndex)> Variables => _variableSymbols;
         public bool IsEmpty => _instructions.Count == 0
             || _instructions is [{ OpCode: OpCode.RET }]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeMethodEnforcement.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeMethodEnforcement.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_SafeMethodEnforcement.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests
+{
+    [TestClass]
+    public class UnitTest_SafeMethodEnforcement
+    {
+        private const string SafeMutationDiagnosticId = "NC3011";
+
+        private const string Header = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Services;
+
+public class Contract : SmartContract
+{
+";
+
+        private static string Compile(string body) => Header + body + "\n}";
+
+        [TestMethod]
+        public void SafeMethod_DirectStorageWrite_FailsCompilation()
+        {
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    [Safe]
+    public static void Get() => Storage.Put(Storage.CurrentContext, ""k"", ""v"");"));
+
+            Assert.IsFalse(context.Success, "A [Safe] method that writes storage must fail compilation.");
+            Assert.IsTrue(
+                context.Diagnostics.Any(d => d.Id == SafeMutationDiagnosticId && d.Severity == DiagnosticSeverity.Error),
+                "Expected an NC3011 error for a Safe method that mutates state.");
+        }
+
+        [TestMethod]
+        public void SafeMethod_TransitiveStorageWrite_FailsCompilation()
+        {
+            // The write is hidden behind a private helper: the check must follow the
+            // intra-contract call graph, not just scan the Safe method's own body.
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    [Safe]
+    public static void Get() => Write();
+
+    private static void Write() => Storage.Put(Storage.CurrentContext, ""k"", ""v"");"));
+
+            Assert.IsFalse(context.Success, "A [Safe] method that writes storage transitively must fail compilation.");
+            Assert.IsTrue(
+                context.Diagnostics.Any(d => d.Id == SafeMutationDiagnosticId && d.Severity == DiagnosticSeverity.Error),
+                "Expected an NC3011 error for a Safe method that reaches a write through a helper.");
+        }
+
+        [TestMethod]
+        public void SafeMethod_StorageDelete_FailsCompilation()
+        {
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    [Safe]
+    public static void Get() => Storage.Delete(Storage.CurrentContext, ""k"");"));
+
+            Assert.IsFalse(context.Success, "A [Safe] method that deletes storage must fail compilation.");
+            Assert.IsTrue(
+                context.Diagnostics.Any(d => d.Id == SafeMutationDiagnosticId && d.Severity == DiagnosticSeverity.Error),
+                "Expected an NC3011 error for a Safe method that deletes state.");
+        }
+
+        [TestMethod]
+        public void SafeMethod_ReadOnly_Compiles()
+        {
+            // Reading storage and emitting an event are not state mutations.
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    [Safe]
+    public static ByteString Get() => Storage.Get(Storage.CurrentContext, ""k"");"));
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            Assert.IsFalse(
+                context.Diagnostics.Any(d => d.Id == SafeMutationDiagnosticId),
+                "A read-only Safe method must not produce an NC3011 diagnostic.");
+        }
+
+        [TestMethod]
+        public void NonSafeMethod_StorageWrite_Compiles()
+        {
+            // The same write is perfectly legal when the method is not advertised as Safe.
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    public static void Put() => Storage.Put(Storage.CurrentContext, ""k"", ""v"");"));
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            Assert.IsFalse(
+                context.Diagnostics.Any(d => d.Id == SafeMutationDiagnosticId),
+                "A non-Safe method writing storage must not produce an NC3011 diagnostic.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The manifest `safe` flag is currently set purely from the presence of the `[Safe]` attribute, with **no verification that the method is actually read-only** (`AbiMethod.cs`: `Safe = GetSafeAttribute(symbol) != null`). Wallets, explorers and dApps treat `safe:true` as "free to call, no signature prompt", so a `[Safe]` method that writes storage advertises a **false on-chain guarantee**.

This is the direct analog of a Solidity `view` function performing an `SSTORE`, which `solc` rejects at compile time. This PR gives the Neo `[Safe]` flag the same enforcement.

## How

A post-codegen verification pass (`CompilationContext.SafeMethodAnalysis.cs`) runs after every method is converted and instructions are finalized. For each exported `[Safe]` method it walks the statically-resolvable **intra-contract call graph** and emits error **`NC3011`** when the method — or any method transitively reachable from it through direct calls — performs a `System.Storage.Put` / `System.Storage.Delete` syscall.

- **Call graph:** recorded as `MethodConvert` call edges at the single in-contract call chokepoint (`EmitCall`), so no fragile bytecode archaeology is needed.
- **Write detection:** read from the emitted `SYSCALL` operands, which also covers writes pulled in by inline expansion (inlined bodies are copied into the caller).
- **Severity:** error, consistent with the existing `[Safe]` setter rejection (`NC3010`).

## Soundness & scope

The check has **no false positives** over what it covers: storage writes are unambiguous state mutations, and every reported path follows a real static call edge. `Runtime.Notify` is intentionally **not** treated as a mutation (emitting an event is not a state change in the safe-to-call sense).

Deliberately **out of scope** (left for a follow-up, as they need interprocedural / cross-contract dataflow):
- writes reachable only through **virtual dispatch**;
- **dynamic** (`CALLA`) invocations;
- writes performed by **another contract** via a cross-contract call carrying the `WriteStates` flag.

## Testing

- New `UnitTest_SafeMethodEnforcement`: direct write, transitive write through a private helper, `Storage.Delete`, read-only Safe method (compiles), and a non-Safe writer (compiles).
- Full compiler (1319), framework (253), template (41), and testing (83) suites pass. All example contracts compile with no `NC3011`.
- The change emits **no bytecode**, so contract artifacts and gas baselines are unaffected (verified: test artifacts regenerate byte-identically; no artifact churn in this PR).