### PR TITLE
Add AccessControl base for role-based authorization

### DIFF
--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -23,10 +23,10 @@ namespace Neo.SmartContract.Framework
     /// administered by another role.
     /// </summary>
     /// <remarks>
-    /// A role is identified by a 32-byte id. Derive named roles deterministically, e.g.
-    /// <c>CryptoLib.Sha256((ByteString)"MINTER_ROLE")</c>. <see cref="DEFAULT_ADMIN_ROLE"/> (32
-    /// zero bytes) is the root role and is its own admin; the account it is granted to at
-    /// deployment can administer every other role.
+    /// A role is identified by a compact 4-byte key. Define role enums in your contract and derive
+    /// keys with <see cref="RoleKey"/>, e.g. <c>RoleKey((int)Roles.Minter)</c>.
+    /// <see cref="DEFAULT_ADMIN_ROLE"/> (four zero bytes) is the root role and is its own admin;
+    /// the account it is granted to at deployment can administer every other role.
     /// <para>
     /// Authorization is by explicit actor: callers pass the acting account and the contract
     /// verifies it both holds the required role and witnessed the call
@@ -53,11 +53,11 @@ namespace Neo.SmartContract.Framework
     {
         private const byte Prefix = 0xFB;
 
-        // Sub-namespace tags. 0x00 is reserved for the one-time init flag only; the variable-length
-        // membership/admin/count keys use non-zero tags so they can never collide with it.
-        private const byte TAG_MEMBER = 0x01;  // [role:32][account:20] -> granted
-        private const byte TAG_ADMIN = 0x02;   // [role:32]             -> admin role override
-        private const byte TAG_COUNT = 0x03;   // [role:32]             -> member count
+        // Sub-namespace tags. 0x00 is reserved for the one-time init flag only; the role keys use
+        // non-zero tags so they can never collide with it.
+        private const byte TAG_MEMBER = 0x01;  // [role:4][account:20] -> granted
+        private const byte TAG_ADMIN = 0x02;   // [role:4]             -> admin role override
+        private const byte TAG_COUNT = 0x03;   // [role:4]             -> member count
 
         // The init flag lives under tag 0x00 (a fixed single-byte key) so it can never collide with
         // the non-zero tagged variable-length role keys.
@@ -74,17 +74,26 @@ namespace Neo.SmartContract.Framework
         private static byte[] CountKey(ByteString role)
             => new byte[] { TAG_COUNT }.Concat((byte[])role);
 
-        // Roles are fixed 32 bytes so that the flat (role ++ account) key is injective: with both
-        // fields fixed-width, two distinct (role, account) pairs can never alias to one key.
+        /// <summary>
+        /// Converts an enum-style integer role id to the fixed 4-byte role key used by storage.
+        /// </summary>
+        protected static ByteString RoleKey(int role)
+        {
+            ExecutionEngine.Assert(role >= 0, "AccessControl: role must be non-negative");
+            return (ByteString)new byte[] { (byte)role, (byte)(role >> 8), (byte)(role >> 16), (byte)(role >> 24) };
+        }
+
+        // Roles are fixed 4 bytes so that the flat (role ++ account) key is injective with lower
+        // storage overhead than 32-byte hashes.
         private static void ValidateRole(ByteString role)
-            => ExecutionEngine.Assert(role.Length == 32, "AccessControl: role must be 32 bytes");
+            => ExecutionEngine.Assert(role.Length == 4, "AccessControl: role must be 4 bytes");
 
         /// <summary>
-        /// The root admin role (32 zero bytes). It is its own admin, and the account granted this
+        /// The root admin role (four zero bytes). It is its own admin, and the account granted this
         /// role at deployment can administer every other role.
         /// </summary>
         [Safe]
-        public static ByteString DEFAULT_ADMIN_ROLE() => (ByteString)new byte[32];
+        public static ByteString DEFAULT_ADMIN_ROLE() => RoleKey(0);
 
         /// <summary>
         /// Returns whether <paramref name="account"/> has been granted <paramref name="role"/>.

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -1,0 +1,282 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// AccessControl.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+using System.Numerics;
+
+namespace Neo.SmartContract.Framework
+{
+    /// <summary>
+    /// A role-based access-control base contract, the OpenZeppelin <c>AccessControl</c> analog
+    /// for Neo. Unlike <see cref="Ownable"/> (a single owner), it lets a contract grant distinct
+    /// roles (for example a minter role, a pauser role) to multiple accounts, each role
+    /// administered by another role.
+    /// </summary>
+    /// <remarks>
+    /// A role is identified by a 32-byte id. Derive named roles deterministically, e.g.
+    /// <c>CryptoLib.Sha256((ByteString)"MINTER_ROLE")</c>. <see cref="DEFAULT_ADMIN_ROLE"/> (32
+    /// zero bytes) is the root role and is its own admin; the account it is granted to at
+    /// deployment can administer every other role.
+    /// <para>
+    /// Authorization is by explicit actor: callers pass the acting account and the contract
+    /// verifies it both holds the required role and witnessed the call
+    /// (<c>Runtime.CheckWitness</c>). This honors the signer's witness scope and lets a contract
+    /// (multisig, DAO) hold a role.
+    /// </para>
+    /// <para>
+    /// The last holder of <see cref="DEFAULT_ADMIN_ROLE"/> can never be removed, so the contract
+    /// can never become un-administrable from a single call. To hand over root control, grant the
+    /// role to a successor first, then renounce your own.
+    /// </para>
+    /// <para>
+    /// To gate your own methods on a role, call <see cref="OnlyRole"/> as the first statement:
+    /// <code>
+    /// public static void Mint(UInt160 minter, UInt160 to, BigInteger amount)
+    /// {
+    ///     OnlyRole(MINTER_ROLE, minter);
+    ///     // ...
+    /// }
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public abstract class AccessControl : SmartContract
+    {
+        private const byte Prefix = 0xFB;
+
+        // Sub-namespace tags. 0x00 is reserved for the one-time init flag only; the variable-length
+        // membership/admin/count keys use non-zero tags so they can never collide with it.
+        private const byte TAG_MEMBER = 0x01;  // [role:32][account:20] -> granted
+        private const byte TAG_ADMIN = 0x02;   // [role:32]             -> admin role override
+        private const byte TAG_COUNT = 0x03;   // [role:32]             -> member count
+
+        // The init flag lives under tag 0x00 (a fixed single-byte key) so it can never collide with
+        // the non-zero tagged variable-length role keys.
+        private const byte TAG_INIT = 0x00;
+
+        private static StorageMap Map => new(Storage.CurrentContext, Prefix);
+
+        private static byte[] MemberKey(ByteString role, UInt160 account)
+            => new byte[] { TAG_MEMBER }.Concat((byte[])role).Concat((byte[])account);
+
+        private static byte[] AdminKey(ByteString role)
+            => new byte[] { TAG_ADMIN }.Concat((byte[])role);
+
+        private static byte[] CountKey(ByteString role)
+            => new byte[] { TAG_COUNT }.Concat((byte[])role);
+
+        // Roles are fixed 32 bytes so that the flat (role ++ account) key is injective: with both
+        // fields fixed-width, two distinct (role, account) pairs can never alias to one key.
+        private static void ValidateRole(ByteString role)
+            => ExecutionEngine.Assert(role.Length == 32, "AccessControl: role must be 32 bytes");
+
+        /// <summary>
+        /// The root admin role (32 zero bytes). It is its own admin, and the account granted this
+        /// role at deployment can administer every other role.
+        /// </summary>
+        [Safe]
+        public static ByteString DEFAULT_ADMIN_ROLE() => (ByteString)new byte[32];
+
+        /// <summary>
+        /// Returns whether <paramref name="account"/> has been granted <paramref name="role"/>.
+        /// </summary>
+        [Safe]
+        public static bool HasRole(ByteString role, UInt160 account)
+        {
+            ValidateRole(role);
+            return Map.Get(MemberKey(role, account)) is not null;
+        }
+
+        /// <summary>
+        /// Returns the admin role that controls granting and revoking <paramref name="role"/>.
+        /// Defaults to <see cref="DEFAULT_ADMIN_ROLE"/> when no override has been set.
+        /// </summary>
+        [Safe]
+        public static ByteString GetRoleAdmin(ByteString role)
+        {
+            ValidateRole(role);
+            return Map.Get(AdminKey(role)) ?? DEFAULT_ADMIN_ROLE();
+        }
+
+        /// <summary>
+        /// Returns the number of accounts that currently hold <paramref name="role"/>.
+        /// </summary>
+        [Safe]
+        public static BigInteger GetRoleMemberCount(ByteString role)
+        {
+            ValidateRole(role);
+            return Map.GetIntegerOrZero(CountKey(role));
+        }
+
+        public delegate void OnRoleGrantedDelegate(ByteString role, UInt160 account, UInt160 sender);
+
+        [DisplayName("RoleGranted")]
+        public static event OnRoleGrantedDelegate OnRoleGranted = null!;
+
+        public delegate void OnRoleRevokedDelegate(ByteString role, UInt160 account, UInt160 sender);
+
+        [DisplayName("RoleRevoked")]
+        public static event OnRoleRevokedDelegate OnRoleRevoked = null!;
+
+        public delegate void OnRoleAdminChangedDelegate(ByteString role, ByteString previousAdminRole, ByteString newAdminRole);
+
+        [DisplayName("RoleAdminChanged")]
+        public static event OnRoleAdminChangedDelegate OnRoleAdminChanged = null!;
+
+        /// <summary>
+        /// Asserts that <paramref name="account"/> holds <paramref name="role"/> and witnessed the
+        /// current invocation. This is the authorization core; it aborts otherwise.
+        /// </summary>
+        protected static void CheckRole(ByteString role, UInt160 account)
+        {
+            ValidateRole(role);
+            ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
+            ExecutionEngine.Assert(HasRole(role, account) && Runtime.CheckWitness(account),
+                "AccessControl: account is missing role");
+        }
+
+        /// <summary>
+        /// The first-line guard for an author's role-gated method: asserts that
+        /// <paramref name="account"/> holds <paramref name="role"/> and signed the call.
+        /// </summary>
+        protected static void OnlyRole(ByteString role, UInt160 account) => CheckRole(role, account);
+
+        /// <summary>
+        /// Grants <paramref name="role"/> to <paramref name="account"/>. <paramref name="admin"/>
+        /// must hold the role's admin role and witness the call. A no-op if already granted.
+        /// </summary>
+        public static void GrantRole(ByteString role, UInt160 admin, UInt160 account)
+        {
+            ValidateRole(role);
+            ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
+            CheckRole(GetRoleAdmin(role), admin);
+            GrantRoleInternal(role, account, admin);
+        }
+
+        /// <summary>
+        /// Revokes <paramref name="role"/> from <paramref name="account"/>. <paramref name="admin"/>
+        /// must hold the role's admin role and witness the call. A no-op if not granted.
+        /// </summary>
+        public static void RevokeRole(ByteString role, UInt160 admin, UInt160 account)
+        {
+            ValidateRole(role);
+            ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
+            CheckRole(GetRoleAdmin(role), admin);
+            if (!HasRole(role, account))
+                return;
+            GuardLastAdmin(role);
+            RevokeRoleInternal(role, account, admin);
+        }
+
+        /// <summary>
+        /// Renounces <paramref name="role"/> for the caller. Only <paramref name="account"/> itself
+        /// (verified by witness) may renounce its own role. A no-op if not held.
+        /// </summary>
+        public static void RenounceRole(ByteString role, UInt160 account)
+        {
+            ValidateRole(role);
+            ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
+            ExecutionEngine.Assert(Runtime.CheckWitness(account), "AccessControl: can only renounce roles for self");
+            if (!HasRole(role, account))
+                return;
+            GuardLastAdmin(role);
+            RevokeRoleInternal(role, account, account);
+        }
+
+        // The final DEFAULT_ADMIN_ROLE holder can never be removed, so a single call can never
+        // leave the contract un-administrable. Hand over root control by granting the role to a
+        // successor first (count >= 2), then dropping your own.
+        private static void GuardLastAdmin(ByteString role)
+        {
+            if (role == DEFAULT_ADMIN_ROLE())
+                ExecutionEngine.Assert(GetRoleMemberCount(role) > 1, "AccessControl: cannot remove last default admin");
+        }
+
+        /// <summary>
+        /// Unconditionally grants <paramref name="role"/> to <paramref name="account"/> (no admin
+        /// check). Idempotent. Not exported; wrap it behind your own authorization.
+        /// </summary>
+        protected static void GrantRoleInternal(ByteString role, UInt160 account, UInt160 sender)
+        {
+            ValidateRole(role);
+            ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
+            byte[] key = MemberKey(role, account);
+            if (Map.Get(key) is not null)
+                return;
+            Map.Put(key, 1);
+            Map.Increase(CountKey(role));
+            OnRoleGranted(role, account, sender);
+        }
+
+        /// <summary>
+        /// Unconditionally revokes <paramref name="role"/> from <paramref name="account"/> (no admin
+        /// or last-admin check). Idempotent. Not exported; the public callers apply the guards.
+        /// </summary>
+        protected static void RevokeRoleInternal(ByteString role, UInt160 account, UInt160 sender)
+        {
+            ValidateRole(role);
+            byte[] key = MemberKey(role, account);
+            if (Map.Get(key) is null)
+                return;
+            Map.Delete(key);
+            Map.Decrease(CountKey(role));
+            OnRoleRevoked(role, account, sender);
+        }
+
+        /// <summary>
+        /// Sets the admin role for <paramref name="role"/>. Not exported (no admin check); expose it
+        /// behind a gated wrapper, for example:
+        /// <code>
+        /// public static void SetRoleAdmin(ByteString role, ByteString adminRole, UInt160 admin)
+        /// {
+        ///     OnlyRole(GetRoleAdmin(role), admin);
+        ///     AccessControl.SetRoleAdminInternal(role, adminRole);
+        /// }
+        /// </code>
+        /// </summary>
+        protected static void SetRoleAdminInternal(ByteString role, ByteString adminRole)
+        {
+            ValidateRole(role);
+            ValidateRole(adminRole);
+            ByteString previous = GetRoleAdmin(role);
+            if (previous == adminRole)
+                return;
+            if (adminRole == DEFAULT_ADMIN_ROLE())
+                Map.Delete(AdminKey(role));
+            else
+                Map.Put(AdminKey(role), adminRole);
+            OnRoleAdminChanged(role, previous, adminRole);
+        }
+
+        /// <summary>
+        /// Bootstraps access control by granting <see cref="DEFAULT_ADMIN_ROLE"/> to the initial
+        /// admin. Call this from the contract's <c>_deploy</c> method. Defaults the admin to the
+        /// transaction sender when <paramref name="data"/> is null; a no-op on update. Can only run
+        /// once.
+        /// </summary>
+        protected static void InitializeAccessControl(object? data, bool update)
+        {
+            if (update)
+                return;
+
+            ExecutionEngine.Assert(Map.Get(new byte[] { TAG_INIT }) is null, "AccessControl: already initialized");
+            Map.Put(new byte[] { TAG_INIT }, 1);
+
+            data ??= Runtime.Transaction.Sender;
+
+            UInt160 admin = (UInt160)data;
+            ExecutionEngine.Assert(admin.IsValidAndNotZero, "AccessControl: invalid initial admin");
+
+            GrantRoleInternal(DEFAULT_ADMIN_ROLE(), admin, admin);
+        }
+    }
+}

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -23,9 +23,9 @@ namespace Neo.SmartContract.Framework
     /// administered by another role.
     /// </summary>
     /// <remarks>
-    /// A role is identified by a compact 4-byte key. Define role enums in your contract and derive
-    /// keys with <see cref="RoleKey"/>, e.g. <c>RoleKey((int)Roles.Minter)</c>.
-    /// <see cref="DEFAULT_ADMIN_ROLE"/> (four zero bytes) is the root role and is its own admin;
+    /// A role is identified by a non-negative integer. Define role enums in your contract and pass
+    /// their numeric values directly, e.g. <c>OnlyRole((int)Roles.Minter, minter)</c>.
+    /// <see cref="DEFAULT_ADMIN_ROLE"/> (0) is the root role and is its own admin;
     /// the account it is granted to at deployment can administer every other role.
     /// <para>
     /// Authorization is by explicit actor: callers pass the acting account and the contract
@@ -55,9 +55,9 @@ namespace Neo.SmartContract.Framework
 
         // Sub-namespace tags. 0x00 is reserved for the one-time init flag only; the role keys use
         // non-zero tags so they can never collide with it.
-        private const byte TAG_MEMBER = 0x01;  // [role:4][account:20] -> granted
-        private const byte TAG_ADMIN = 0x02;   // [role:4]             -> admin role override
-        private const byte TAG_COUNT = 0x03;   // [role:4]             -> member count
+        private const byte TAG_MEMBER = 0x01;  // [role][account:20] -> granted
+        private const byte TAG_ADMIN = 0x02;   // [role]             -> admin role override
+        private const byte TAG_COUNT = 0x03;   // [role]             -> member count
 
         // The init flag lives under tag 0x00 (a fixed single-byte key) so it can never collide with
         // the non-zero tagged variable-length role keys.
@@ -65,41 +65,33 @@ namespace Neo.SmartContract.Framework
 
         private static StorageMap Map => new(Storage.CurrentContext, Prefix);
 
-        private static byte[] MemberKey(ByteString role, UInt160 account)
-            => new byte[] { TAG_MEMBER }.Concat((byte[])role).Concat((byte[])account);
+        private static byte[] MemberKey(BigInteger role, UInt160 account)
+            => new byte[] { TAG_MEMBER }.Concat(RoleBytes(role)).Concat((byte[])account);
 
-        private static byte[] AdminKey(ByteString role)
-            => new byte[] { TAG_ADMIN }.Concat((byte[])role);
+        private static byte[] AdminKey(BigInteger role)
+            => new byte[] { TAG_ADMIN }.Concat(RoleBytes(role));
 
-        private static byte[] CountKey(ByteString role)
-            => new byte[] { TAG_COUNT }.Concat((byte[])role);
+        private static byte[] CountKey(BigInteger role)
+            => new byte[] { TAG_COUNT }.Concat(RoleBytes(role));
 
-        /// <summary>
-        /// Converts an enum-style integer role id to the fixed 4-byte role key used by storage.
-        /// </summary>
-        protected static ByteString RoleKey(int role)
-        {
-            ExecutionEngine.Assert(role >= 0, "AccessControl: role must be non-negative");
-            return (ByteString)new byte[] { (byte)role, (byte)(role >> 8), (byte)(role >> 16), (byte)(role >> 24) };
-        }
+        private static byte[] RoleBytes(BigInteger role)
+            => (byte[])(ByteString)role;
 
-        // Roles are fixed 4 bytes so that the flat (role ++ account) key is injective with lower
-        // storage overhead than 32-byte hashes.
-        private static void ValidateRole(ByteString role)
-            => ExecutionEngine.Assert(role.Length == 4, "AccessControl: role must be 4 bytes");
+        private static void ValidateRole(BigInteger role)
+            => ExecutionEngine.Assert(role >= 0, "AccessControl: role must be non-negative");
 
         /// <summary>
-        /// The root admin role (four zero bytes). It is its own admin, and the account granted this
+        /// The root admin role (0). It is its own admin, and the account granted this
         /// role at deployment can administer every other role.
         /// </summary>
         [Safe]
-        public static ByteString DEFAULT_ADMIN_ROLE() => RoleKey(0);
+        public static BigInteger DEFAULT_ADMIN_ROLE() => BigInteger.Zero;
 
         /// <summary>
         /// Returns whether <paramref name="account"/> has been granted <paramref name="role"/>.
         /// </summary>
         [Safe]
-        public static bool HasRole(ByteString role, UInt160 account)
+        public static bool HasRole(BigInteger role, UInt160 account)
         {
             ValidateRole(role);
             return Map.Get(MemberKey(role, account)) is not null;
@@ -112,33 +104,33 @@ namespace Neo.SmartContract.Framework
         /// administer <paramref name="role"/>.
         /// </summary>
         [Safe]
-        public static ByteString GetRoleAdmin(ByteString role)
+        public static BigInteger GetRoleAdmin(BigInteger role)
         {
             ValidateRole(role);
-            return Map.Get(AdminKey(role)) ?? DEFAULT_ADMIN_ROLE();
+            return Map.GetIntegerOrZero(AdminKey(role));
         }
 
         /// <summary>
         /// Returns the number of accounts that currently hold <paramref name="role"/>.
         /// </summary>
         [Safe]
-        public static BigInteger GetRoleMemberCount(ByteString role)
+        public static BigInteger GetRoleMemberCount(BigInteger role)
         {
             ValidateRole(role);
             return Map.GetIntegerOrZero(CountKey(role));
         }
 
-        public delegate void OnRoleGrantedDelegate(ByteString role, UInt160 account, UInt160 sender);
+        public delegate void OnRoleGrantedDelegate(BigInteger role, UInt160 account, UInt160 sender);
 
         [DisplayName("RoleGranted")]
         public static event OnRoleGrantedDelegate OnRoleGranted = null!;
 
-        public delegate void OnRoleRevokedDelegate(ByteString role, UInt160 account, UInt160 sender);
+        public delegate void OnRoleRevokedDelegate(BigInteger role, UInt160 account, UInt160 sender);
 
         [DisplayName("RoleRevoked")]
         public static event OnRoleRevokedDelegate OnRoleRevoked = null!;
 
-        public delegate void OnRoleAdminChangedDelegate(ByteString role, ByteString previousAdminRole, ByteString newAdminRole);
+        public delegate void OnRoleAdminChangedDelegate(BigInteger role, BigInteger previousAdminRole, BigInteger newAdminRole);
 
         [DisplayName("RoleAdminChanged")]
         public static event OnRoleAdminChangedDelegate OnRoleAdminChanged = null!;
@@ -147,7 +139,7 @@ namespace Neo.SmartContract.Framework
         /// Asserts that <paramref name="account"/> holds <paramref name="role"/> and witnessed the
         /// current invocation. This is the authorization core; it aborts otherwise.
         /// </summary>
-        protected static void CheckRole(ByteString role, UInt160 account)
+        protected static void CheckRole(BigInteger role, UInt160 account)
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
@@ -159,13 +151,13 @@ namespace Neo.SmartContract.Framework
         /// The first-line guard for an author's role-gated method: asserts that
         /// <paramref name="account"/> holds <paramref name="role"/> and signed the call.
         /// </summary>
-        protected static void OnlyRole(ByteString role, UInt160 account) => CheckRole(role, account);
+        protected static void OnlyRole(BigInteger role, UInt160 account) => CheckRole(role, account);
 
         /// <summary>
         /// Grants <paramref name="role"/> to <paramref name="account"/>. <paramref name="admin"/>
         /// must hold the role's admin role and witness the call. A no-op if already granted.
         /// </summary>
-        public static void GrantRole(ByteString role, UInt160 admin, UInt160 account)
+        public static void GrantRole(BigInteger role, UInt160 admin, UInt160 account)
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
@@ -177,7 +169,7 @@ namespace Neo.SmartContract.Framework
         /// Revokes <paramref name="role"/> from <paramref name="account"/>. <paramref name="admin"/>
         /// must hold the role's admin role and witness the call. A no-op if not granted.
         /// </summary>
-        public static void RevokeRole(ByteString role, UInt160 admin, UInt160 account)
+        public static void RevokeRole(BigInteger role, UInt160 admin, UInt160 account)
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
@@ -192,7 +184,7 @@ namespace Neo.SmartContract.Framework
         /// Renounces <paramref name="role"/> for the caller. Only <paramref name="account"/> itself
         /// (verified by witness) may renounce its own role. A no-op if not held.
         /// </summary>
-        public static void RenounceRole(ByteString role, UInt160 account)
+        public static void RenounceRole(BigInteger role, UInt160 account)
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
@@ -206,7 +198,7 @@ namespace Neo.SmartContract.Framework
         // The final DEFAULT_ADMIN_ROLE holder can never be removed, so a single call can never
         // leave the contract un-administrable. Hand over root control by granting the role to a
         // successor first (count >= 2), then dropping your own.
-        private static void GuardLastAdmin(ByteString role)
+        private static void GuardLastAdmin(BigInteger role)
         {
             if (role == DEFAULT_ADMIN_ROLE())
                 ExecutionEngine.Assert(GetRoleMemberCount(role) > 1, "AccessControl: cannot remove last default admin");
@@ -216,7 +208,7 @@ namespace Neo.SmartContract.Framework
         /// Unconditionally grants <paramref name="role"/> to <paramref name="account"/> (no admin
         /// check). Idempotent. Not exported; wrap it behind your own authorization.
         /// </summary>
-        protected static void GrantRoleInternal(ByteString role, UInt160 account, UInt160 sender)
+        protected static void GrantRoleInternal(BigInteger role, UInt160 account, UInt160 sender)
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
@@ -232,7 +224,7 @@ namespace Neo.SmartContract.Framework
         /// Unconditionally revokes <paramref name="role"/> from <paramref name="account"/> (no admin
         /// or last-admin check). Idempotent. Not exported; the public callers apply the guards.
         /// </summary>
-        protected static void RevokeRoleInternal(ByteString role, UInt160 account, UInt160 sender)
+        protected static void RevokeRoleInternal(BigInteger role, UInt160 account, UInt160 sender)
         {
             ValidateRole(role);
             byte[] key = MemberKey(role, account);
@@ -247,18 +239,18 @@ namespace Neo.SmartContract.Framework
         /// Sets the admin role for <paramref name="role"/>. Not exported (no admin check); expose it
         /// behind a gated wrapper, for example:
         /// <code>
-        /// public static void SetRoleAdmin(ByteString role, ByteString adminRole, UInt160 admin)
+        /// public static void SetRoleAdmin(BigInteger role, BigInteger adminRole, UInt160 admin)
         /// {
         ///     OnlyRole(GetRoleAdmin(role), admin);
         ///     AccessControl.SetRoleAdminInternal(role, adminRole);
         /// }
         /// </code>
         /// </summary>
-        protected static void SetRoleAdminInternal(ByteString role, ByteString adminRole)
+        protected static void SetRoleAdminInternal(BigInteger role, BigInteger adminRole)
         {
             ValidateRole(role);
             ValidateRole(adminRole);
-            ByteString previous = GetRoleAdmin(role);
+            BigInteger previous = GetRoleAdmin(role);
             if (previous == adminRole)
                 return;
             if (adminRole == DEFAULT_ADMIN_ROLE())

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -98,7 +98,9 @@ namespace Neo.SmartContract.Framework
 
         /// <summary>
         /// Returns the admin role that controls granting and revoking <paramref name="role"/>.
-        /// Defaults to <see cref="DEFAULT_ADMIN_ROLE"/> when no override has been set.
+        /// Defaults to <see cref="DEFAULT_ADMIN_ROLE"/> when no override has been set. This is
+        /// the admin role id, not a single admin account; every account holding the admin role can
+        /// administer <paramref name="role"/>.
         /// </summary>
         [Safe]
         public static ByteString GetRoleAdmin(ByteString role)

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -220,8 +220,11 @@ namespace Neo.SmartContract.Framework
         }
 
         /// <summary>
-        /// Unconditionally revokes <paramref name="role"/> from <paramref name="account"/> (no admin
-        /// or last-admin check). Idempotent. Not exported; the public callers apply the guards.
+        /// Unconditionally revokes <paramref name="role"/> from <paramref name="account"/>.
+        /// This protected primitive intentionally bypasses both admin authorization and the
+        /// last-default-admin guard so derived contracts can implement their own policy.
+        /// Public callers apply the standard guards; custom callers are responsible for preserving
+        /// <see cref="DEFAULT_ADMIN_ROLE"/> when that behavior is required.
         /// </summary>
         protected static void RevokeRoleInternal(BigInteger role, UInt160 account, UInt160 sender)
         {

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -262,10 +262,10 @@ namespace Neo.SmartContract.Framework
         /// <summary>
         /// Bootstraps access control by granting <see cref="DEFAULT_ADMIN_ROLE"/> to the initial
         /// admin. Call this from the contract's <c>_deploy</c> method. Defaults the admin to the
-        /// transaction sender when <paramref name="data"/> is null; a no-op on update. Can only run
+        /// transaction sender when <paramref name="admin"/> is null; a no-op on update. Can only run
         /// once.
         /// </summary>
-        protected static void InitializeAccessControl(object? data, bool update)
+        protected static void InitializeAccessControl(UInt160? admin, bool update)
         {
             if (update)
                 return;
@@ -273,12 +273,10 @@ namespace Neo.SmartContract.Framework
             ExecutionEngine.Assert(Map.Get(new byte[] { TAG_INIT }) is null, "AccessControl: already initialized");
             Map.Put(new byte[] { TAG_INIT }, 1);
 
-            data ??= Runtime.Transaction.Sender;
+            UInt160 initialAdmin = admin ?? Runtime.Transaction.Sender;
+            ExecutionEngine.Assert(initialAdmin.IsValidAndNotZero, "AccessControl: invalid initial admin");
 
-            UInt160 admin = (UInt160)data;
-            ExecutionEngine.Assert(admin.IsValidAndNotZero, "AccessControl: invalid initial admin");
-
-            GrantRoleInternal(DEFAULT_ADMIN_ROLE(), admin, admin);
+            GrantRoleInternal(DEFAULT_ADMIN_ROLE(), initialAdmin, initialAdmin);
         }
     }
 }

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -182,15 +182,14 @@ namespace Neo.SmartContract.Framework
 
         /// <summary>
         /// Renounces <paramref name="role"/> for the caller. Only <paramref name="account"/> itself
-        /// (verified by witness) may renounce its own role. A no-op if not held.
+        /// (verified by witness) may renounce its own role. Aborts if the role is not held.
         /// </summary>
         public static void RenounceRole(BigInteger role, UInt160 account)
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
             ExecutionEngine.Assert(Runtime.CheckWitness(account), "AccessControl: can only renounce roles for self");
-            if (!HasRole(role, account))
-                return;
+            ExecutionEngine.Assert(HasRole(role, account), "AccessControl: account is missing role");
             GuardLastAdmin(role);
             RevokeRoleInternal(role, account, account);
         }

--- a/src/Neo.SmartContract.Framework/AccessControl.cs
+++ b/src/Neo.SmartContract.Framework/AccessControl.cs
@@ -140,8 +140,8 @@ namespace Neo.SmartContract.Framework
         {
             ValidateRole(role);
             ExecutionEngine.Assert(account.IsValidAndNotZero, "AccessControl: invalid account");
-            ExecutionEngine.Assert(HasRole(role, account) && Runtime.CheckWitness(account),
-                "AccessControl: account is missing role");
+            ExecutionEngine.Assert(HasRole(role, account), "AccessControl: account is missing role");
+            ExecutionEngine.Assert(Runtime.CheckWitness(account), "AccessControl: missing witness for account");
         }
 
         /// <summary>

--- a/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
@@ -15,6 +15,7 @@ using Neo.Compiler;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Coverage;
 using Neo.SmartContract.Testing.Exceptions;
 using System;
 using System.ComponentModel;
@@ -36,13 +37,16 @@ public class AccessControlTest
     private static readonly byte[] Minter = Enumerable.Repeat((byte)0x11, 32).ToArray();
     private static readonly byte[] MinterAdmin = Enumerable.Repeat((byte)0x22, 32).ToArray();
 
-    private static (NefFile nef, ContractManifest manifest) _compiled;
+    private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) _compiled;
 
     [ClassInitialize]
     public static void ClassInitialize(TestContext _) => _compiled = CompileContract();
 
     private static AccessControlProxy Deploy(TestEngine engine, object? admin = null)
         => engine.Deploy<AccessControlProxy>(_compiled.nef, _compiled.manifest, admin);
+
+    private static void Merge(AccessControlProxy contract)
+        => DynamicCoverageMergeHelper.Merge(contract, _compiled.debugInfo);
 
     private static TestEngine CreateEngine()
     {
@@ -61,6 +65,7 @@ public class AccessControlTest
 
         Assert.IsTrue(c.HasRole(DefaultAdmin, Alice.Account));
         Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(DefaultAdmin));
+        Merge(c);
     }
 
     [TestMethod]
