### PR TITLE
Add Ownable2Step base for safe two-step ownership transfer

### DIFF
--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -1,0 +1,196 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Ownable2Step.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+
+namespace Neo.SmartContract.Framework
+{
+    /// <summary>
+    /// A base contract providing two-step ownership transfer, the OpenZeppelin
+    /// <c>Ownable2Step</c> analog for Neo.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="Ownable"/>, ownership is never handed over in a single call.
+    /// <see cref="TransferOwnership"/> only records a <em>pending</em> owner; the transfer
+    /// completes only when that account itself calls <see cref="AcceptOwnership"/> and proves
+    /// control via <c>Runtime.CheckWitness</c>. This prevents the classic footgun where a
+    /// mistyped or otherwise unusable address is set as owner in one step and control is lost
+    /// forever. There is intentionally no single-step setter on this class.
+    /// <para>
+    /// <see cref="RenounceOwnership"/> is the one deliberate, irreversible action: it removes the
+    /// owner entirely (and any in-flight pending transfer). After renouncing, every owner-gated
+    /// method is permanently uncallable.
+    /// </para>
+    /// <para>
+    /// Composition note: do not gate <see cref="CancelOwnershipTransfer"/> or
+    /// <see cref="RenounceOwnership"/> behind a pause guard. Both must remain callable so that an
+    /// in-flight transfer to a compromised account can always be neutralized.
+    /// </para>
+    /// </remarks>
+    public abstract class Ownable2Step : SmartContract
+    {
+        // The current confirmed owner. Absent (null) means renounced or not yet initialized.
+        private const byte Prefix_Owner = 0xFD;
+
+        // The proposed owner awaiting acceptance. Absent (null) means no transfer is in flight.
+        private const byte Prefix_PendingOwner = 0xFC;
+
+        /// <summary>
+        /// Returns the current owner, or <see langword="null"/> if ownership has been renounced
+        /// or the contract has not been initialized.
+        /// </summary>
+        [Safe]
+        public static UInt160? GetOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_Owner })!;
+        }
+
+        /// <summary>
+        /// Returns the account that has been proposed as the new owner and is awaiting its own
+        /// acceptance, or <see langword="null"/> when no transfer is in flight.
+        /// </summary>
+        [Safe]
+        public static UInt160? GetPendingOwner()
+        {
+            return (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+        }
+
+        protected static bool IsOwner()
+        {
+            UInt160? owner = GetOwner();
+            return owner is not null && Runtime.CheckWitness(owner);
+        }
+
+        public delegate void OnOwnershipTransferStartedDelegate(UInt160? previousOwner, UInt160? newOwner);
+
+        /// <summary>
+        /// Raised when an owner proposes a new owner. <c>newOwner</c> is the pending candidate and
+        /// is not yet the owner; the change is not effective until <see cref="AcceptOwnership"/>.
+        /// </summary>
+        [DisplayName("OwnershipTransferStarted")]
+        public static event OnOwnershipTransferStartedDelegate OnOwnershipTransferStarted = null!;
+
+        public delegate void OnOwnershipTransferredDelegate(UInt160? previousOwner, UInt160? newOwner);
+
+        /// <summary>
+        /// Raised whenever the owner actually changes: on initialization (<c>previousOwner</c>
+        /// null), on a completed acceptance, and on renounce (<c>newOwner</c> null).
+        /// </summary>
+        [DisplayName("OwnershipTransferred")]
+        public static event OnOwnershipTransferredDelegate OnOwnershipTransferred = null!;
+
+        public delegate void OnOwnershipTransferCanceledDelegate(UInt160? currentOwner, UInt160? canceledPendingOwner);
+
+        /// <summary>
+        /// Raised when a pending transfer is dropped without completing: explicitly via
+        /// <see cref="CancelOwnershipTransfer"/>, or implicitly when a new proposal supersedes it.
+        /// </summary>
+        [DisplayName("OwnershipTransferCanceled")]
+        public static event OnOwnershipTransferCanceledDelegate OnOwnershipTransferCanceled = null!;
+
+        /// <summary>
+        /// Step 1 of an ownership transfer. The current owner proposes <paramref name="newOwner"/>;
+        /// the owner does not change until that account calls <see cref="AcceptOwnership"/>.
+        /// </summary>
+        public static void TransferOwnership(UInt160 newOwner)
+        {
+            if (!IsOwner())
+                throw new System.InvalidOperationException("No Authorization!");
+
+            ExecutionEngine.Assert(newOwner.IsValidAndNotZero, "owner must be valid");
+
+            UInt160? previousOwner = GetOwner();
+            ExecutionEngine.Assert(previousOwner != newOwner, "owner must change");
+
+            // A new proposal supersedes any earlier one; emit a terminal event for the dropped
+            // candidate so off-chain indexers never see a pending offer left dangling.
+            UInt160? oldPending = (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            if (oldPending is not null)
+                OnOwnershipTransferCanceled(previousOwner, oldPending);
+
+            Storage.Put(new[] { Prefix_PendingOwner }, newOwner);
+            OnOwnershipTransferStarted(previousOwner, newOwner);
+        }
+
+        /// <summary>
+        /// Step 2 of an ownership transfer. The pending owner accepts and becomes the owner.
+        /// Must be called by the pending account itself (verified with <c>Runtime.CheckWitness</c>).
+        /// </summary>
+        public static void AcceptOwnership()
+        {
+            UInt160? pendingOwner = (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            ExecutionEngine.Assert(pendingOwner is not null, "no pending owner");
+            ExecutionEngine.Assert(pendingOwner!.IsValidAndNotZero, "no pending owner");
+            ExecutionEngine.Assert(Runtime.CheckWitness(pendingOwner), "only pending owner");
+
+            UInt160? previousOwner = GetOwner();
+            Storage.Put(new[] { Prefix_Owner }, pendingOwner);
+            Storage.Delete(new[] { Prefix_PendingOwner });
+            OnOwnershipTransferred(previousOwner, pendingOwner);
+        }
+
+        /// <summary>
+        /// Cancels an in-flight ownership transfer, leaving the current owner in place. Only the
+        /// owner may call this, and only while a transfer is pending.
+        /// </summary>
+        public static void CancelOwnershipTransfer()
+        {
+            if (!IsOwner())
+                throw new System.InvalidOperationException("No Authorization!");
+
+            UInt160? pendingOwner = (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            ExecutionEngine.Assert(pendingOwner is not null, "no pending owner");
+
+            Storage.Delete(new[] { Prefix_PendingOwner });
+            OnOwnershipTransferCanceled(GetOwner(), pendingOwner);
+        }
+
+        /// <summary>
+        /// Permanently removes the owner. This is irreversible: after renouncing, every
+        /// owner-gated method becomes uncallable. Any in-flight pending transfer is also cleared
+        /// so a previously-proposed account cannot seize the abandoned contract.
+        /// </summary>
+        public static void RenounceOwnership()
+        {
+            if (!IsOwner())
+                throw new System.InvalidOperationException("No Authorization!");
+
+            UInt160? previousOwner = GetOwner();
+            Storage.Delete(new[] { Prefix_Owner });
+            Storage.Delete(new[] { Prefix_PendingOwner });
+            OnOwnershipTransferred(previousOwner, null);
+        }
+
+        /// <summary>
+        /// Initializes the owner. Call this from the contract's <c>_deploy</c> method.
+        /// </summary>
+        /// <remarks>
+        /// On a contract update this is a no-op and never resets the owner. Note that an in-flight
+        /// pending transfer is intentionally left untouched across an update; operators should
+        /// cancel any in-flight transfer before upgrading if the upgrade changes trust assumptions.
+        /// </remarks>
+        protected static void InitializeOwner(object? data, bool update)
+        {
+            if (update)
+                return;
+
+            data ??= Runtime.Transaction.Sender;
+
+            UInt160 initialOwner = (UInt160)data;
+            ExecutionEngine.Assert(initialOwner.IsValidAndNotZero, "owner must be valid");
+
+            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OnOwnershipTransferred(null, initialOwner);
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -112,8 +112,6 @@ namespace Neo.SmartContract.Framework
             if (!IsOwner())
                 throw new System.InvalidOperationException("No Authorization!");
 
-            var pendingOwnerStorage = PendingOwnerStorage;
-
             ExecutionEngine.Assert(newOwner.IsValidAndNotZero, "owner must be valid");
 
             UInt160? previousOwner = GetOwner();
@@ -121,6 +119,7 @@ namespace Neo.SmartContract.Framework
 
             // A new proposal supersedes any earlier one; emit a terminal event for the dropped
             // candidate so off-chain indexers never see a pending offer left dangling.
+            var pendingOwnerStorage = PendingOwnerStorage;
             UInt160? oldPending = (UInt160)pendingOwnerStorage.Get(ByteString.Empty)!;
             if (oldPending is not null)
                 OnOwnershipTransferCanceled(previousOwner, oldPending);

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -183,13 +183,15 @@ namespace Neo.SmartContract.Framework
         /// Initializes the owner. Call this from the contract's <c>_deploy</c> method.
         /// </summary>
         /// <remarks>
-        /// On a contract update this is a no-op and never resets the owner. Note that an in-flight
-        /// pending transfer is intentionally left untouched across an update; operators should
-        /// cancel any in-flight transfer before upgrading if the upgrade changes trust assumptions.
+        /// On a contract update this preserves the current owner. If no owner is stored yet, it
+        /// initializes one so contracts adopting <see cref="Ownable2Step"/> during an upgrade do not
+        /// remain ownerless. Note that an in-flight pending transfer is intentionally left untouched
+        /// across an update; operators should cancel any in-flight transfer before upgrading if the
+        /// upgrade changes trust assumptions.
         /// </remarks>
         protected static void InitializeOwner(object? data, bool update)
         {
-            if (update)
+            if (update && GetOwner() is not null)
                 return;
 
             data ??= Runtime.Transaction.Sender;

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -12,6 +12,7 @@
 using Neo.SmartContract.Framework.Attributes;
 using Neo.SmartContract.Framework.Services;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Neo.SmartContract.Framework
 {
@@ -37,6 +38,7 @@ namespace Neo.SmartContract.Framework
     /// in-flight transfer to a compromised account can always be neutralized.
     /// </para>
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     public abstract class Ownable2Step : SmartContract
     {
         // The current confirmed owner. Absent (null) means renounced or not yet initialized.

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -112,6 +112,8 @@ namespace Neo.SmartContract.Framework
             if (!IsOwner())
                 throw new System.InvalidOperationException("No Authorization!");
 
+            var pendingOwnerStorage = PendingOwnerStorage;
+
             ExecutionEngine.Assert(newOwner.IsValidAndNotZero, "owner must be valid");
 
             UInt160? previousOwner = GetOwner();
@@ -119,11 +121,11 @@ namespace Neo.SmartContract.Framework
 
             // A new proposal supersedes any earlier one; emit a terminal event for the dropped
             // candidate so off-chain indexers never see a pending offer left dangling.
-            UInt160? oldPending = (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
+            UInt160? oldPending = (UInt160)pendingOwnerStorage.Get(ByteString.Empty)!;
             if (oldPending is not null)
                 OnOwnershipTransferCanceled(previousOwner, oldPending);
 
-            PendingOwnerStorage.Put(ByteString.Empty, newOwner);
+            pendingOwnerStorage.Put(ByteString.Empty, newOwner);
             OnOwnershipTransferStarted(previousOwner, newOwner);
         }
 
@@ -133,14 +135,15 @@ namespace Neo.SmartContract.Framework
         /// </summary>
         public static void AcceptOwnership()
         {
-            UInt160? pendingOwner = (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
+            var pendingOwnerStorage = PendingOwnerStorage;
+            UInt160? pendingOwner = (UInt160)pendingOwnerStorage.Get(ByteString.Empty)!;
             ExecutionEngine.Assert(pendingOwner is not null, "no pending owner");
             ExecutionEngine.Assert(pendingOwner!.IsValidAndNotZero, "no pending owner");
             ExecutionEngine.Assert(Runtime.CheckWitness(pendingOwner), "only pending owner");
 
             UInt160? previousOwner = GetOwner();
             OwnerStorage.Put(ByteString.Empty, pendingOwner);
-            PendingOwnerStorage.Delete(ByteString.Empty);
+            pendingOwnerStorage.Delete(ByteString.Empty);
             OnOwnershipTransferred(previousOwner, pendingOwner);
         }
 
@@ -153,10 +156,11 @@ namespace Neo.SmartContract.Framework
             if (!IsOwner())
                 throw new System.InvalidOperationException("No Authorization!");
 
-            UInt160? pendingOwner = (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
+            var pendingOwnerStorage = PendingOwnerStorage;
+            UInt160? pendingOwner = (UInt160)pendingOwnerStorage.Get(ByteString.Empty)!;
             ExecutionEngine.Assert(pendingOwner is not null, "no pending owner");
 
-            PendingOwnerStorage.Delete(ByteString.Empty);
+            pendingOwnerStorage.Delete(ByteString.Empty);
             OnOwnershipTransferCanceled(GetOwner(), pendingOwner);
         }
 

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -47,6 +47,9 @@ namespace Neo.SmartContract.Framework
         // The proposed owner awaiting acceptance. Absent (null) means no transfer is in flight.
         private const byte Prefix_PendingOwner = 0xFC;
 
+        private static LocalStorageMap OwnerStorage => new(Prefix_Owner);
+        private static LocalStorageMap PendingOwnerStorage => new(Prefix_PendingOwner);
+
         /// <summary>
         /// Returns the current owner, or <see langword="null"/> if ownership has been renounced
         /// or the contract has not been initialized.
@@ -54,7 +57,7 @@ namespace Neo.SmartContract.Framework
         [Safe]
         public static UInt160? GetOwner()
         {
-            return (UInt160)Storage.Get(new[] { Prefix_Owner })!;
+            return (UInt160)OwnerStorage.Get(ByteString.Empty)!;
         }
 
         /// <summary>
@@ -64,7 +67,7 @@ namespace Neo.SmartContract.Framework
         [Safe]
         public static UInt160? GetPendingOwner()
         {
-            return (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            return (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
         }
 
         protected static bool IsOwner()
@@ -116,11 +119,11 @@ namespace Neo.SmartContract.Framework
 
             // A new proposal supersedes any earlier one; emit a terminal event for the dropped
             // candidate so off-chain indexers never see a pending offer left dangling.
-            UInt160? oldPending = (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            UInt160? oldPending = (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
             if (oldPending is not null)
                 OnOwnershipTransferCanceled(previousOwner, oldPending);
 
-            Storage.Put(new[] { Prefix_PendingOwner }, newOwner);
+            PendingOwnerStorage.Put(ByteString.Empty, newOwner);
             OnOwnershipTransferStarted(previousOwner, newOwner);
         }
 
@@ -130,14 +133,14 @@ namespace Neo.SmartContract.Framework
         /// </summary>
         public static void AcceptOwnership()
         {
-            UInt160? pendingOwner = (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            UInt160? pendingOwner = (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
             ExecutionEngine.Assert(pendingOwner is not null, "no pending owner");
             ExecutionEngine.Assert(pendingOwner!.IsValidAndNotZero, "no pending owner");
             ExecutionEngine.Assert(Runtime.CheckWitness(pendingOwner), "only pending owner");
 
             UInt160? previousOwner = GetOwner();
-            Storage.Put(new[] { Prefix_Owner }, pendingOwner);
-            Storage.Delete(new[] { Prefix_PendingOwner });
+            OwnerStorage.Put(ByteString.Empty, pendingOwner);
+            PendingOwnerStorage.Delete(ByteString.Empty);
             OnOwnershipTransferred(previousOwner, pendingOwner);
         }
 
@@ -150,10 +153,10 @@ namespace Neo.SmartContract.Framework
             if (!IsOwner())
                 throw new System.InvalidOperationException("No Authorization!");
 
-            UInt160? pendingOwner = (UInt160)Storage.Get(new[] { Prefix_PendingOwner })!;
+            UInt160? pendingOwner = (UInt160)PendingOwnerStorage.Get(ByteString.Empty)!;
             ExecutionEngine.Assert(pendingOwner is not null, "no pending owner");
 
-            Storage.Delete(new[] { Prefix_PendingOwner });
+            PendingOwnerStorage.Delete(ByteString.Empty);
             OnOwnershipTransferCanceled(GetOwner(), pendingOwner);
         }
 
@@ -168,8 +171,8 @@ namespace Neo.SmartContract.Framework
                 throw new System.InvalidOperationException("No Authorization!");
 
             UInt160? previousOwner = GetOwner();
-            Storage.Delete(new[] { Prefix_Owner });
-            Storage.Delete(new[] { Prefix_PendingOwner });
+            OwnerStorage.Delete(ByteString.Empty);
+            PendingOwnerStorage.Delete(ByteString.Empty);
             OnOwnershipTransferred(previousOwner, null);
         }
 
@@ -191,7 +194,7 @@ namespace Neo.SmartContract.Framework
             UInt160 initialOwner = (UInt160)data;
             ExecutionEngine.Assert(initialOwner.IsValidAndNotZero, "owner must be valid");
 
-            Storage.Put(new[] { Prefix_Owner }, initialOwner);
+            OwnerStorage.Put(ByteString.Empty, initialOwner);
             OnOwnershipTransferred(null, initialOwner);
         }
     }

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -190,9 +190,10 @@ namespace Neo.SmartContract.Framework
         /// <remarks>
         /// On a contract update this preserves the current owner. If no owner is stored yet, it
         /// initializes one so contracts adopting <see cref="Ownable2Step"/> during an upgrade do not
-        /// remain ownerless. Note that an in-flight pending transfer is intentionally left untouched
-        /// across an update; operators should cancel any in-flight transfer before upgrading if the
-        /// upgrade changes trust assumptions.
+        /// remain ownerless. If an owner exists but the initialization marker is missing, the update
+        /// aborts instead of silently accepting inconsistent ownership state. Note that an in-flight
+        /// pending transfer is intentionally left untouched across an update; operators should cancel
+        /// any in-flight transfer before upgrading if the upgrade changes trust assumptions.
         /// </remarks>
         protected static void InitializeOwner(object? data, bool update)
         {
@@ -201,11 +202,7 @@ namespace Neo.SmartContract.Framework
                 if (OwnerInitializedStorage.GetBoolean(ByteString.Empty))
                     return;
 
-                if (GetOwner() is not null)
-                {
-                    OwnerInitializedStorage.Put(ByteString.Empty, true);
-                    return;
-                }
+                ExecutionEngine.Assert(GetOwner() is null, "owner initialization state is inconsistent");
             }
 
             data ??= Runtime.Transaction.Sender;

--- a/src/Neo.SmartContract.Framework/Ownable2Step.cs
+++ b/src/Neo.SmartContract.Framework/Ownable2Step.cs
@@ -47,8 +47,12 @@ namespace Neo.SmartContract.Framework
         // The proposed owner awaiting acceptance. Absent (null) means no transfer is in flight.
         private const byte Prefix_PendingOwner = 0xFC;
 
+        // Separates "not initialized yet" from "initialized and later renounced".
+        private const byte Prefix_OwnerInitialized = 0xFB;
+
         private static LocalStorageMap OwnerStorage => new(Prefix_Owner);
         private static LocalStorageMap PendingOwnerStorage => new(Prefix_PendingOwner);
+        private static LocalStorageMap OwnerInitializedStorage => new(Prefix_OwnerInitialized);
 
         /// <summary>
         /// Returns the current owner, or <see langword="null"/> if ownership has been renounced
@@ -175,6 +179,7 @@ namespace Neo.SmartContract.Framework
 
             UInt160? previousOwner = GetOwner();
             OwnerStorage.Delete(ByteString.Empty);
+            OwnerInitializedStorage.Put(ByteString.Empty, true);
             PendingOwnerStorage.Delete(ByteString.Empty);
             OnOwnershipTransferred(previousOwner, null);
         }
@@ -191,8 +196,17 @@ namespace Neo.SmartContract.Framework
         /// </remarks>
         protected static void InitializeOwner(object? data, bool update)
         {
-            if (update && GetOwner() is not null)
-                return;
+            if (update)
+            {
+                if (OwnerInitializedStorage.GetBoolean(ByteString.Empty))
+                    return;
+
+                if (GetOwner() is not null)
+                {
+                    OwnerInitializedStorage.Put(ByteString.Empty, true);
+                    return;
+                }
+            }
 
             data ??= Runtime.Transaction.Sender;
 
@@ -200,6 +214,7 @@ namespace Neo.SmartContract.Framework
             ExecutionEngine.Assert(initialOwner.IsValidAndNotZero, "owner must be valid");
 
             OwnerStorage.Put(ByteString.Empty, initialOwner);
+            OwnerInitializedStorage.Put(ByteString.Empty, true);
             OnOwnershipTransferred(null, initialOwner);
         }
     }

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -284,6 +284,22 @@ public class Ownable2StepTest
     }
 
     [TestMethod]
+    public void InitializeOwner_UpdateInitializesWhenOwnerMissing()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.ClearOwnerForTest();
+        Assert.IsNull(contract.GetOwner());
+
+        contract.InitializeForTest(Bob.Account, true);
+
+        Assert.AreEqual(Bob.Account, contract.GetOwner());
+        Assert.IsNull(contract.GetPendingOwner());
+        Merge(contract);
+    }
+
+    [TestMethod]
     public void RePropose_SupersedesPending()
     {
         var engine = CreateEngine();

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -121,6 +121,19 @@ public class Ownable2StepTest
     }
 
     [TestMethod]
+    public void AcceptOwnership_InvalidStoredPending_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.SetPendingOwnerForTest(UInt160.Zero);
+
+        Assert.AreEqual(UInt160.Zero, contract.GetPendingOwner());
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+        Merge(contract);
+    }
+
+    [TestMethod]
     public void AcceptOwnership_ByWrongAccount_Aborts()
     {
         var engine = CreateEngine();
@@ -240,6 +253,19 @@ public class Ownable2StepTest
     }
 
     [TestMethod]
+    public void OwnerGatedMethods_WithNoStoredOwner_Throw()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.ClearOwnerForTest();
+
+        Assert.IsNull(contract.GetOwner());
+        Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Bob.Account));
+        Merge(contract);
+    }
+
+    [TestMethod]
     public void InitializeOwner_UpdateIsNoOp_AndInvalidOwnerAborts()
     {
         var engine = CreateEngine();
@@ -353,6 +379,7 @@ public class Ownable2StepTest
     private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) CompileContract()
     {
         const string source = @"using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services;
 
 public class Contract : Ownable2Step
 {
@@ -364,6 +391,16 @@ public class Contract : Ownable2Step
     public static void InitializeForTest(object data, bool update)
     {
         InitializeOwner(data, update);
+    }
+
+    public static void SetPendingOwnerForTest(UInt160 pendingOwner)
+    {
+        Storage.Put(new byte[] { 0xFC }, pendingOwner);
+    }
+
+    public static void ClearOwnerForTest()
+    {
+        Storage.Delete(new byte[] { 0xFD });
     }
 }";
 
@@ -420,6 +457,12 @@ public class Contract : Ownable2Step
 
         [DisplayName("initializeForTest")]
         public abstract void InitializeForTest(object data, bool update);
+
+        [DisplayName("setPendingOwnerForTest")]
+        public abstract void SetPendingOwnerForTest(UInt160 pendingOwner);
+
+        [DisplayName("clearOwnerForTest")]
+        public abstract void ClearOwnerForTest();
 
         [DisplayName("transferOwnership")]
         public abstract void TransferOwnership(UInt160 newOwner);

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -300,6 +300,19 @@ public class Ownable2StepTest
     }
 
     [TestMethod]
+    public void InitializeOwner_UpdateWithUnmarkedOwner_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.SetOwnerWithoutInitializedForTest(Bob.Account);
+
+        Assert.ThrowsException<TestException>(() => contract.InitializeForTest(Charlie.Account, true));
+        Assert.AreEqual(Bob.Account, contract.GetOwner());
+        Merge(contract);
+    }
+
+    [TestMethod]
     public void InitializeOwner_UpdateDoesNotReinitializeAfterRenounce()
     {
         var engine = CreateEngine();
@@ -438,6 +451,12 @@ public class Contract : Ownable2Step
         Storage.Delete(new byte[] { 0xFD });
         Storage.Delete(new byte[] { 0xFB });
     }
+
+    public static void SetOwnerWithoutInitializedForTest(UInt160 owner)
+    {
+        Storage.Put(new byte[] { 0xFD }, owner);
+        Storage.Delete(new byte[] { 0xFB });
+    }
 }";
 
         var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
