### PR TITLE
Improve optimizer and analyzer robustness

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/AssetBuilder.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/AssetBuilder.cs
@@ -14,6 +14,7 @@ using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.VM;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace Neo.Optimizer
 {
@@ -51,12 +52,35 @@ namespace Neo.Optimizer
                 if (oldAddressToInstruction.TryGetValue(method.Offset, out Instruction? i)
                  && simplifiedInstructionsToAddress.Contains(i))
                     method.Offset = (int)simplifiedInstructionsToAddress[i]!;
-                else  // old start of method was deleted
-                    method.Offset = oldSequencePointAddressToNew![method.Offset];
+                else if (oldSequencePointAddressToNew is not null && oldSequencePointAddressToNew.TryGetValue(method.Offset, out int newOffset))
+                    method.Offset = newOffset;
+                else if (TryResolveDeletedMethodOffset(method.Offset, simplifiedInstructionsToAddress, oldAddressToInstruction, out newOffset))
+                    method.Offset = newOffset;
             debugInfo = DebugInfoBuilder.ModifyDebugInfo(
                 debugInfo, simplifiedInstructionsToAddress, oldAddressToInstruction,
                 oldSequencePointAddressToNew: oldSequencePointAddressToNew);
             return (nef, manifest, debugInfo);
+        }
+
+        private static bool TryResolveDeletedMethodOffset(
+            int oldOffset,
+            OrderedDictionary simplifiedInstructionsToAddress,
+            Dictionary<int, Instruction> oldAddressToInstruction,
+            out int newOffset)
+        {
+            for (int currentOffset = oldOffset;
+                oldAddressToInstruction.TryGetValue(currentOffset, out Instruction? instruction);
+                currentOffset += instruction.Size)
+            {
+                if (simplifiedInstructionsToAddress.Contains(instruction))
+                {
+                    newOffset = (int)simplifiedInstructionsToAddress[instruction]!;
+                    return true;
+                }
+            }
+
+            newOffset = oldOffset;
+            return false;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/JumpCompresser.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/JumpCompresser.cs
@@ -405,19 +405,24 @@ namespace Neo.Optimizer
                         // (The second operand was a copy-paste of the same condition. Folding a
                         // jump into a conditional target is intentionally not done; see the FoldJump
                         // remarks.)
-                        if (unconditionalJump.Contains(target.OpCode))
+                        if (TryGetFoldedUnconditionalJumpTarget(i, target, jumpSourceToTargets, out Instruction foldedTarget))
                         {
                             modified = true;
-                            Instruction finalTarget = jumpSourceToTargets[target];
                             // No need to change opcode. Use the old instruction without a new one.
                             // No need to reset operand. BuildOptimizedAssets does it.
                             simplifiedInstructionsToAddress.Add(i, newAddr);
                             oldSequencePointAddressToNew.Add(a, newAddr);
                             newAddr += i.Size;
 
-                            jumpSourceToTargets[i] = finalTarget;
-                            jumpTargetToSources[target].Remove(i);
-                            jumpTargetToSources[finalTarget].Add(i);
+                            jumpSourceToTargets[i] = foldedTarget;
+                            if (jumpTargetToSources.TryGetValue(target, out HashSet<Instruction>? targetSources))
+                                targetSources.Remove(i);
+                            if (!jumpTargetToSources.TryGetValue(foldedTarget, out HashSet<Instruction>? finalTargetSources))
+                            {
+                                finalTargetSources = new HashSet<Instruction>();
+                                jumpTargetToSources[foldedTarget] = finalTargetSources;
+                            }
+                            finalTargetSources.Add(i);
                             continue;
                         }
                         if ((target.OpCode == OpCode.ENDTRY || target.OpCode == OpCode.ENDTRY_L)
@@ -455,6 +460,31 @@ namespace Neo.Optimizer
             }
             while (modified);
             return JumpCompresser.CompressJump(nef, manifest, debugInfo);
+        }
+
+        private static bool TryGetFoldedUnconditionalJumpTarget(
+            Instruction source,
+            Instruction target,
+            Dictionary<Instruction, Instruction> jumpSourceToTargets,
+            out Instruction finalTarget)
+        {
+            finalTarget = target;
+            HashSet<Instruction> visited = new() { source };
+            Instruction current = target;
+            while (unconditionalJump.Contains(current.OpCode) &&
+                   jumpSourceToTargets.TryGetValue(current, out Instruction? next))
+            {
+                if (!visited.Add(current) || visited.Contains(next))
+                    return false;
+
+                finalTarget = next;
+                if (!unconditionalJump.Contains(next.OpCode))
+                    return finalTarget != target;
+
+                current = next;
+            }
+
+            return finalTarget != target;
         }
     }
 }