@@ -70,6 +75,7 @@ public class AccessControlTest
         var c = Deploy(engine);
 
         CollectionAssert.AreEqual(new byte[32], c.DEFAULT_ADMIN_ROLE());
+        Merge(c);
     }
 
     [TestMethod]
@@ -82,6 +88,7 @@ public class AccessControlTest
         Assert.ThrowsException<TestException>(() => c.ReInit(Bob.Account));
         Assert.IsFalse(c.HasRole(DefaultAdmin, Bob.Account));
         Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(DefaultAdmin));
+        Merge(c);
     }
 
     [TestMethod]
@@ -102,6 +109,7 @@ public class AccessControlTest
         Assert.IsFalse(c.HasRole(Minter, Bob.Account));
         c.GrantRole(Minter, Alice.Account, Bob.Account);
         Assert.IsTrue(c.HasRole(Minter, Bob.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -112,6 +120,7 @@ public class AccessControlTest
 
         Assert.ThrowsException<TestException>(() => c.HasRole(new byte[31], Alice.Account));
         Assert.ThrowsException<TestException>(() => c.HasRole(new byte[33], Alice.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -121,6 +130,7 @@ public class AccessControlTest
         var c = Deploy(engine);
 
         CollectionAssert.AreEqual(DefaultAdmin, c.GetRoleAdmin(Minter));
+        Merge(c);
     }
 
     // ---- Grant ----
@@ -142,6 +152,7 @@ public class AccessControlTest
         CollectionAssert.AreEqual(Minter, grantedRole);
         Assert.AreEqual(Bob.Account, grantedAccount);
         Assert.AreEqual(Alice.Account, grantedSender);
+        Merge(c);
     }
 
     [TestMethod]
@@ -153,6 +164,7 @@ public class AccessControlTest
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Bob.Account, Charlie.Account));
         Assert.IsFalse(c.HasRole(Minter, Charlie.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -166,6 +178,7 @@ public class AccessControlTest
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Alice.Account, Charlie.Account));
         Assert.IsFalse(c.HasRole(Minter, Charlie.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -181,6 +194,7 @@ public class AccessControlTest
 
         Assert.AreEqual(0, events);
         Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(Minter));
+        Merge(c);
     }
 
     [TestMethod]