@@ -502,6 +521,9 @@ public class Contract : Ownable2Step
 
         [DisplayName("clearOwnershipStateForTest")]
         public abstract void ClearOwnershipStateForTest();
+
+        [DisplayName("setOwnerWithoutInitializedForTest")]
+        public abstract void SetOwnerWithoutInitializedForTest(UInt160 owner);
 
         [DisplayName("transferOwnership")]
         public abstract void TransferOwnership(UInt160 newOwner);

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -15,6 +15,7 @@ using Neo.Compiler;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Coverage;
 using Neo.SmartContract.Testing.Exceptions;
 using System;
 using System.ComponentModel;
@@ -31,7 +32,7 @@ public class Ownable2StepTest
     private static readonly Signer Bob = TestEngine.Bob;
     private static readonly Signer Charlie = TestEngine.Charlie;
 
-    private static (NefFile nef, ContractManifest manifest) _compiled;
+    private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) _compiled;
 
     [ClassInitialize]
     public static void ClassInitialize(TestContext _) => _compiled = CompileContract();
@@ -44,6 +45,7 @@ public class Ownable2StepTest
 
         Assert.AreEqual(Alice.Account, contract.GetOwner());
         Assert.IsNull(contract.GetPendingOwner());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -62,6 +64,7 @@ public class Ownable2StepTest
         contract.AcceptOwnership();
         Assert.AreEqual(Bob.Account, contract.GetOwner());
         Assert.IsNull(contract.GetPendingOwner());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -72,6 +75,7 @@ public class Ownable2StepTest
 
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Bob.Account));
+        Merge(contract);
     }
 
     [TestMethod]
