### PR TITLE
Limit debug info decompression

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/DumpNef.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/DumpNef.cs
@@ -28,6 +28,9 @@ namespace Neo.Optimizer
 {
     internal static class DumpNef
     {
+        internal const int MaxDebugInfoJsonBytes = 16 * 1024 * 1024;
+        private const int CopyBufferSize = 81920;
+
         internal static readonly Regex DocumentRegex = new(@"\[(\d+)\](\d+)\:(\d+)\-(\d+)\:(\d+)", RegexOptions.Compiled);
         internal static readonly Regex RangeRegex = new(@"(\d+)\-(\d+)", RegexOptions.Compiled);
         internal static readonly Regex SequencePointRegex = new(@"(\d+)(\[\d+\]\d+\:\d+\-\d+\:\d+)", RegexOptions.Compiled);
@@ -55,13 +58,28 @@ namespace Neo.Optimizer
             var entry = archive.Entries.FirstOrDefault();
             if (entry != null)
             {
+                if (entry.Length > MaxDebugInfoJsonBytes)
+                    throw new InvalidDataException($"Debug info JSON exceeds the maximum size of {MaxDebugInfoJsonBytes} bytes.");
                 using var unzippedEntryStream = entry.Open();
-                using var ms = new MemoryStream();
-                unzippedEntryStream.CopyTo(ms);
-                var unzippedArray = ms.ToArray();
-                return Encoding.UTF8.GetString(unzippedArray);
+                return Encoding.UTF8.GetString(ReadToEndWithLimit(unzippedEntryStream, MaxDebugInfoJsonBytes));
             }
             throw new ArgumentException("No file found in zip archive");
+        }
+
+        private static byte[] ReadToEndWithLimit(Stream stream, int maxBytes)
+        {
+            using var ms = new MemoryStream();
+            byte[] buffer = new byte[CopyBufferSize];
+            int read;
+            long totalRead = 0;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                totalRead += read;
+                if (totalRead > maxBytes)
+                    throw new InvalidDataException($"Debug info JSON exceeds the maximum size of {maxBytes} bytes.");
+                ms.Write(buffer, 0, read);
+            }
+            return ms.ToArray();
         }
 
         public static string GetInstructionAddressPadding(this Script script)