@@ -190,6 +204,7 @@ public class AccessControlTest
         var c = Deploy(engine);
 
         Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Alice.Account, UInt160.Zero));
+        Merge(c);
     }
 
     // ---- Revoke / renounce ----
@@ -204,6 +219,7 @@ public class AccessControlTest
         c.RevokeRole(Minter, Alice.Account, Bob.Account);
         Assert.IsFalse(c.HasRole(Minter, Bob.Account));
         Assert.AreEqual(BigInteger.Zero, c.GetRoleMemberCount(Minter));
+        Merge(c);
     }
 
     [TestMethod]
@@ -216,6 +232,7 @@ public class AccessControlTest
         c.OnRoleRevoked += (_, _, _) => events++;
         c.RevokeRole(Minter, Alice.Account, Bob.Account); // never granted
         Assert.AreEqual(0, events);
+        Merge(c);
     }
 
     [TestMethod]
@@ -228,6 +245,7 @@ public class AccessControlTest
         engine.SetTransactionSigners(Bob);
         c.RenounceRole(Minter, Bob.Account);
         Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -241,6 +259,7 @@ public class AccessControlTest
         engine.SetTransactionSigners(Charlie);
         Assert.ThrowsException<TestException>(() => c.RenounceRole(Minter, Bob.Account));
         Assert.IsTrue(c.HasRole(Minter, Bob.Account));
