### PR TITLE
[debugger 2] Add a per-instruction execution hook to the testing engine

### DIFF
--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -51,6 +51,20 @@ namespace Neo.SmartContract.Testing
         public delegate void OnRuntimeNotifyDelegate(UInt160 sender, string eventName, Neo.VM.Types.Array state);
         public event OnRuntimeNotifyDelegate? OnRuntimeNotify;
 
+        public delegate void OnPreExecuteInstructionDelegate(ApplicationEngine engine, Instruction instruction);
+
+        /// <summary>
+        /// Raised before each instruction is executed during <see cref="Execute"/>. A debugger can
+        /// observe execution through this hook; because the handler runs on the execution thread,
+        /// blocking inside it pauses the virtual machine until the handler returns.
+        /// </summary>
+        public event OnPreExecuteInstructionDelegate? OnPreExecuteInstruction;
+
+        internal bool HasPreExecuteInstructionObserver => OnPreExecuteInstruction is not null;
+
+        internal void RaisePreExecuteInstruction(ApplicationEngine engine, Instruction instruction)
+            => OnPreExecuteInstruction?.Invoke(engine, instruction);
+
         /// <summary>
         /// Default Protocol Settings
         /// </summary>

--- a/src/Neo.SmartContract.Testing/TestEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestEngine.cs
@@ -63,7 +63,7 @@ namespace Neo.SmartContract.Testing
         internal bool HasPreExecuteInstructionObserver => OnPreExecuteInstruction is not null;
 
         internal void RaisePreExecuteInstruction(ApplicationEngine engine, Instruction instruction)
-            => OnPreExecuteInstruction?.Invoke(engine, instruction);
+            => OnPreExecuteInstruction!.Invoke(engine, instruction);
 
         /// <summary>
         /// Default Protocol Settings

--- a/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
+++ b/src/Neo.SmartContract.Testing/TestingApplicationEngine.cs
@@ -195,6 +195,11 @@ namespace Neo.SmartContract.Testing
             // Regular action
 
             base.PreExecuteInstruction(instruction);
+
+            // Notify a debug observer that this instruction is about to execute (after the base
+            // gas/limit checks). A blocking handler pauses execution here until it returns.
+            if (Engine.HasPreExecuteInstructionObserver)
+                Engine.RaisePreExecuteInstruction(this, instruction);
         }
 
         protected override void OnFault(Exception ex)

--- a/tests/Neo.SmartContract.Testing.UnitTests/DebugHookTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/DebugHookTests.cs
@@ -1,0 +1,93 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DebugHookTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.SmartContract.Testing.UnitTests
+{
+    [TestClass]
+    public class DebugHookTests
+    {
+        // PUSH5 PUSH7 ADD -> 12. Three single-byte instructions at addresses 0, 1, 2.
+        private static byte[] AddScript()
+        {
+            using ScriptBuilder sb = new();
+            sb.EmitPush(5);
+            sb.EmitPush(7);
+            sb.Emit(OpCode.ADD);
+            return sb.ToArray();
+        }
+
+        [TestMethod]
+        public void OnPreExecuteInstruction_FiresForEachInstruction()
+        {
+            var engine = new TestEngine(true);
+            var opcodes = new List<OpCode>();
+            var addresses = new List<int>();
+            engine.OnPreExecuteInstruction += (e, instruction) =>
+            {
+                opcodes.Add(instruction.OpCode);
+                addresses.Add(e.CurrentContext!.InstructionPointer);
+            };
+
+            var result = engine.Execute(AddScript());
+
+            Assert.AreEqual(new BigInteger(12), result.GetInteger());
+            // The hook fires once per executed instruction, in execution order: the three emitted
+            // instructions (PUSH 5, PUSH 7, ADD) plus the implicit terminal RET.
+            Assert.IsTrue(opcodes.Count >= 3, "the hook should fire for every executed instruction");
+            Assert.AreEqual(OpCode.ADD, opcodes[2]);
+            Assert.AreEqual(0, addresses[0], "the first instruction is at the script entry");
+            for (int i = 1; i < addresses.Count; i++)
+                Assert.IsTrue(addresses[i] > addresses[i - 1], "instruction addresses advance monotonically");
+        }
+
+        [TestMethod]
+        public void NoSubscriber_ExecutesNormally()
+        {
+            var engine = new TestEngine(true);
+            Assert.AreEqual(new BigInteger(12), engine.Execute(AddScript()).GetInteger());
+        }
+
+        [TestMethod]
+        public void OnPreExecuteInstruction_BlockingHandler_PausesAndResumesExecution()
+        {
+            var engine = new TestEngine(true);
+            using var paused = new SemaphoreSlim(0);
+            using var resume = new SemaphoreSlim(0);
+            var firstHit = false;
+
+            engine.OnPreExecuteInstruction += (e, instruction) =>
+            {
+                if (firstHit) return;
+                firstHit = true;
+                paused.Release(); // tell the test we reached (and are about to block on) the first instruction
+                resume.Wait();    // block the VM thread until the test resumes it
+            };
+
+            var task = Task.Run(() => engine.Execute(AddScript()).GetInteger());
+
+            Assert.IsTrue(paused.Wait(TimeSpan.FromSeconds(5)), "the debug hook should have been hit");
+            // The VM thread is blocked inside the handler, so execution must not have completed.
+            Assert.IsFalse(task.Wait(TimeSpan.FromMilliseconds(250)), "execution should be paused inside the handler");
+
+            resume.Release();
+            Assert.IsTrue(task.Wait(TimeSpan.FromSeconds(5)), "execution should resume after the handler returns");
+            Assert.AreEqual(new BigInteger(12), task.Result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A source-level debugger needs to **observe execution one instruction at a time and pause it**. Neo.VM's single-step `ExecuteNext()` and `State` setter are `internal`, so the VM cannot be driven step-by-step from outside — but `TestingApplicationEngine` already overrides `PreExecuteInstruction`, which is a reliable per-instruction interception point (the same hook the coverage instrumentation uses).

This exposes that point as an opt-in **`TestEngine.OnPreExecuteInstruction`** event, raised before each instruction executes (after the base gas/limit checks), with the engine and the instruction.

- **Opt-in / zero-overhead when unused:** the hook only fires when something is subscribed, so normal test runs are unaffected.
- **Pause by blocking:** because the handler runs on the execution thread, a debugger can pause the virtual machine simply by blocking inside the handler and resume it by returning. This is the foundation the debug adapter builds on, with **no fork of Neo.VM required**.

## Context

This is **phase 1, step 2** of the first-party DAP debugger tracked in #1776 (step 1 — the breakpoint resolver — is #1775). The next step wires this hook together with the resolver into a `DebugSession` (pause/resume on a worker thread, breakpoints) in the `Neo.SmartContract.Debugging` project.

## Testing

`DebugHookTests` (3 cases): the hook fires for every executed instruction in address order; a **blocking handler pauses execution on a worker thread and returning resumes it to completion** (the pause/resume mechanism the debugger relies on); and execution is unchanged when nothing is subscribed. Full `Neo.SmartContract.Testing` suite green (86).