--- a/src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs
@@ -16,6 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Neo.SmartContract.Testing.Coverage
@@ -37,6 +38,9 @@ namespace Neo.SmartContract.Testing.Coverage
     /// </remarks>
     public partial class NeoDebugInfo(UInt160 hash, string documentRoot, IReadOnlyList<string> documents, IReadOnlyList<NeoDebugInfo.Method> methods)
     {
+        internal const int MaxDebugInfoJsonBytes = 16 * 1024 * 1024;
+        private const int CopyBufferSize = 81920;
+
         static readonly Regex spRegex = new(@"^(\d+)\[(-?\d+)\](\d+)\:(\d+)\-(\d+)\:(\d+)$");
 
         public const string MANIFEST_FILE_EXTENSION = ".manifest.json";
@@ -168,6 +172,8 @@ namespace Neo.SmartContract.Testing.Coverage
                 {
                     if (entry.FullName.EndsWith(DEBUG_JSON_EXTENSION, StringComparison.OrdinalIgnoreCase))
                     {
+                        if (entry.Length > MaxDebugInfoJsonBytes)
+                            throw new InvalidDataException($"Debug info JSON exceeds the maximum size of {MaxDebugInfoJsonBytes} bytes.");
                         using var entryStream = entry.Open();
                         debugInfo = Load(entryStream);
                         return true;
@@ -199,11 +205,26 @@ namespace Neo.SmartContract.Testing.Coverage
 
         internal static NeoDebugInfo Load(Stream stream)
         {
-            using StreamReader reader = new(stream);
-            var text = reader.ReadToEnd();
+            var text = ReadUtf8TextWithLimit(stream, MaxDebugInfoJsonBytes);
             var json = JToken.Parse(text) ?? throw new InvalidOperationException();
             if (json is not JObject jo) throw new FormatException("The debug info root must be a JSON object.");
             return FromDebugInfoJson(jo);
+        }
+
+        private static string ReadUtf8TextWithLimit(Stream stream, int maxBytes)
+        {
+            using var ms = new MemoryStream();
+            byte[] buffer = new byte[CopyBufferSize];
+            int read;
+            long totalRead = 0;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                totalRead += read;
+                if (totalRead > maxBytes)
+                    throw new InvalidDataException($"Debug info JSON exceeds the maximum size of {maxBytes} bytes.");
+                ms.Write(buffer, 0, read);
+            }
+            return Encoding.UTF8.GetString(ms.ToArray());
         }
 
         public static NeoDebugInfo FromDebugInfoJson(string json)

--- a/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_DumpNef.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_DumpNef.cs
@@ -18,11 +18,38 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace Neo.Compiler.CSharp.UnitTests.Peripheral
 {
+    [TestClass]
+    public class UnitTest_DumpNefDebugInfoLimits
+    {
+        private const int MaxDebugInfoJsonBytes = 16 * 1024 * 1024;
+
+        [TestMethod]
+        public void Test_UnzipDebugInfoReadsSmallArchive()
+        {
+            const string json = "{\"hash\":\"0x0000000000000000000000000000000000000000\",\"documents\":[],\"methods\":[]}";
+            byte[] archive = DumpNef.ZipDebugInfo(Encoding.UTF8.GetBytes(json), "test.debug.json");
+
+            Assert.AreEqual(json, DumpNef.UnzipDebugInfo(archive));
+        }
+
+        [TestMethod]
+        public void Test_UnzipDebugInfoRejectsOversizedArchive()
+        {
+            string json = "{\"hash\":\"0x0000000000000000000000000000000000000000\",\"documents\":[\"" +
+                new string('a', MaxDebugInfoJsonBytes) +
+                "\"],\"methods\":[]}";
+            byte[] archive = DumpNef.ZipDebugInfo(Encoding.UTF8.GetBytes(json), "test.debug.json");
+
+            Assert.ThrowsException<InvalidDataException>(() => DumpNef.UnzipDebugInfo(archive));
+        }
+    }
+
     [TestClass]
     public class UnitTest_DumpNef
     {

--- a/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
@@ -15,6 +15,7 @@ using Neo.SmartContract.Testing.Coverage;
 using Neo.SmartContract.Testing.Coverage.Formats;
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Numerics;
 using System.Reflection;
 using System.Text;
@@ -26,6 +27,7 @@ namespace Neo.SmartContract.Testing.UnitTests.Coverage
     public class CoverageDataTests
     {
         private static readonly Regex WhiteSpaceRegex = new("\\s");
+        private const int MaxDebugInfoJsonBytes = 16 * 1024 * 1024;
 
         [TestMethod]
         public void NeoDebugInfoLoadThrowsHelpfulMessageForNonObjectJson()
@@ -41,6 +43,54 @@ namespace Neo.SmartContract.Testing.UnitTests.Coverage
 
             Assert.IsInstanceOfType(exception.InnerException, typeof(FormatException));
             Assert.AreEqual("The debug info root must be a JSON object.", exception.InnerException!.Message);
+        }
+
+        [TestMethod]
+        public void NeoDebugInfoTryLoadCompressedLoadsSmallDebugInfo()
+        {
+            const string json = "{\"hash\":\"0x0000000000000000000000000000000000000000\",\"documents\":[],\"methods\":[]}";
+            byte[] archive = CreateDebugInfoArchive(json);
+
+            Assert.IsTrue(TryLoadCompressed(archive, out var debugInfo));
+            Assert.IsNotNull(debugInfo);
+            Assert.AreEqual(UInt160.Zero, debugInfo.Hash);
+        }
+
+        [TestMethod]
+        public void NeoDebugInfoTryLoadCompressedRejectsOversizedDebugInfo()
+        {
+            string json = "{\"hash\":\"0x0000000000000000000000000000000000000000\",\"documents\":[\"" +
+                new string('a', MaxDebugInfoJsonBytes) +
+                "\"],\"methods\":[]}";
+            byte[] archive = CreateDebugInfoArchive(json);
+
+            Assert.IsFalse(TryLoadCompressed(archive, out var debugInfo));
+            Assert.IsNull(debugInfo);
+        }
+
+        private static byte[] CreateDebugInfoArchive(string json)
+        {
+            using var compressedFileStream = new MemoryStream();
+            using (var zipArchive = new ZipArchive(compressedFileStream, ZipArchiveMode.Create, false))
+            {
+                var zipEntry = zipArchive.CreateEntry("test.debug.json");
+                using var zipEntryStream = zipEntry.Open();
+                byte[] content = Encoding.UTF8.GetBytes(json);
+                zipEntryStream.Write(content, 0, content.Length);
+            }
+            return compressedFileStream.ToArray();
+        }
+
+        private static bool TryLoadCompressed(byte[] archive, out NeoDebugInfo? debugInfo)
+        {
+            var tryLoadCompressed = typeof(NeoDebugInfo).GetMethod("TryLoadCompressed", BindingFlags.Static | BindingFlags.NonPublic, [typeof(Stream), typeof(NeoDebugInfo).MakeByRefType()]);
+            Assert.IsNotNull(tryLoadCompressed);
+
+            using var stream = new MemoryStream(archive);
+            object?[] args = [stream, null];
+            bool loaded = (bool)tryLoadCompressed!.Invoke(null, args)!;
+            debugInfo = (NeoDebugInfo?)args[1];
+            return loaded;
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- cap decompressed debug info JSON at 16 MiB in DumpNef and NeoDebugInfo loading paths
- reject oversized .nefdbgnfo entries before reading them into memory
- add regression coverage for small valid archives and oversized compressed debug info

## Testing
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "UnitTest_DumpNefDebugInfoLimits" --no-restore
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter "NeoDebugInfoTryLoadCompressed|NeoDebugInfoLoadThrowsHelpfulMessageForNonObjectJson" --no-restore
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "UnitTest_DumpNef" --no-restore
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter "CoverageDataTests" --no-restore
- dotnet format neo-devpack-dotnet.sln --verify-no-changes --no-restore --include src/Neo.Compiler.CSharp/Optimizer/DumpNef.cs src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_DumpNef.cs tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