+        Merge(c);
     }
 
     // ---- Last-admin guard ----
@@ -253,6 +272,7 @@ public class AccessControlTest
 
         Assert.ThrowsException<TestException>(() => c.RevokeRole(DefaultAdmin, Alice.Account, Alice.Account));
         Assert.IsTrue(c.HasRole(DefaultAdmin, Alice.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -263,6 +283,7 @@ public class AccessControlTest
 
         Assert.ThrowsException<TestException>(() => c.RenounceRole(DefaultAdmin, Alice.Account));
         Assert.IsTrue(c.HasRole(DefaultAdmin, Alice.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -283,6 +304,7 @@ public class AccessControlTest
         engine.SetTransactionSigners(Bob);
         c.GrantRole(Minter, Bob.Account, Charlie.Account);
         Assert.IsTrue(c.HasRole(Minter, Charlie.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -295,6 +317,7 @@ public class AccessControlTest
         // The sole minter can be revoked freely.
         c.RevokeRole(Minter, Alice.Account, Bob.Account);
         Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+        Merge(c);
     }
 
     // ---- Admin hierarchy ----
@@ -323,6 +346,7 @@ public class AccessControlTest
         engine.SetTransactionSigners(Bob);
         c.GrantRole(Minter, Bob.Account, Charlie.Account);
         Assert.IsTrue(c.HasRole(Minter, Charlie.Account));
+        Merge(c);
     }
 
     [TestMethod]
@@ -333,6 +357,7 @@ public class AccessControlTest
 
         engine.SetTransactionSigners(Bob);
         Assert.ThrowsException<TestException>(() => c.SetRoleAdmin(Minter, MinterAdmin, Bob.Account));
+        Merge(c);
     }
 
     // ---- OnlyRole guard ----
@@ -351,6 +376,7 @@ public class AccessControlTest
         // Non-holder fails.
         engine.SetTransactionSigners(Charlie);
         Assert.ThrowsException<TestException>(() => c.GuardedAction(Minter, Charlie.Account));
+        Merge(c);
     }
 
     // ---- Manifest / ABI surface ----
@@ -373,7 +399,7 @@ public class AccessControlTest
             Assert.IsFalse(names.Contains(hidden), $"{hidden} must not be exported to the ABI");
     }
 
-    private static (NefFile nef, ContractManifest manifest) CompileContract()
+    private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) CompileContract()
     {
         const string source = @"using Neo.SmartContract.Framework;
 
@@ -421,8 +447,8 @@ public class Contract : AccessControl
             var context = contexts[0];
             Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
 
-            var (nef, manifest, _) = context.CreateResults(repoRoot);
-            return (nef, manifest);
+            var (nef, manifest, debugInfoJson) = context.CreateResults(repoRoot);
+            return (nef, manifest, NeoDebugInfo.FromDebugInfoJson(debugInfoJson));
         }
         finally
         {

--- a/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
@@ -33,9 +33,9 @@ public class AccessControlTest
     private static readonly Signer Bob = TestEngine.Bob;
     private static readonly Signer Charlie = TestEngine.Charlie;
 
-    private static readonly byte[] DefaultAdmin = new byte[32];
-    private static readonly byte[] Minter = Enumerable.Repeat((byte)0x11, 32).ToArray();
-    private static readonly byte[] MinterAdmin = Enumerable.Repeat((byte)0x22, 32).ToArray();
+    private static readonly byte[] DefaultAdmin = new byte[4];
+    private static readonly byte[] Minter = { 1, 0, 0, 0 };
+    private static readonly byte[] MinterAdmin = { 2, 0, 0, 0 };
 
     private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) _compiled;
 