@@ -81,6 +85,7 @@ public class Ownable2StepTest
         var contract = Deploy(engine, out _, out _);
 
         Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Alice.Account));
+        Merge(contract);
     }
 
     [TestMethod]
@@ -90,6 +95,7 @@ public class Ownable2StepTest
         var contract = Deploy(engine, out _, out _);
 
         Assert.ThrowsException<TestException>(() => contract.TransferOwnership(UInt160.Zero));
+        Merge(contract);
     }
 
     [TestMethod]
@@ -100,6 +106,7 @@ public class Ownable2StepTest
 
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -119,6 +126,7 @@ public class Ownable2StepTest
 
         // Pending is still Bob; the offer survives the failed attempts.
         Assert.AreEqual(Bob.Account, contract.GetPendingOwner());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -132,6 +140,7 @@ public class Ownable2StepTest
         contract.AcceptOwnership();
 
         Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -149,6 +158,7 @@ public class Ownable2StepTest
         // Bob can no longer seize the abandoned contract.
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -166,6 +176,7 @@ public class Ownable2StepTest
         // The formerly-pending account can no longer accept.
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -175,6 +186,7 @@ public class Ownable2StepTest
         var contract = Deploy(engine, out _, out _);
 
         Assert.ThrowsException<TestException>(() => contract.CancelOwnershipTransfer());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -186,6 +198,7 @@ public class Ownable2StepTest
         contract.TransferOwnership(Bob.Account);
         engine.SetTransactionSigners(Charlie);
         Assert.ThrowsException<TestException>(() => contract.CancelOwnershipTransfer());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -201,6 +214,7 @@ public class Ownable2StepTest
         Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Bob.Account));
         Assert.ThrowsException<TestException>(() => contract.CancelOwnershipTransfer());
         Assert.ThrowsException<TestException>(() => contract.RenounceOwnership());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -211,6 +225,7 @@ public class Ownable2StepTest
 
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => contract.RenounceOwnership());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -232,6 +247,7 @@ public class Ownable2StepTest
         engine.SetTransactionSigners(Charlie);
         contract.AcceptOwnership();
         Assert.AreEqual(Charlie.Account, contract.GetOwner());