--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/JumpCompresser.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/JumpCompresser.cs
@@ -415,14 +415,8 @@ namespace Neo.Optimizer
                             newAddr += i.Size;
 
                             jumpSourceToTargets[i] = foldedTarget;
-                            if (jumpTargetToSources.TryGetValue(target, out HashSet<Instruction>? targetSources))
-                                targetSources.Remove(i);
-                            if (!jumpTargetToSources.TryGetValue(foldedTarget, out HashSet<Instruction>? finalTargetSources))
-                            {
-                                finalTargetSources = new HashSet<Instruction>();
-                                jumpTargetToSources[foldedTarget] = finalTargetSources;
-                            }
-                            finalTargetSources.Add(i);
+                            jumpTargetToSources[target].Remove(i);
+                            jumpTargetToSources[foldedTarget].Add(i);
                             continue;
                         }
                         if ((target.OpCode == OpCode.ENDTRY || target.OpCode == OpCode.ENDTRY_L)

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
@@ -56,6 +56,8 @@ namespace Neo.Compiler.SecurityAnalyzer
                 if (instruction.OpCode == OpCode.CALLT)
                 {
                     uint tokenId = instruction.TokenU16;
+                    if (tokenId >= nef.Tokens.Length)
+                        continue;
                     MethodToken token = nef.Tokens[tokenId];
                     if (token.Hash == NativeContract.ContractManagement.Hash && token.Method == methodName && ((token.CallFlags & CallFlags.WriteStates) != 0))
                         return true;

--- a/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
+++ b/src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Neo.Compiler.SecurityAnalyzer
                 {
                     uint tokenId = instruction.TokenU16;
                     if (tokenId >= nef.Tokens.Length)
-                        continue;
+                        throw new BadScriptException($"Invalid CALLT token {tokenId} at address {instructions[i].addr}");
                     MethodToken token = nef.Tokens[tokenId];
                     if (token.Hash == NativeContract.ContractManagement.Hash && token.Method == methodName && ((token.CallFlags & CallFlags.WriteStates) != 0))
                         return true;

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
@@ -141,6 +141,22 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             Assert.IsFalse(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "CALLT destroy without WriteStates should not be detected");
         }
 
+        [TestMethod]
+        public void Test_UpdateAnalyzer_CallT_OutOfRangeToken_NotDetected()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.CALLT, 0xff, 0xff,
+                (byte)OpCode.RET
+            ];
+
+            NefFile nef = CreateNefFile(script, Array.Empty<MethodToken>());
+            var manifest = CreateManifest();
+
+            Assert.IsFalse(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Out-of-range CALLT token should not be detected as update");
+            Assert.IsFalse(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "Out-of-range CALLT token should not be detected as destroy");
+        }
+
         /// <summary>
         /// Test that the bitwise operator fix correctly identifies WriteStates flag.
         /// </summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
@@ -142,7 +142,7 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
         }
 
         [TestMethod]