@@ -69,12 +69,22 @@ public class AccessControlTest
     }
 
     [TestMethod]
-    public void Init_DefaultAdminRole_Is32ZeroBytes()
+    public void Init_DefaultAdminRole_IsFourZeroBytes()
     {
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        CollectionAssert.AreEqual(new byte[32], c.DEFAULT_ADMIN_ROLE());
+        CollectionAssert.AreEqual(new byte[4], c.DEFAULT_ADMIN_ROLE());
+        Merge(c);
+    }
+
+    [TestMethod]
+    public void RoleKey_EnumValue_IsFourByteLittleEndian()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        CollectionAssert.AreEqual(Minter, c.MinterRoleForTest());
         Merge(c);
     }
 
@@ -118,8 +128,8 @@ public class AccessControlTest
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[31], Alice.Account));
-        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[33], Alice.Account));
+        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[3], Alice.Account));
+        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[5], Alice.Account));
         Merge(c);
     }
 
@@ -394,7 +404,7 @@ public class AccessControlTest
             Assert.IsFalse(abi.Single(m => m.Name == mutator).Safe, $"{mutator} must not be safe");
 
         // Protected cores and private helpers must not be exported.
-        foreach (var hidden in new[] { "checkRole", "onlyRole", "GrantRoleInternal", "RevokeRoleInternal", "SetRoleAdminInternal",
+        foreach (var hidden in new[] { "roleKey", "checkRole", "onlyRole", "GrantRoleInternal", "RevokeRoleInternal", "SetRoleAdminInternal",
             "initializeAccessControl", "validateRole", "guardLastAdmin", "memberKey", "adminKey", "countKey" })
             Assert.IsFalse(names.Contains(hidden), $"{hidden} must not be exported to the ABI");
     }
@@ -405,9 +415,20 @@ public class AccessControlTest
 
 public class Contract : AccessControl
 {
+    private enum TestRole
+    {
+        Minter = 1,
+        MinterAdmin = 2
+    }
+
     public static void _deploy(object data, bool update)
     {
         InitializeAccessControl(data, update);
+    }
+
+    public static ByteString MinterRoleForTest()
+    {
+        return RoleKey((int)TestRole.Minter);
     }
 
     public static bool GuardedAction(ByteString role, UInt160 actor)
@@ -484,6 +505,9 @@ public class Contract : AccessControl
 
         [DisplayName("getRoleMemberCount")]
         public abstract BigInteger GetRoleMemberCount(byte[] role);
+
+        [DisplayName("minterRoleForTest")]
+        public abstract byte[] MinterRoleForTest();
 
         [DisplayName("grantRole")]
         public abstract void GrantRole(byte[] role, UInt160 admin, UInt160 account);

--- a/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
@@ -261,6 +261,18 @@ public class AccessControlTest
         Merge(c);
     }
 
+    [TestMethod]
+    public void RenounceRole_NotHeld_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => c.RenounceRole(Minter, Bob.Account));
+        Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+        Merge(c);
+    }
+
     // ---- Last-admin guard ----
 
     [TestMethod]

--- a/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
@@ -33,9 +33,9 @@ public class AccessControlTest
     private static readonly Signer Bob = TestEngine.Bob;
     private static readonly Signer Charlie = TestEngine.Charlie;
 
-    private static readonly byte[] DefaultAdmin = new byte[4];
-    private static readonly byte[] Minter = { 1, 0, 0, 0 };
-    private static readonly byte[] MinterAdmin = { 2, 0, 0, 0 };
+    private static readonly BigInteger DefaultAdmin = BigInteger.Zero;
+    private static readonly BigInteger Minter = BigInteger.One;
+    private static readonly BigInteger MinterAdmin = new(2);
 
     private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) _compiled;
 
@@ -69,22 +69,12 @@ public class AccessControlTest
     }
 
     [TestMethod]