+        Merge(contract);
     }
 
     [TestMethod]
@@ -272,12 +288,13 @@ public class Ownable2StepTest
         Assert.IsTrue(transferredRaised);
         Assert.AreEqual(Charlie.Account, transferredPrev);
         Assert.IsNull(transferredNew);
+        Merge(contract);
     }
 
     [TestMethod]
     public void Manifest_SafeFlags_GettersSafe_MutatorsUnsafe()
     {
-        var (_, manifest) = _compiled;
+        var (_, manifest, _) = _compiled;
         var abi = manifest.Abi.Methods;
 
         foreach (var safe in new[] { "getOwner", "getPendingOwner" })
@@ -289,9 +306,13 @@ public class Ownable2StepTest
 
     private static OwnableTwoStepProxy Deploy(TestEngine engine, out NefFile nef, out ContractManifest manifest)
     {
-        (nef, manifest) = _compiled;
+        nef = _compiled.nef;
+        manifest = _compiled.manifest;
         return engine.Deploy<OwnableTwoStepProxy>(nef, manifest, null);
     }
+
+    private static void Merge(OwnableTwoStepProxy contract)
+        => DynamicCoverageMergeHelper.Merge(contract, _compiled.debugInfo);
 
     private static TestEngine CreateEngine()
     {
@@ -300,7 +321,7 @@ public class Ownable2StepTest
         return engine;
     }
 
-    private static (NefFile nef, ContractManifest manifest) CompileContract()
+    private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) CompileContract()
     {
         const string source = @"using Neo.SmartContract.Framework;
 
@@ -331,8 +352,8 @@ public class Contract : Ownable2Step
             var context = contexts[0];
             Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
 
-            var (nef, manifest, _) = context.CreateResults(repoRoot);
-            return (nef, manifest);
+            var (nef, manifest, debugInfoJson) = context.CreateResults(repoRoot);
+            return (nef, manifest, NeoDebugInfo.FromDebugInfoJson(debugInfoJson));
         }
         finally
         {

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -289,13 +289,27 @@ public class Ownable2StepTest
         var engine = CreateEngine();
         var contract = Deploy(engine, out _, out _);
 
-        contract.ClearOwnerForTest();
+        contract.ClearOwnershipStateForTest();
         Assert.IsNull(contract.GetOwner());
 
         contract.InitializeForTest(Bob.Account, true);
 
         Assert.AreEqual(Bob.Account, contract.GetOwner());
         Assert.IsNull(contract.GetPendingOwner());
+        Merge(contract);
+    }
+
+    [TestMethod]
+    public void InitializeOwner_UpdateDoesNotReinitializeAfterRenounce()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.RenounceOwnership();
+        contract.InitializeForTest(Bob.Account, true);
+
+        Assert.IsNull(contract.GetOwner());
+        Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Charlie.Account));
         Merge(contract);
     }
 