-        public void Test_UpdateAnalyzer_CallT_OutOfRangeToken_NotDetected()
+        public void Test_UpdateAnalyzer_CallT_OutOfRangeToken_Throws()
         {
             byte[] script =
             [
@@ -153,8 +153,11 @@ namespace Neo.Compiler.CSharp.UnitTests.SecurityAnalyzer
             NefFile nef = CreateNefFile(script, Array.Empty<MethodToken>());
             var manifest = CreateManifest();
 
-            Assert.IsFalse(UpdateAnalyzer.AnalyzeUpdate(nef, manifest), "Out-of-range CALLT token should not be detected as update");
-            Assert.IsFalse(UpdateAnalyzer.AnalyzeDestroy(nef, manifest), "Out-of-range CALLT token should not be detected as destroy");
+            var updateException = Assert.ThrowsException<BadScriptException>(() => UpdateAnalyzer.AnalyzeUpdate(nef, manifest));
+            StringAssert.Contains(updateException.Message, "Invalid CALLT token");
+
+            var destroyException = Assert.ThrowsException<BadScriptException>(() => UpdateAnalyzer.AnalyzeDestroy(nef, manifest));
+            StringAssert.Contains(destroyException.Message, "Invalid CALLT token");
         }
 
         /// <summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs
@@ -19,8 +19,10 @@ using Neo.SmartContract.Testing;
 using Neo.VM;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using OptimizerClass = Neo.Optimizer.Optimizer;
 using StrategyAttribute = Neo.Optimizer.StrategyAttribute;
 
@@ -165,6 +167,61 @@ namespace Neo.Compiler.CSharp.UnitTests
             var instruction = new Script(optimizedNef.Script.ToArray()).GetInstruction(0);
             Assert.AreEqual(OpCode.CALLT, instruction.OpCode);
             Assert.AreEqual(0, instruction.TokenU16);
+        }
+
+        [TestMethod]
+        public void Test_FoldJump_DoesNotHangOnSelfJump()
+        {
+            var nef = CreateNefFile([(byte)OpCode.JMP, 0x00], Array.Empty<MethodToken>());
+            Task optimizeTask = Task.Run(() => OptimizerClass.Optimize(
+                nef,
+                CreateEmptyManifest(),
+                null,
+                CompilationOptions.OptimizationType.Experimental));
+
+            Assert.IsTrue(optimizeTask.Wait(TimeSpan.FromSeconds(2)), "Optimizer should converge on a self-referential jump");
+        }
+
+        [TestMethod]
+        public void Test_FoldJump_DoesNotHangOnJumpCycle()
+        {
+            var nef = CreateNefFile([(byte)OpCode.JMP, 0x02, (byte)OpCode.JMP, 0xfe], Array.Empty<MethodToken>());
+            Task optimizeTask = Task.Run(() => OptimizerClass.Optimize(
+                nef,
+                CreateEmptyManifest(),
+                null,
+                CompilationOptions.OptimizationType.Experimental));
+
+            Assert.IsTrue(optimizeTask.Wait(TimeSpan.FromSeconds(2)), "Optimizer should converge on a cyclic jump chain");
+        }
+
+        [TestMethod]
+        public void Test_BuildOptimizedAssets_RetargetsDeletedMethodOffsetWithoutSequencePointRemap()
+        {
+            var nef = CreateNefFile([(byte)OpCode.NOP, (byte)OpCode.RET], Array.Empty<MethodToken>());
+            var manifest = CreateManifestWithMethodOffset(0);
+            var instructions = new Script(nef.Script.ToArray()).EnumerateInstructions().ToArray();
+            Neo.VM.Instruction nop = instructions[0].instruction;
+            Neo.VM.Instruction ret = instructions[1].instruction;
+            OrderedDictionary simplifiedInstructionsToAddress = new()
+            {
+                { ret, 0 }
+            };
+
+            var (_, optimizedManifest, _) = AssetBuilder.BuildOptimizedAssets(
+                nef,
+                manifest,
+                null,
+                simplifiedInstructionsToAddress,
+                new Dictionary<Neo.VM.Instruction, Neo.VM.Instruction>(),
+                new Dictionary<Neo.VM.Instruction, (Neo.VM.Instruction, Neo.VM.Instruction)>(),
+                new Dictionary<int, Neo.VM.Instruction>
+                {
+                    [0] = nop,
+                    [nop.Size] = ret
+                });
+
+            Assert.AreEqual(0, optimizedManifest.Abi.Methods[0].Offset);
         }
 
         [TestMethod]
@@ -490,6 +547,23 @@ namespace Neo.Compiler.CSharp.UnitTests
                 Trusts = WildcardContainer<ContractPermissionDescriptor>.Create(),
                 Extra = null
             };