-    public void Init_DefaultAdminRole_IsFourZeroBytes()
+    public void Init_DefaultAdminRole_IsZero()
     {
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        CollectionAssert.AreEqual(new byte[4], c.DEFAULT_ADMIN_ROLE());
-        Merge(c);
-    }
-
-    [TestMethod]
-    public void RoleKey_EnumValue_IsFourByteLittleEndian()
-    {
-        var engine = CreateEngine();
-        var c = Deploy(engine);
-
-        CollectionAssert.AreEqual(Minter, c.MinterRoleForTest());
+        Assert.AreEqual(BigInteger.Zero, c.DEFAULT_ADMIN_ROLE());
         Merge(c);
     }
 
@@ -123,13 +113,12 @@ public class AccessControlTest
     }
 
     [TestMethod]
-    public void HasRole_MalformedRole_Faults()
+    public void HasRole_NegativeRole_Faults()
     {
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[3], Alice.Account));
-        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[5], Alice.Account));
+        Assert.ThrowsException<TestException>(() => c.HasRole(new BigInteger(-1), Alice.Account));
         Merge(c);
     }
 
@@ -139,7 +128,7 @@ public class AccessControlTest
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        CollectionAssert.AreEqual(DefaultAdmin, c.GetRoleAdmin(Minter));
+        Assert.AreEqual(DefaultAdmin, c.GetRoleAdmin(Minter));
         Merge(c);
     }
 
@@ -151,7 +140,7 @@ public class AccessControlTest
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        byte[]? grantedRole = null;
+        BigInteger? grantedRole = null;
         UInt160? grantedAccount = null, grantedSender = null;
         c.OnRoleGranted += (r, a, s) => { grantedRole = r; grantedAccount = a; grantedSender = s; };
 
@@ -159,7 +148,7 @@ public class AccessControlTest
 
         Assert.IsTrue(c.HasRole(Minter, Bob.Account));
         Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(Minter));
-        CollectionAssert.AreEqual(Minter, grantedRole);
+        Assert.AreEqual(Minter, grantedRole);
         Assert.AreEqual(Bob.Account, grantedAccount);
         Assert.AreEqual(Alice.Account, grantedSender);
         Merge(c);
@@ -338,15 +327,15 @@ public class AccessControlTest
         var engine = CreateEngine();
         var c = Deploy(engine);
 
-        byte[]? evRole = null, evPrev = null, evNew = null;
+        BigInteger? evRole = null, evPrev = null, evNew = null;
         c.OnRoleAdminChanged += (r, p, n) => { evRole = r; evPrev = p; evNew = n; };
 
         // Make MinterAdmin the admin of Minter, and give it to Bob.
         c.SetRoleAdmin(Minter, MinterAdmin, Alice.Account);
-        CollectionAssert.AreEqual(Minter, evRole);
-        CollectionAssert.AreEqual(DefaultAdmin, evPrev);
-        CollectionAssert.AreEqual(MinterAdmin, evNew);
-        CollectionAssert.AreEqual(MinterAdmin, c.GetRoleAdmin(Minter));
+        Assert.AreEqual(Minter, evRole);
+        Assert.AreEqual(DefaultAdmin, evPrev);
+        Assert.AreEqual(MinterAdmin, evNew);
+        Assert.AreEqual(MinterAdmin, c.GetRoleAdmin(Minter));
 
         c.GrantRole(MinterAdmin, Alice.Account, Bob.Account);
 
@@ -404,7 +393,7 @@ public class AccessControlTest
             Assert.IsFalse(abi.Single(m => m.Name == mutator).Safe, $"{mutator} must not be safe");
 
         // Protected cores and private helpers must not be exported.