@@ -418,6 +432,12 @@ public class Contract : Ownable2Step
     {
         Storage.Delete(new byte[] { 0xFD });
     }
+
+    public static void ClearOwnershipStateForTest()
+    {
+        Storage.Delete(new byte[] { 0xFD });
+        Storage.Delete(new byte[] { 0xFB });
+    }
 }";
 
         var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
@@ -479,6 +499,9 @@ public class Contract : Ownable2Step
 
         [DisplayName("clearOwnerForTest")]
         public abstract void ClearOwnerForTest();
+
+        [DisplayName("clearOwnershipStateForTest")]
+        public abstract void ClearOwnershipStateForTest();
 
         [DisplayName("transferOwnership")]
         public abstract void TransferOwnership(UInt160 newOwner);

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -49,6 +49,17 @@ public class Ownable2StepTest
     }
 
     [TestMethod]
+    public void Deploy_WithExplicitOwner_InitializesOwnerFromData()
+    {
+        var engine = CreateEngine();
+        var contract = engine.Deploy<OwnableTwoStepProxy>(_compiled.nef, _compiled.manifest, Bob.Account);
+
+        Assert.AreEqual(Bob.Account, contract.GetOwner());
+        Assert.IsNull(contract.GetPendingOwner());
+        Merge(contract);
+    }
+
+    [TestMethod]
     public void HappyPath_TwoStepTransfer()
     {
         var engine = CreateEngine();
@@ -229,6 +240,24 @@ public class Ownable2StepTest
     }
 
     [TestMethod]
