### PR TITLE
Fix default(struct) to default-initialize its fields instead of an empty struct

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/LiteralExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/LiteralExpression.cs
@@ -110,10 +110,17 @@ internal partial class MethodConvert
                 {
                     AddInstruction(OpCode.PUSHNULL);
                 }
+                else if (type.TypeKind == TypeKind.Enum)
+                {
+                    // An enum's default value is its underlying zero, not a struct.
+                    AddInstruction(OpCode.PUSH0);
+                }
                 else if (type.IsValueType)
                 {
-                    // For structs and other value types, we need to create a default instance
-                    AddInstruction(OpCode.NEWSTRUCT0);
+                    // A struct's default is a struct whose fields are themselves default-initialized
+                    // (the same shape as new T()). Emitting NEWSTRUCT0 produced a zero-field struct that
+                    // faulted on any later field access.
+                    CreateObject(model, type);
                 }
                 else
                 {

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Default.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Default.cs
@@ -101,9 +101,28 @@ namespace Neo.Compiler.CSharp.TestContracts
             return a;
         }
 
+        public static int TestStructDefaultFieldAccess()
+        {
+            TestStruct a = default;
+            return a.Value;
+        }
+
+        public static int TestEnumDefault()
+        {
+            TestEnum e = default;
+            return (int)e;
+        }
+
         public struct TestStruct
         {
             public int Value;
+        }
+
+        public enum TestEnum
+        {
+            A,
+            B,
+            C
         }
 
 #pragma warning disable CS8600,CS8603

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Default.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Default.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Default(Neo.SmartContract.Testing.SmartContractIn
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Default"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testBooleanDefault"",""parameters"":[],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testByteDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":7,""safe"":false},{""name"":""testSByteDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":14,""safe"":false},{""name"":""testInt16Default"",""parameters"":[],""returntype"":""Integer"",""offset"":21,""safe"":false},{""name"":""testUInt16Default"",""parameters"":[],""returntype"":""Integer"",""offset"":28,""safe"":false},{""name"":""testInt32Default"",""parameters"":[],""returntype"":""Integer"",""offset"":35,""safe"":false},{""name"":""testUInt32Default"",""parameters"":[],""returntype"":""Integer"",""offset"":42,""safe"":false},{""name"":""testInt64Default"",""parameters"":[],""returntype"":""Integer"",""offset"":49,""safe"":false},{""name"":""testUInt64Default"",""parameters"":[],""returntype"":""Integer"",""offset"":56,""safe"":false},{""name"":""testCharDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":63,""safe"":false},{""name"":""testStringDefault"",""parameters"":[],""returntype"":""String"",""offset"":70,""safe"":false},{""name"":""testObjectDefault"",""parameters"":[],""returntype"":""Any"",""offset"":77,""safe"":false},{""name"":""testBigIntegerDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":84,""safe"":false},{""name"":""testStructDefault"",""parameters"":[],""returntype"":""Array"",""offset"":91,""safe"":false},{""name"":""testClassDefault"",""parameters"":[],""returntype"":""Any"",""offset"":98,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Default"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testBooleanDefault"",""parameters"":[],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testByteDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":7,""safe"":false},{""name"":""testSByteDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":14,""safe"":false},{""name"":""testInt16Default"",""parameters"":[],""returntype"":""Integer"",""offset"":21,""safe"":false},{""name"":""testUInt16Default"",""parameters"":[],""returntype"":""Integer"",""offset"":28,""safe"":false},{""name"":""testInt32Default"",""parameters"":[],""returntype"":""Integer"",""offset"":35,""safe"":false},{""name"":""testUInt32Default"",""parameters"":[],""returntype"":""Integer"",""offset"":42,""safe"":false},{""name"":""testInt64Default"",""parameters"":[],""returntype"":""Integer"",""offset"":49,""safe"":false},{""name"":""testUInt64Default"",""parameters"":[],""returntype"":""Integer"",""offset"":56,""safe"":false},{""name"":""testCharDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":63,""safe"":false},{""name"":""testStringDefault"",""parameters"":[],""returntype"":""String"",""offset"":70,""safe"":false},{""name"":""testObjectDefault"",""parameters"":[],""returntype"":""Any"",""offset"":77,""safe"":false},{""name"":""testBigIntegerDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":84,""safe"":false},{""name"":""testStructDefault"",""parameters"":[],""returntype"":""Array"",""offset"":91,""safe"":false},{""name"":""testStructDefaultFieldAccess"",""parameters"":[],""returntype"":""Integer"",""offset"":100,""safe"":false},{""name"":""testEnumDefault"",""parameters"":[],""returntype"":""Integer"",""offset"":111,""safe"":false},{""name"":""testClassDefault"",""parameters"":[],""returntype"":""Any"",""offset"":118,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGlXAQAJcGhAVwEAEHBoQFcBABBwaEBXAQAQcGhAVwEAEHBoQFcBABBwaEBXAQAQcGhAVwEAEHBoQFcBABBwaEBXAQAQcGhAVwEAC3BoQFcBAAtwaEBXAQAQcGhAVwEAxXBoQFcBAAtwaEBJsgEj").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH1XAQAJcGhAVwEAEHBoQFcBABBwaEBXAQAQcGhAVwEAEHBoQFcBABBwaEBXAQAQcGhAVwEAEHBoQFcBABBwaEBXAQAQcGhAVwEAC3BoQFcBAAtwaEBXAQAQcGhAVwEAEBG/cGhAVwEAEBG/cGgQzkBXAQAQcGhAVwEAC3BoQPyHdc4=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -93,6 +93,20 @@ public abstract class Contract_Default(Neo.SmartContract.Testing.SmartContractIn
     /// </remarks>
     [DisplayName("testClassDefault")]
     public abstract object? TestClassDefault();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEAEHBoQA==
+    /// INITSLOT 0100 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testEnumDefault")]
+    public abstract BigInteger? TestEnumDefault();
 
     /// <summary>
     /// Unsafe method
@@ -182,15 +196,35 @@ public abstract class Contract_Default(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEAxXBoQA==
+    /// Script: VwEAEBG/cGhA
     /// INITSLOT 0100 [64 datoshi]
-    /// NEWSTRUCT0 [16 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
     /// STLOC0 [2 datoshi]
     /// LDLOC0 [2 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testStructDefault")]
     public abstract IList<object>? TestStructDefault();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEAEBG/cGgQzkA=
+    /// INITSLOT 0100 [64 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// PACKSTRUCT [2048 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// PUSH0 [1 datoshi]
+    /// PICKITEM [64 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testStructDefaultFieldAccess")]
+    public abstract BigInteger? TestStructDefaultFieldAccess();
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Default.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Default.cs
@@ -115,7 +115,22 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             var result = Contract.TestStructDefault();
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Count);
+            // default(TestStruct) is a struct with its one (zero-initialized) field, not an empty struct.
+            Assert.AreEqual(1, result.Count);
+        }
+
+        [TestMethod]
+        public void TestStructDefaultFieldAccess()
+        {
+            // Accessing a field of default(struct) used to fault (PICKITEM on a zero-field struct).
+            Assert.AreEqual(0, Contract.TestStructDefaultFieldAccess());
+        }
+
+        [TestMethod]
+        public void TestEnumDefault()
+        {
+            // default(enum) is its underlying zero, not a struct.
+            Assert.AreEqual(0, Contract.TestEnumDefault());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Problem

`default(T)` for a custom struct emits `NEWSTRUCT0` — a struct with **zero** items:

```csharp
else if (type.IsValueType)
{
    AddInstruction(OpCode.NEWSTRUCT0);   // zero-field struct
}
```

But a struct's default should be a struct whose fields are themselves default-initialized (the same shape as `new T()`). So:

```csharp
struct S { public int Value; }
S s = default;
return s.Value;   // PICKITEM index 0 on a 0-length struct -> VM FAULT
```

faults at runtime. The same fallback also (incorrectly) emitted `NEWSTRUCT0` for an **enum**, whose default is its underlying zero.

## Fix

- Route a struct's `default` through the same `CreateObject` path `new T()` uses (emit each field's default, then `PACKSTRUCT`) — no constructor is run, so it stays `default` semantics.
- Emit `PUSH0` for an enum's `default`.

Primitives, strings, classes and `BigInteger` are unchanged.

## Tests

- `default(struct).Value` now returns `0` instead of faulting (new `TestStructDefaultFieldAccess`).
- The struct default is a one-field struct, not empty (`TestStructDefault` updated from `Count == 0` to `Count == 1`).
- `default(enum)` is `0` (new `TestEnumDefault`).

Only `Contract_Default` uses `default(struct)`/`default(enum)`, so it is the only regenerated artifact; the full `UnitTest_Default` suite (27) and the struct/enum/initializer suites (61) are green.