+        }
+
+        private static ContractManifest CreateManifestWithMethodOffset(int offset)
+        {
+            var manifest = CreateEmptyManifest();
+            manifest.Abi.Methods =
+            [
+                new ContractMethodDescriptor
+                {
+                    Name = "main",
+                    Offset = offset,
+                    Parameters = Array.Empty<ContractParameterDefinition>(),
+                    ReturnType = ContractParameterType.Void,
+                    Safe = false
+                }
+            ];
+            return manifest;
         }
 
         public static class InvalidOptimizationStrategies

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs
@@ -196,6 +196,36 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         [TestMethod]
+        public void Test_FoldJump_RetargetsJumpChainToFinalTarget()
+        {
+            var nef = CreateNefFile([(byte)OpCode.JMP, 0x02, (byte)OpCode.JMP, 0x02, (byte)OpCode.JMP, 0x02, (byte)OpCode.RET], Array.Empty<MethodToken>());
+
+            var (optimizedNef, _, _) = JumpCompresser.FoldJump(
+                nef,
+                CreateEmptyManifest(),
+                null);
+
+            var instructions = new Script(optimizedNef.Script.ToArray()).EnumerateInstructions().ToArray();
+            Assert.AreEqual(OpCode.JMP, instructions[0].instruction.OpCode);
+            Assert.AreEqual(6, instructions[0].instruction.TokenI8);
+        }
+
+        [TestMethod]
+        public void Test_FoldJump_ReplacesJumpToEndTryWithEndTry()
+        {
+            var nef = CreateNefFile([(byte)OpCode.JMP, 0x02, (byte)OpCode.ENDTRY, 0x02, (byte)OpCode.RET], Array.Empty<MethodToken>());
+
+            var (optimizedNef, _, _) = JumpCompresser.FoldJump(
+                nef,
+                CreateEmptyManifest(),
+                null);
+
+            var instructions = new Script(optimizedNef.Script.ToArray()).EnumerateInstructions().ToArray();
+            Assert.AreEqual(OpCode.ENDTRY, instructions[0].instruction.OpCode);
+            Assert.AreEqual(4, instructions[0].instruction.TokenI8);
+        }
+
+        [TestMethod]
         public void Test_BuildOptimizedAssets_RetargetsDeletedMethodOffsetWithoutSequencePointRemap()
         {
             var nef = CreateNefFile([(byte)OpCode.NOP, (byte)OpCode.RET], Array.Empty<MethodToken>());
@@ -219,6 +249,59 @@ namespace Neo.Compiler.CSharp.UnitTests
                 {
                     [0] = nop,
                     [nop.Size] = ret
+                });
+
+            Assert.AreEqual(0, optimizedManifest.Abi.Methods[0].Offset);
+        }
+
+        [TestMethod]
+        public void Test_BuildOptimizedAssets_UsesSequencePointRemapForDeletedMethodOffset()
+        {
+            var nef = CreateNefFile([(byte)OpCode.NOP, (byte)OpCode.RET], Array.Empty<MethodToken>());
+            var manifest = CreateManifestWithMethodOffset(0);
+            var instructions = new Script(nef.Script.ToArray()).EnumerateInstructions().ToArray();
+            Neo.VM.Instruction nop = instructions[0].instruction;
+            Neo.VM.Instruction ret = instructions[1].instruction;
+            OrderedDictionary simplifiedInstructionsToAddress = new()
+            {
+                { ret, 0 }
+            };
+
+            var (_, optimizedManifest, _) = AssetBuilder.BuildOptimizedAssets(
+                nef,
+                manifest,
+                null,
+                simplifiedInstructionsToAddress,
+                new Dictionary<Neo.VM.Instruction, Neo.VM.Instruction>(),
+                new Dictionary<Neo.VM.Instruction, (Neo.VM.Instruction, Neo.VM.Instruction)>(),
+                new Dictionary<int, Neo.VM.Instruction>
+                {
+                    [0] = nop,
+                    [nop.Size] = ret
+                },
+                new Dictionary<int, int> { [0] = 0 });
+
+            Assert.AreEqual(0, optimizedManifest.Abi.Methods[0].Offset);
+        }
+
+        [TestMethod]
+        public void Test_BuildOptimizedAssets_KeepsMethodOffsetWhenDeletedOffsetCannotBeResolved()
+        {
+            var nef = CreateNefFile([(byte)OpCode.NOP], Array.Empty<MethodToken>());
+            var manifest = CreateManifestWithMethodOffset(0);
+            Neo.VM.Instruction nop = new Script(nef.Script.ToArray()).GetInstruction(0);
+            OrderedDictionary simplifiedInstructionsToAddress = new();
+
+            var (_, optimizedManifest, _) = AssetBuilder.BuildOptimizedAssets(
+                nef,
+                manifest,
+                null,
+                simplifiedInstructionsToAddress,
+                new Dictionary<Neo.VM.Instruction, Neo.VM.Instruction>(),
+                new Dictionary<Neo.VM.Instruction, (Neo.VM.Instruction, Neo.VM.Instruction)>(),
+                new Dictionary<int, Neo.VM.Instruction>
+                {
+                    [0] = nop
                 });
 
             Assert.AreEqual(0, optimizedManifest.Abi.Methods[0].Offset);


### PR DESCRIPTION
## Summary
- avoid repeated FoldJump rewrites for self-referential and cyclic unconditional jump chains
- guard UpdateAnalyzer against out-of-range CALLT tokens
- remap deleted method offsets to the next live instruction when no sequence point remap is available

## Testing
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "Test_FoldJump_DoesNotHangOnSelfJump|Test_FoldJump_DoesNotHangOnJumpCycle|Test_BuildOptimizedAssets_RetargetsDeletedMethodOffsetWithoutSequencePointRemap|Test_UpdateAnalyzer_CallT_OutOfRangeToken_NotDetected" --no-restore
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "UnitTest_OptimizerAutomation|UpdateAnalyzerTests" --no-restore
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Optimizer" --no-restore
- dotnet format neo-devpack-dotnet.sln --verify-no-changes --no-restore --include src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/AssetBuilder.cs src/Neo.Compiler.CSharp/Optimizer/Strategies/JumpCompresser.cs src/Neo.Compiler.CSharp/SecurityAnalyzer/UpdateAnalyzer.cs tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs tests/Neo.Compiler.CSharp.UnitTests/SecurityAnalyzer/UnitTest_UpdateAnalyzer.cs