+    public void InitializeOwner_UpdateIsNoOp_AndInvalidOwnerAborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+        contract.InitializeForTest(Charlie.Account, true);
+
+        Assert.AreEqual(Alice.Account, contract.GetOwner());
+        Assert.AreEqual(Bob.Account, contract.GetPendingOwner());
+
+        Assert.ThrowsException<TestException>(() => contract.InitializeForTest(UInt160.Zero, false));
+        Assert.AreEqual(Alice.Account, contract.GetOwner());
+        Assert.AreEqual(Bob.Account, contract.GetPendingOwner());
+        Merge(contract);
+    }
+
+    [TestMethod]
     public void RePropose_SupersedesPending()
     {
         var engine = CreateEngine();
@@ -331,6 +360,11 @@ public class Contract : Ownable2Step
     {
         InitializeOwner(data, update);
     }
+
+    public static void InitializeForTest(object data, bool update)
+    {
+        InitializeOwner(data, update);
+    }
 }";
 
         var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
@@ -383,6 +417,9 @@ public class Contract : Ownable2Step
 
         [DisplayName("getPendingOwner")]
         public abstract UInt160? GetPendingOwner();
+
+        [DisplayName("initializeForTest")]
+        public abstract void InitializeForTest(object data, bool update);
 
         [DisplayName("transferOwnership")]
         public abstract void TransferOwnership(UInt160 newOwner);