-        foreach (var hidden in new[] { "roleKey", "checkRole", "onlyRole", "GrantRoleInternal", "RevokeRoleInternal", "SetRoleAdminInternal",
+        foreach (var hidden in new[] { "roleBytes", "checkRole", "onlyRole", "GrantRoleInternal", "RevokeRoleInternal", "SetRoleAdminInternal",
             "initializeAccessControl", "validateRole", "guardLastAdmin", "memberKey", "adminKey", "countKey" })
             Assert.IsFalse(names.Contains(hidden), $"{hidden} must not be exported to the ABI");
     }
@@ -412,6 +401,7 @@ public class AccessControlTest
     private static (NefFile nef, ContractManifest manifest, NeoDebugInfo debugInfo) CompileContract()
     {
         const string source = @"using Neo.SmartContract.Framework;
+using System.Numerics;
 
 public class Contract : AccessControl
 {
@@ -426,18 +416,13 @@ public class Contract : AccessControl
         InitializeAccessControl(data, update);
     }
 
-    public static ByteString MinterRoleForTest()
-    {
-        return RoleKey((int)TestRole.Minter);
-    }
-
-    public static bool GuardedAction(ByteString role, UInt160 actor)
+    public static bool GuardedAction(BigInteger role, UInt160 actor)
     {
         OnlyRole(role, actor);
         return true;
     }
 
-    public static void SetRoleAdmin(ByteString role, ByteString adminRole, UInt160 admin)
+    public static void SetRoleAdmin(BigInteger role, BigInteger adminRole, UInt160 admin)
     {
         OnlyRole(GetRoleAdmin(role), admin);
         AccessControl.SetRoleAdminInternal(role, adminRole);
@@ -481,9 +466,9 @@ public class Contract : AccessControl
     public abstract class AccessControlProxy(SmartContractInitialize initialize)
         : Neo.SmartContract.Testing.SmartContract(initialize)
     {
-        public delegate void RoleGrantedDelegate(byte[]? role, UInt160? account, UInt160? sender);
-        public delegate void RoleRevokedDelegate(byte[]? role, UInt160? account, UInt160? sender);
-        public delegate void RoleAdminChangedDelegate(byte[]? role, byte[]? previousAdminRole, byte[]? newAdminRole);
+        public delegate void RoleGrantedDelegate(BigInteger? role, UInt160? account, UInt160? sender);
+        public delegate void RoleRevokedDelegate(BigInteger? role, UInt160? account, UInt160? sender);
+        public delegate void RoleAdminChangedDelegate(BigInteger? role, BigInteger? previousAdminRole, BigInteger? newAdminRole);
 
         [DisplayName("RoleGranted")]
         public event RoleGrantedDelegate? OnRoleGranted;
@@ -495,34 +480,31 @@ public class Contract : AccessControl
         public event RoleAdminChangedDelegate? OnRoleAdminChanged;
 
         [DisplayName("dEFAULT_ADMIN_ROLE")]
-        public abstract byte[] DEFAULT_ADMIN_ROLE();
+        public abstract BigInteger DEFAULT_ADMIN_ROLE();
 
         [DisplayName("hasRole")]
-        public abstract bool HasRole(byte[] role, UInt160 account);
+        public abstract bool HasRole(BigInteger role, UInt160 account);
 
         [DisplayName("getRoleAdmin")]
-        public abstract byte[] GetRoleAdmin(byte[] role);
+        public abstract BigInteger GetRoleAdmin(BigInteger role);
 
         [DisplayName("getRoleMemberCount")]
-        public abstract BigInteger GetRoleMemberCount(byte[] role);
-
-        [DisplayName("minterRoleForTest")]
-        public abstract byte[] MinterRoleForTest();
+        public abstract BigInteger GetRoleMemberCount(BigInteger role);
 
         [DisplayName("grantRole")]
-        public abstract void GrantRole(byte[] role, UInt160 admin, UInt160 account);
+        public abstract void GrantRole(BigInteger role, UInt160 admin, UInt160 account);
 
         [DisplayName("revokeRole")]
-        public abstract void RevokeRole(byte[] role, UInt160 admin, UInt160 account);
+        public abstract void RevokeRole(BigInteger role, UInt160 admin, UInt160 account);
 
         [DisplayName("renounceRole")]
-        public abstract void RenounceRole(byte[] role, UInt160 account);
+        public abstract void RenounceRole(BigInteger role, UInt160 account);
 
         [DisplayName("guardedAction")]
-        public abstract bool? GuardedAction(byte[] role, UInt160 actor);
+        public abstract bool? GuardedAction(BigInteger role, UInt160 actor);
 
         [DisplayName("setRoleAdmin")]
-        public abstract void SetRoleAdmin(byte[] role, byte[] adminRole, UInt160 admin);
+        public abstract void SetRoleAdmin(BigInteger role, BigInteger adminRole, UInt160 admin);
 
         [DisplayName("reInit")]
         public abstract void ReInit(UInt160 admin);

--- a/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
@@ -1,0 +1,480 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// AccessControlTest.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing;
+using Neo.SmartContract.Testing.Exceptions;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using CompilationOptions = Neo.Compiler.CompilationOptions;
+
+namespace Neo.SmartContract.Framework.UnitTests;
+
+[TestClass]
+public class AccessControlTest
+{
+    private static readonly Signer Alice = TestEngine.Alice;
+    private static readonly Signer Bob = TestEngine.Bob;
+    private static readonly Signer Charlie = TestEngine.Charlie;
+
+    private static readonly byte[] DefaultAdmin = new byte[32];
+    private static readonly byte[] Minter = Enumerable.Repeat((byte)0x11, 32).ToArray();
+    private static readonly byte[] MinterAdmin = Enumerable.Repeat((byte)0x22, 32).ToArray();
+
+    private static (NefFile nef, ContractManifest manifest) _compiled;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext _) => _compiled = CompileContract();
+
+    private static AccessControlProxy Deploy(TestEngine engine, object? admin = null)
+        => engine.Deploy<AccessControlProxy>(_compiled.nef, _compiled.manifest, admin);
+
+    private static TestEngine CreateEngine()
+    {
+        var engine = new TestEngine(true);
+        engine.SetTransactionSigners(Alice);
+        return engine;
+    }
+
+    // ---- Bootstrap / init ----
+
+    [TestMethod]
+    public void Init_GrantsDefaultAdminToSender()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        Assert.IsTrue(c.HasRole(DefaultAdmin, Alice.Account));
+        Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(DefaultAdmin));
+    }
+
+    [TestMethod]
+    public void Init_DefaultAdminRole_Is32ZeroBytes()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        CollectionAssert.AreEqual(new byte[32], c.DEFAULT_ADMIN_ROLE());
+    }
+
+    [TestMethod]
+    public void Init_Replay_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        // A second initialization must be rejected so an attacker cannot add a co-admin.
+        Assert.ThrowsException<TestException>(() => c.ReInit(Bob.Account));
+        Assert.IsFalse(c.HasRole(DefaultAdmin, Bob.Account));
+        Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(DefaultAdmin));
+    }
+
+    [TestMethod]
+    public void Init_ZeroAdmin_Aborts()
+    {
+        var engine = CreateEngine();
+        Assert.ThrowsException<TestException>(() => Deploy(engine, UInt160.Zero));
+    }
+
+    // ---- Reads ----
+
+    [TestMethod]
+    public void HasRole_FalseBeforeGrant_TrueAfter()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+        Assert.IsTrue(c.HasRole(Minter, Bob.Account));
+    }
+
+    [TestMethod]
+    public void HasRole_MalformedRole_Faults()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[31], Alice.Account));
+        Assert.ThrowsException<TestException>(() => c.HasRole(new byte[33], Alice.Account));
+    }
+
+    [TestMethod]
+    public void GetRoleAdmin_DefaultsToDefaultAdminRole()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        CollectionAssert.AreEqual(DefaultAdmin, c.GetRoleAdmin(Minter));
+    }
+
+    // ---- Grant ----
+
+    [TestMethod]
+    public void GrantRole_ByAdmin_Succeeds()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        byte[]? grantedRole = null;
+        UInt160? grantedAccount = null, grantedSender = null;
+        c.OnRoleGranted += (r, a, s) => { grantedRole = r; grantedAccount = a; grantedSender = s; };
+
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        Assert.IsTrue(c.HasRole(Minter, Bob.Account));
+        Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(Minter));
+        CollectionAssert.AreEqual(Minter, grantedRole);
+        Assert.AreEqual(Bob.Account, grantedAccount);
+        Assert.AreEqual(Alice.Account, grantedSender);
+    }
+
+    [TestMethod]
+    public void GrantRole_ByNonAdmin_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Bob.Account, Charlie.Account));
+        Assert.IsFalse(c.HasRole(Minter, Charlie.Account));
+    }
+
+    [TestMethod]
+    public void GrantRole_AdminWithoutWitness_Aborts()
+    {
+        // Confused-deputy: Alice holds the admin role, but the call is signed by Bob, so
+        // CheckWitness(Alice) is false. Mere admin membership without a witness must not pass.
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Alice.Account, Charlie.Account));
+        Assert.IsFalse(c.HasRole(Minter, Charlie.Account));
+    }
+
+    [TestMethod]
+    public void GrantRole_Idempotent_NoSecondEvent()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        int events = 0;
+        c.OnRoleGranted += (_, _, _) => events++;
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        Assert.AreEqual(0, events);
+        Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(Minter));
+    }
+
+    [TestMethod]
+    public void GrantRole_ZeroAccount_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Alice.Account, UInt160.Zero));
+    }
+
+    // ---- Revoke / renounce ----
+
+    [TestMethod]
+    public void RevokeRole_ByAdmin_Succeeds()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        c.RevokeRole(Minter, Alice.Account, Bob.Account);
+        Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+        Assert.AreEqual(BigInteger.Zero, c.GetRoleMemberCount(Minter));
+    }
+
+    [TestMethod]
+    public void RevokeRole_Idempotent_NoEvent()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        int events = 0;
+        c.OnRoleRevoked += (_, _, _) => events++;
+        c.RevokeRole(Minter, Alice.Account, Bob.Account); // never granted
+        Assert.AreEqual(0, events);
+    }
+
+    [TestMethod]
+    public void RenounceRole_Self_Succeeds()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        engine.SetTransactionSigners(Bob);
+        c.RenounceRole(Minter, Bob.Account);
+        Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+    }
+
+    [TestMethod]
+    public void RenounceRole_Other_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        // Charlie tries to renounce Bob's role.
+        engine.SetTransactionSigners(Charlie);
+        Assert.ThrowsException<TestException>(() => c.RenounceRole(Minter, Bob.Account));
+        Assert.IsTrue(c.HasRole(Minter, Bob.Account));
+    }
+
+    // ---- Last-admin guard ----
+
+    [TestMethod]
+    public void RevokeRole_LastDefaultAdmin_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        Assert.ThrowsException<TestException>(() => c.RevokeRole(DefaultAdmin, Alice.Account, Alice.Account));
+        Assert.IsTrue(c.HasRole(DefaultAdmin, Alice.Account));
+    }
+
+    [TestMethod]
+    public void RenounceRole_LastDefaultAdmin_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        Assert.ThrowsException<TestException>(() => c.RenounceRole(DefaultAdmin, Alice.Account));
+        Assert.IsTrue(c.HasRole(DefaultAdmin, Alice.Account));
+    }
+
+    [TestMethod]
+    public void DefaultAdmin_SafeHandoff()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        // Grant to a successor first (count -> 2), then the original can renounce (count -> 1).
+        c.GrantRole(DefaultAdmin, Alice.Account, Bob.Account);
+        Assert.AreEqual(new BigInteger(2), c.GetRoleMemberCount(DefaultAdmin));
+
+        c.RenounceRole(DefaultAdmin, Alice.Account);
+        Assert.IsFalse(c.HasRole(DefaultAdmin, Alice.Account));
+        Assert.AreEqual(BigInteger.One, c.GetRoleMemberCount(DefaultAdmin));
+
+        // Administration still works through Bob.
+        engine.SetTransactionSigners(Bob);
+        c.GrantRole(Minter, Bob.Account, Charlie.Account);
+        Assert.IsTrue(c.HasRole(Minter, Charlie.Account));
+    }
+
+    [TestMethod]
+    public void LastAdminGuard_DoesNotRestrictOtherRoles()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        // The sole minter can be revoked freely.
+        c.RevokeRole(Minter, Alice.Account, Bob.Account);
+        Assert.IsFalse(c.HasRole(Minter, Bob.Account));
+    }
+
+    // ---- Admin hierarchy ----
+
+    [TestMethod]
+    public void SetRoleAdmin_ChangesAuthority()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        byte[]? evRole = null, evPrev = null, evNew = null;
+        c.OnRoleAdminChanged += (r, p, n) => { evRole = r; evPrev = p; evNew = n; };
+
+        // Make MinterAdmin the admin of Minter, and give it to Bob.
+        c.SetRoleAdmin(Minter, MinterAdmin, Alice.Account);
+        CollectionAssert.AreEqual(Minter, evRole);
+        CollectionAssert.AreEqual(DefaultAdmin, evPrev);
+        CollectionAssert.AreEqual(MinterAdmin, evNew);
+        CollectionAssert.AreEqual(MinterAdmin, c.GetRoleAdmin(Minter));
+
+        c.GrantRole(MinterAdmin, Alice.Account, Bob.Account);
+
+        // Default admin (Alice) can no longer grant Minter; only MinterAdmin holders can.
+        Assert.ThrowsException<TestException>(() => c.GrantRole(Minter, Alice.Account, Charlie.Account));
+
+        engine.SetTransactionSigners(Bob);
+        c.GrantRole(Minter, Bob.Account, Charlie.Account);
+        Assert.IsTrue(c.HasRole(Minter, Charlie.Account));
+    }
+
+    [TestMethod]
+    public void SetRoleAdmin_ByNonAdmin_Aborts()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+
+        engine.SetTransactionSigners(Bob);
+        Assert.ThrowsException<TestException>(() => c.SetRoleAdmin(Minter, MinterAdmin, Bob.Account));
+    }
+
+    // ---- OnlyRole guard ----
+
+    [TestMethod]
+    public void OnlyRole_GuardedAction()
+    {
+        var engine = CreateEngine();
+        var c = Deploy(engine);
+        c.GrantRole(Minter, Alice.Account, Bob.Account);
+
+        // Holder with witness passes.
+        engine.SetTransactionSigners(Bob);
+        Assert.IsTrue(c.GuardedAction(Minter, Bob.Account)!.Value);
+
+        // Non-holder fails.
+        engine.SetTransactionSigners(Charlie);
+        Assert.ThrowsException<TestException>(() => c.GuardedAction(Minter, Charlie.Account));
+    }
+
+    // ---- Manifest / ABI surface ----
+
+    [TestMethod]
+    public void Manifest_SafeFlags_And_ProtectedNotExported()
+    {
+        var abi = _compiled.manifest.Abi.Methods;
+        var names = abi.Select(m => m.Name).ToArray();
+
+        foreach (var safe in new[] { "dEFAULT_ADMIN_ROLE", "hasRole", "getRoleAdmin", "getRoleMemberCount" })
+            Assert.IsTrue(abi.Single(m => m.Name == safe).Safe, $"{safe} must be safe");
+
+        foreach (var mutator in new[] { "grantRole", "revokeRole", "renounceRole" })
+            Assert.IsFalse(abi.Single(m => m.Name == mutator).Safe, $"{mutator} must not be safe");
+
+        // Protected cores and private helpers must not be exported.
+        foreach (var hidden in new[] { "checkRole", "onlyRole", "GrantRoleInternal", "RevokeRoleInternal", "SetRoleAdminInternal",
+            "initializeAccessControl", "validateRole", "guardLastAdmin", "memberKey", "adminKey", "countKey" })
+            Assert.IsFalse(names.Contains(hidden), $"{hidden} must not be exported to the ABI");
+    }
+
+    private static (NefFile nef, ContractManifest manifest) CompileContract()
+    {
+        const string source = @"using Neo.SmartContract.Framework;
+
+public class Contract : AccessControl
+{
+    public static void _deploy(object data, bool update)
+    {
+        InitializeAccessControl(data, update);
+    }
+
+    public static bool GuardedAction(ByteString role, UInt160 actor)
+    {
+        OnlyRole(role, actor);
+        return true;
+    }
+
+    public static void SetRoleAdmin(ByteString role, ByteString adminRole, UInt160 admin)
+    {
+        OnlyRole(GetRoleAdmin(role), admin);
+        AccessControl.SetRoleAdminInternal(role, adminRole);
+    }
+
+    public static void ReInit(UInt160 admin)
+    {
+        InitializeAccessControl(admin, false);
+    }
+}";
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(tempFile, source);
+        try
+        {
+            var options = new CompilationOptions
+            {
+                Optimize = CompilationOptions.OptimizationType.All,
+                Nullable = NullableContextOptions.Enable,
+                SkipRestoreIfAssetsPresent = true
+            };
+            var engine = new CompilationEngine(options);
+            var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            var contexts = engine.CompileSources(new CompilationSourceReferences { Projects = new[] { frameworkProject } }, tempFile);
+            Assert.AreEqual(1, contexts.Count, "Expected exactly one contract compilation context.");
+            var context = contexts[0];
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+            var (nef, manifest, _) = context.CreateResults(repoRoot);
+            return (nef, manifest);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public abstract class AccessControlProxy(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        public delegate void RoleGrantedDelegate(byte[]? role, UInt160? account, UInt160? sender);
+        public delegate void RoleRevokedDelegate(byte[]? role, UInt160? account, UInt160? sender);
+        public delegate void RoleAdminChangedDelegate(byte[]? role, byte[]? previousAdminRole, byte[]? newAdminRole);
+
+        [DisplayName("RoleGranted")]
+        public event RoleGrantedDelegate? OnRoleGranted;
+
+        [DisplayName("RoleRevoked")]
+        public event RoleRevokedDelegate? OnRoleRevoked;
+
+        [DisplayName("RoleAdminChanged")]
+        public event RoleAdminChangedDelegate? OnRoleAdminChanged;
+
+        [DisplayName("dEFAULT_ADMIN_ROLE")]
+        public abstract byte[] DEFAULT_ADMIN_ROLE();
+
+        [DisplayName("hasRole")]
+        public abstract bool HasRole(byte[] role, UInt160 account);
+
+        [DisplayName("getRoleAdmin")]
+        public abstract byte[] GetRoleAdmin(byte[] role);
+
+        [DisplayName("getRoleMemberCount")]
+        public abstract BigInteger GetRoleMemberCount(byte[] role);
+
+        [DisplayName("grantRole")]
+        public abstract void GrantRole(byte[] role, UInt160 admin, UInt160 account);
+
+        [DisplayName("revokeRole")]
+        public abstract void RevokeRole(byte[] role, UInt160 admin, UInt160 account);
+
+        [DisplayName("renounceRole")]
+        public abstract void RenounceRole(byte[] role, UInt160 account);
+
+        [DisplayName("guardedAction")]
+        public abstract bool? GuardedAction(byte[] role, UInt160 actor);
+
+        [DisplayName("setRoleAdmin")]
+        public abstract void SetRoleAdmin(byte[] role, byte[] adminRole, UInt160 admin);
+
+        [DisplayName("reInit")]
+        public abstract void ReInit(UInt160 admin);
+    }
+}

--- a/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/AccessControlTest.cs
@@ -425,7 +425,7 @@ public class Contract : AccessControl
 
     public static void _deploy(object data, bool update)
     {
-        InitializeAccessControl(data, update);
+        InitializeAccessControl((UInt160?)data, update);
     }
 
     public static bool GuardedAction(BigInteger role, UInt160 actor)


### PR DESCRIPTION
## Summary

The framework only shipped single-owner `Ownable`, so every contract that needs more than one privileged account (a minter, a pauser, a fee setter) hand-rolls its own unaudited authorization. This adds **`AccessControl`**, the OpenZeppelin `AccessControl` analog adapted to Neo's static-method model — the single most-used safety primitive in the OZ library.

A role is a 32-byte id; accounts are granted roles, and each role is administered by another role. `DEFAULT_ADMIN_ROLE` (32 zero bytes) is the root role and is its own admin; the account it is granted to at deployment can administer every other role.

## Security properties

- **Explicit-actor authorization.** Callers pass the acting account and the contract verifies it both holds the required role **and** witnessed the call (`Runtime.CheckWitness`), honoring the signer's witness scope. This avoids the confused-deputy hole of deriving the actor from `Transaction.Sender`, and lets a contract/multisig hold a role.
- **No key aliasing.** Roles are a fixed 32 bytes, validated on every entry point, so the membership key `tag ++ role ++ account` is structurally injective — no two distinct `(role, account)` pairs can collide on one storage cell.
- **No single-call brick.** The last `DEFAULT_ADMIN_ROLE` holder can never be removed (guarded on **both** revoke and renounce), so the contract can never be left un-administrable from one call; root control is handed over by granting to a successor first.
- **No init replay.** A one-time initialization flag stops a deploy-time re-init from adding a co-admin.
- **Idempotent + event-accurate.** Grant/revoke/admin-change are idempotent and emit events only on an actual state change; a maintained per-role member count backs the last-admin guard.

## API

`DEFAULT_ADMIN_ROLE` / `HasRole` / `GetRoleAdmin` / `GetRoleMemberCount` (`[Safe]` reads); `GrantRole(role, admin, account)` / `RevokeRole(role, admin, account)` / `RenounceRole(role, account)`; the `OnlyRole(role, account)` guard authors call at the top of their own role-gated methods; and protected `GrantRoleInternal` / `RevokeRoleInternal` / `SetRoleAdminInternal` cores that are **not** exported to the ABI. Storage uses reserved prefix `0xFB`.

No `[OnlyRole]` modifier attribute is shipped: a Neo `ModifierAttribute.Enter()` cannot read the decorated method's runtime arguments, so it could only gate a compile-time-constant role against the wrong actor model. The `OnlyRole` guard is the runtime-flexible substitute.

## Testing

`AccessControlTest` (24 cases): bootstrap and replay protection, the **confused-deputy attack** (admin without a witness for this call), grant/revoke/renounce by the wrong party, idempotency, the **last-admin brick on both revoke and renounce**, safe admin handoff, the admin-role **hierarchy** (re-pointing a role's admin), malformed-role faults, and the manifest safe-flag + ABI-exclusion surface (protected cores absent from the ABI). Full framework suite green (277).

The design and this implementation were each put through an independent multi-design + adversarial security-audit pass (privilege escalation, bricking, key aliasing, witness bypass, count desync) before submission.