--- a/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Ownable2StepTest.cs
@@ -1,0 +1,378 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Ownable2StepTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Exceptions;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using CompilationOptions = Neo.Compiler.CompilationOptions;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+[TestClass]
+public class Ownable2StepTest
+{
+    private static readonly Signer Alice = TestEngine.Alice;
+    private static readonly Signer Bob = TestEngine.Bob;
+    private static readonly Signer Charlie = TestEngine.Charlie;
+
+    private static (NefFile nef, ContractManifest manifest) _compiled;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext _) => _compiled = CompileContract();
+
+    [TestMethod]
+    public void Deploy_InitializesOwnerToSender_NoPending()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        Assert.AreEqual(Alice.Account, contract.GetOwner());
+        Assert.IsNull(contract.GetPendingOwner());
+    }
+
+    [TestMethod]
+    public void HappyPath_TwoStepTransfer()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        // Step 1: owner proposes Bob — owner unchanged, pending == Bob.
+        contract.TransferOwnership(Bob.Account);
+        Assert.AreEqual(Alice.Account, contract.GetOwner());
+        Assert.AreEqual(Bob.Account, contract.GetPendingOwner());
+
+        // Step 2: Bob accepts — Bob is the owner, pending cleared.
+        engine.SetTransactionSigners(Bob);
+        contract.AcceptOwnership();
+        Assert.AreEqual(Bob.Account, contract.GetOwner());
+        Assert.IsNull(contract.GetPendingOwner());
+    }
+
+    [TestMethod]
+    public void TransferOwnership_ByNonOwner_Throws()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Bob.Account));
+    }
+
+    [TestMethod]
+    public void TransferOwnership_ToSelf_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Alice.Account));
+    }
+
+    [TestMethod]
+    public void TransferOwnership_ToZero_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        Assert.ThrowsException<TestException>(() => contract.TransferOwnership(UInt160.Zero));
+    }
+
+    [TestMethod]
+    public void AcceptOwnership_NoPending_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+    }
+
+    [TestMethod]
+    public void AcceptOwnership_ByWrongAccount_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+
+        // Current owner cannot accept on the pending owner's behalf.
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+
+        // A third party cannot accept either.
+        engine.SetTransactionSigners(Charlie);
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+
+        // Pending is still Bob; the offer survives the failed attempts.
+        Assert.AreEqual(Bob.Account, contract.GetPendingOwner());
+    }
+
+    [TestMethod]
+    public void AcceptOwnership_Twice_SecondAborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+        engine.SetTransactionSigners(Bob);
+        contract.AcceptOwnership();
+
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+    }
+
+    [TestMethod]
+    public void Renounce_ThenStaleAccept_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+        contract.RenounceOwnership();
+
+        Assert.IsNull(contract.GetOwner());
+        Assert.IsNull(contract.GetPendingOwner());
+
+        // Bob can no longer seize the abandoned contract.
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+    }
+
+    [TestMethod]
+    public void CancelOwnershipTransfer_ClearsPending_OwnerKept()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+        contract.CancelOwnershipTransfer();
+
+        Assert.AreEqual(Alice.Account, contract.GetOwner());
+        Assert.IsNull(contract.GetPendingOwner());
+
+        // The formerly-pending account can no longer accept.
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+    }
+
+    [TestMethod]
+    public void CancelOwnershipTransfer_NothingPending_Aborts()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        Assert.ThrowsException<TestException>(() => contract.CancelOwnershipTransfer());
+    }
+
+    [TestMethod]
+    public void CancelOwnershipTransfer_ByNonOwner_Throws()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+        engine.SetTransactionSigners(Charlie);
+        Assert.ThrowsException<TestException>(() => contract.CancelOwnershipTransfer());
+    }
+
+    [TestMethod]
+    public void RenounceOwnership_RemovesOwner_AndLocksOut()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.RenounceOwnership();
+        Assert.IsNull(contract.GetOwner());
+
+        // Every owner-gated method is now permanently uncallable.
+        Assert.ThrowsException<TestException>(() => contract.TransferOwnership(Bob.Account));
+        Assert.ThrowsException<TestException>(() => contract.CancelOwnershipTransfer());
+        Assert.ThrowsException<TestException>(() => contract.RenounceOwnership());
+    }
+
+    [TestMethod]
+    public void RenounceOwnership_ByNonOwner_Throws()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.RenounceOwnership());
+    }
+
+    [TestMethod]
+    public void RePropose_SupersedesPending()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        contract.TransferOwnership(Bob.Account);
+        contract.TransferOwnership(Charlie.Account);
+
+        Assert.AreEqual(Charlie.Account, contract.GetPendingOwner());
+
+        // Bob's offer was superseded; he can no longer accept.
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => contract.AcceptOwnership());
+
+        // Charlie can.
+        engine.SetTransactionSigners(Charlie);
+        contract.AcceptOwnership();
+        Assert.AreEqual(Charlie.Account, contract.GetOwner());
+    }
+
+    [TestMethod]
+    public void Events_StartedAcceptedCanceledRenounced_AreRaised()
+    {
+        var engine = CreateEngine();
+        var contract = Deploy(engine, out _, out _);
+
+        UInt160? startedPrev = null, startedNew = null;
+        UInt160? transferredPrev = null, transferredNew = null;
+        UInt160? canceledOwner = null, canceledPending = null;
+        bool transferredRaised = false;
+        contract.OnOwnershipTransferStarted += (p, n) => { startedPrev = p; startedNew = n; };
+        contract.OnOwnershipTransferred += (p, n) => { transferredPrev = p; transferredNew = n; transferredRaised = true; };
+        contract.OnOwnershipTransferCanceled += (o, c) => { canceledOwner = o; canceledPending = c; };
+
+        // Propose -> Started(Alice, Bob)
+        contract.TransferOwnership(Bob.Account);
+        Assert.AreEqual(Alice.Account, startedPrev);
+        Assert.AreEqual(Bob.Account, startedNew);
+
+        // Re-propose -> Canceled(Alice, Bob) then Started(Alice, Charlie)
+        contract.TransferOwnership(Charlie.Account);
+        Assert.AreEqual(Alice.Account, canceledOwner);
+        Assert.AreEqual(Bob.Account, canceledPending);
+        Assert.AreEqual(Charlie.Account, startedNew);
+
+        // Accept -> Transferred(Alice, Charlie)
+        engine.SetTransactionSigners(Charlie);
+        contract.AcceptOwnership();
+        Assert.IsTrue(transferredRaised);
+        Assert.AreEqual(Alice.Account, transferredPrev);
+        Assert.AreEqual(Charlie.Account, transferredNew);
+
+        // Renounce -> Transferred(Charlie, null)
+        transferredRaised = false;
+        contract.RenounceOwnership();
+        Assert.IsTrue(transferredRaised);
+        Assert.AreEqual(Charlie.Account, transferredPrev);
+        Assert.IsNull(transferredNew);
+    }
+
+    [TestMethod]
+    public void Manifest_SafeFlags_GettersSafe_MutatorsUnsafe()
+    {
+        var (_, manifest) = _compiled;
+        var abi = manifest.Abi.Methods;
+
+        foreach (var safe in new[] { "getOwner", "getPendingOwner" })
+            Assert.IsTrue(abi.Single(m => m.Name == safe).Safe, $"{safe} must be safe");
+
+        foreach (var mutator in new[] { "transferOwnership", "acceptOwnership", "cancelOwnershipTransfer", "renounceOwnership" })
+            Assert.IsFalse(abi.Single(m => m.Name == mutator).Safe, $"{mutator} must not be safe");
+    }
+
+    private static OwnableTwoStepProxy Deploy(TestEngine engine, out NefFile nef, out ContractManifest manifest)
+    {
+        (nef, manifest) = _compiled;
+        return engine.Deploy<OwnableTwoStepProxy>(nef, manifest, null);
+    }
+
+    private static TestEngine CreateEngine()
+    {
+        var engine = new TestEngine(true);
+        engine.SetTransactionSigners(Alice);
+        return engine;
+    }
+
+    private static (NefFile nef, ContractManifest manifest) CompileContract()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+
+public class Contract : Ownable2Step
+{
+    public static void _deploy(object data, bool update)
+    {
+        InitializeOwner(data, update);
+    }
+}";
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, source);
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+            var engine = new CompilationEngine(options);
+            var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences { Projects = new[] { frameworkProject } }, tempFile);
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            var context = contexts[0];
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+            var (nef, manifest, _) = context.CreateResults(repoRoot);
+            return (nef, manifest);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public abstract class OwnableTwoStepProxy(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        public delegate void OwnershipTransferStartedDelegate(UInt160? previousOwner, UInt160? newOwner);
+        public delegate void OwnershipTransferredDelegate(UInt160? previousOwner, UInt160? newOwner);
+        public delegate void OwnershipTransferCanceledDelegate(UInt160? currentOwner, UInt160? canceledPendingOwner);
+
+        [DisplayName("OwnershipTransferStarted")]
+        public event OwnershipTransferStartedDelegate? OnOwnershipTransferStarted;
+
+        [DisplayName("OwnershipTransferred")]
+        public event OwnershipTransferredDelegate? OnOwnershipTransferred;
+
+        [DisplayName("OwnershipTransferCanceled")]
+        public event OwnershipTransferCanceledDelegate? OnOwnershipTransferCanceled;
+
+        [DisplayName("getOwner")]
+        public abstract UInt160? GetOwner();
+
+        [DisplayName("getPendingOwner")]
+        public abstract UInt160? GetPendingOwner();
+
+        [DisplayName("transferOwnership")]
+        public abstract void TransferOwnership(UInt160 newOwner);
+
+        [DisplayName("acceptOwnership")]
+        public abstract void AcceptOwnership();
+
+        [DisplayName("cancelOwnershipTransfer")]
+        public abstract void CancelOwnershipTransfer();
+
+        [DisplayName("renounceOwnership")]
+        public abstract void RenounceOwnership();
+    }
+}


### PR DESCRIPTION
## Summary

The framework only shipped single-step `Ownable`: `SetOwner` assigns the new owner immediately, with no witness check on the incoming account. Passing a mistyped or otherwise unusable address loses contract control **irrecoverably** — the classic single-step ownership-transfer footgun that OpenZeppelin introduced `Ownable2Step` to fix.

This adds a standalone **`Ownable2Step`** base (the OpenZeppelin `Ownable2Step` analog, adapted to Neo's static-method model). Ownership changes hands only in two steps:

1. the owner proposes a pending owner via `TransferOwnership`, and
2. the transfer completes only when **that account itself** calls `AcceptOwnership` and proves control with `Runtime.CheckWitness`.

A mistyped address can never take ownership because it can never sign the acceptance.

## API

- **`TransferOwnership(newOwner)`** / **`AcceptOwnership()`** — the two-step flow. Re-proposing supersedes any in-flight pending and emits a cancellation event for the dropped candidate.
- **`CancelOwnershipTransfer()`** — owner clears an in-flight pending.
- **`RenounceOwnership()`** — the one deliberate, irreversible action; removes the owner and clears any pending so a previously-proposed account cannot seize an abandoned contract.
- **`GetOwner()` / `GetPendingOwner()`** — `[Safe]` read-only accessors.
- **`InitializeOwner(data, update)`** — call from `_deploy`; defaults to the tx sender, no-op on update.

## Design notes

- **Standalone, not extending `Ownable`** — so it does not re-expose the unsafe single-step `SetOwner` (Neo has no static-method override to hide it).
- **Storage prefixes `0xFD` (owner) / `0xFC` (pending)**, distinct from `Ownable` (`0xFF`) and `Pausable` (`0xFE`).
- **Absent pending = no transfer in flight** is the single source of truth, which collapses double-accept, accept-with-no-pending, and stale-accept-after-renounce to one null check. Storage is written **before** events on every transition.
- `[Safe]` is only on the two pure-read accessors; every state-mutating method is non-`[Safe]` and reaches `CheckWitness`.

## Testing

`Ownable2StepTest` (17 cases) covers the happy path plus every adversarial edge: transfer to self / to zero / by non-owner; accept with no pending / by the wrong account (incl. the current owner) / twice; renounce-then-stale-accept; cancel with nothing pending / by non-owner; post-renounce lockout; re-propose supersession; full event emission; and the manifest safe-flag attribution. Full framework suite green (270).

The design and this implementation were each put through an independent adversarial security review (ownership-theft, bricking, witness-bypass, storage/event ordering, stale-pending seizure) before submission.