### PR TITLE
Validate optimizer control-flow targets

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/InstructionCoverage.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/InstructionCoverage.cs
@@ -66,6 +66,8 @@ namespace Neo.Optimizer
 
     public class InstructionCoverage
     {
+        internal const int MaxControlFlowAnalysisDepth = 1024;
+
         Script script;
         // Starting from the address, whether the call will surely throw or surely abort, or may be OK
         public Dictionary<int, BranchType> coveredMap { get; protected set; }
@@ -127,7 +129,7 @@ namespace Neo.Optimizer
 
         public static Stack<T> CopyStack<T>(Stack<T> stack) => new(stack.Reverse());
 
-        public BranchType HandleThrow(int entranceAddr, int throwFromAddr, Stack<TryState> stack)
+        public BranchType HandleThrow(int entranceAddr, int throwFromAddr, Stack<TryState> stack, int analysisDepth = 0)
         {
             stack = CopyStack(stack);
             TryType tryStateType;
@@ -142,13 +144,13 @@ namespace Neo.Optimizer
                 {
                     int addr = catchAddr;
                     stack.Push(new TryState(-1, finallyAddr, TryType.CATCH, true));
-                    return CoverInstruction(addr, tryStack: stack, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                    return CoverInstruction(addr, tryStack: stack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                 }
                 // try without catch: execute finally but do not visit codes after finally
                 else if (finallyAddr != -1)
                 {
                     stack.Push(new(-1, -1, TryType.FINALLY, false));
-                    if (CoverInstruction(finallyAddr, stack, jumpFromBasicBlockEntranceAddr: entranceAddr) == BranchType.ABORT)
+                    if (CoverInstruction(finallyAddr, stack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1) == BranchType.ABORT)
                         // ABORT in finally
                         return BranchType.ABORT;
                     return BranchType.THROW;
@@ -163,7 +165,7 @@ namespace Neo.Optimizer
                 if (finallyAddr != -1)
                 {
                     stack.Push(new(-1, -1, TryType.FINALLY, false));
-                    if (CoverInstruction(finallyAddr, stack, jumpFromBasicBlockEntranceAddr: entranceAddr) == BranchType.ABORT)
+                    if (CoverInstruction(finallyAddr, stack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1) == BranchType.ABORT)
                         // ABORT in finally
                         return BranchType.ABORT;
                 }
@@ -171,7 +173,7 @@ namespace Neo.Optimizer
             return BranchType.THROW;
         }
 
-        public BranchType HandleAbort(int entranceAddr, int abortFromAddr, Stack<TryState> stack)
+        public BranchType HandleAbort(int entranceAddr, int abortFromAddr, Stack<TryState> stack, int analysisDepth = 0)
         {
             // See if we are in a try or catch. There may still be runtime exceptions
             (int catchAddr, int finallyAddr, TryType stackType, _) = stack.Peek();
@@ -179,7 +181,7 @@ namespace Neo.Optimizer
                 stackType == TryType.CATCH && finallyAddr != -1)
             {
                 // Visit catchAddr because there may still be exceptions at runtime
-                if (HandleThrow(entranceAddr, abortFromAddr, stack) == BranchType.OK)
+                if (HandleThrow(entranceAddr, abortFromAddr, stack, analysisDepth) == BranchType.OK)
                     return BranchType.OK;  // No need to set coveredMap[entranceAddr] because it's OK when covered
             }
             return BranchType.ABORT;
@@ -196,8 +198,11 @@ namespace Neo.Optimizer
         /// <exception cref="BadScriptException"></exception>
         /// <exception cref="NotImplementedException"></exception>
         public BranchType CoverInstruction(int addr, Stack<TryState>? tryStack = null,
-            int? continueFromBasicBlockEntranceAddr = null, int? jumpFromBasicBlockEntranceAddr = null)
+            int? continueFromBasicBlockEntranceAddr = null, int? jumpFromBasicBlockEntranceAddr = null,
+            int analysisDepth = 0)
         {
+            if (analysisDepth > MaxControlFlowAnalysisDepth)
+                throw new BadScriptException($"Control flow analysis depth exceeds {MaxControlFlowAnalysisDepth}");
             if (continueFromBasicBlockEntranceAddr != null)
                 basicBlockContinuation[(int)continueFromBasicBlockEntranceAddr] = addr;
             if (jumpFromBasicBlockEntranceAddr != null)
@@ -231,7 +236,7 @@ namespace Neo.Optimizer
                 Instruction instruction = script.GetInstruction(addr);
                 if (jumpTargetToSources.ContainsKey(instruction) && addr != entranceAddr)
                     // on target of jump, start a new recursion to split basic blocks
-                    return coveredMap[entranceAddr] = CoverInstruction(addr, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr);
+                    return coveredMap[entranceAddr] = CoverInstruction(addr, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                 if (value != BranchType.UNCOVERED)
                 {
                     if (stackType != TryType.FINALLY)
@@ -245,7 +250,7 @@ namespace Neo.Optimizer
                     // No THROW or ABORT in try, catch or finally
                     // visit codes after ENDFINALLY
                     if (continueAfterFinally)
-                        return coveredMap[entranceAddr] = CoverInstruction(finallyAddr, tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                        return coveredMap[entranceAddr] = CoverInstruction(finallyAddr, tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                     // FINALLY is OK, but throwed in previous TRY (without catch) or CATCH
                     return value;  // Do not set coveredMap[entranceAddr] = BranchType.THROW;
                 }
@@ -264,7 +269,7 @@ namespace Neo.Optimizer
 
                 // ABORT may also THROW in execution; this has been handled in HandleAbort
                 if (instruction.OpCode == OpCode.ABORT || instruction.OpCode == OpCode.ABORTMSG)
-                    return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack);
+                    return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack, analysisDepth);
                 if (callWithJump.Contains(instruction.OpCode))
                 {
                     BranchType returnedType;
@@ -274,7 +279,7 @@ namespace Neo.Optimizer
                         foreach (int callaTarget in pushaTargets.Keys)
                         {
                             // Use `tryStack: null` to avoid using current try stack in a deeper call stack
-                            BranchType singleCallaResult = CoverInstruction(callaTarget, tryStack: null, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                            BranchType singleCallaResult = CoverInstruction(callaTarget, tryStack: null, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                             if (singleCallaResult < returnedType)
                                 returnedType = singleCallaResult;
                             // TODO: if a PUSHA cannot be covered, do not add it as a CALLA target
@@ -284,14 +289,14 @@ namespace Neo.Optimizer
                     {
                         int callTarget = ComputeJumpTarget(addr, instruction);
                         // Use `tryStack: null` to avoid using current try stack in a deeper call stack
-                        returnedType = CoverInstruction(callTarget, tryStack: null, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                        returnedType = CoverInstruction(callTarget, tryStack: null, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                     }
                     if (returnedType == BranchType.OK)
-                        return coveredMap[entranceAddr] = CoverInstruction(addr + instruction.Size, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr);
+                        return coveredMap[entranceAddr] = CoverInstruction(addr + instruction.Size, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                     if (returnedType == BranchType.ABORT)
-                        return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack);
+                        return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack, analysisDepth);
                     if (returnedType == BranchType.THROW)
-                        return coveredMap[entranceAddr] = HandleThrow(entranceAddr, addr, tryStack);
+                        return coveredMap[entranceAddr] = HandleThrow(entranceAddr, addr, tryStack, analysisDepth);
                 }
                 if (instruction.OpCode == OpCode.RET)
                 {
@@ -299,7 +304,7 @@ namespace Neo.Optimizer
                     // Do not judge with current stack.Peek(),
                     // because the try can hide deep in the stack.
                     // Just throw!
-                    HandleThrow(entranceAddr, addr, tryStack);
+                    HandleThrow(entranceAddr, addr, tryStack, analysisDepth);
                     // We should have poped try stack; however nobody else will read it anymore.
                     // No need to handle the try stack!
                     //while (tryStack.Count > 0 && tryStack.Peek().tryType != TryType.NONE)
@@ -314,10 +319,10 @@ namespace Neo.Optimizer
                     {
                         (int catchTarget, int finallyTarget) = ComputeTryTarget(addr, instruction);
                         tryStack.Push(new(catchTarget, finallyTarget, TryType.TRY, true));
-                        return coveredMap[entranceAddr] = CoverInstruction(addr + instruction.Size, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr);
+                        return coveredMap[entranceAddr] = CoverInstruction(addr + instruction.Size, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                     }
                     if (instruction.OpCode == OpCode.THROW)
-                        return coveredMap[entranceAddr] = HandleThrow(entranceAddr, addr, tryStack);
+                        return coveredMap[entranceAddr] = HandleThrow(entranceAddr, addr, tryStack, analysisDepth);
                     if (instruction.OpCode == OpCode.ENDTRY || instruction.OpCode == OpCode.ENDTRY_L)
                     {
                         if (stackType != TryType.TRY && stackType != TryType.CATCH)
@@ -326,7 +331,7 @@ namespace Neo.Optimizer
                         // Terminate the try/catch context, but
                         // visit catchAddr for current try, or finallyAddr for current catch
                         // because there may still be exceptions at runtime
-                        HandleThrow(entranceAddr, addr, tryStack);
+                        HandleThrow(entranceAddr, addr, tryStack, analysisDepth);
 
                         tryStack.Pop();  // pop the ending TRY or CATCH
                         int endPointer = ComputeJumpTarget(addr, instruction);
@@ -337,7 +342,7 @@ namespace Neo.Optimizer
                         }
                         else
                             addr = endPointer;
-                        return coveredMap[entranceAddr] = CoverInstruction(addr, tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                        return coveredMap[entranceAddr] = CoverInstruction(addr, tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                     }
                     if (instruction.OpCode == OpCode.ENDFINALLY)
                     {
@@ -346,7 +351,7 @@ namespace Neo.Optimizer
                             throw new BadScriptException("No finally stack on ENDFINALLY");
                         tryStack.Pop();  // pop the ending FINALLY
                         if (continueAfterFinally)
-                            return coveredMap[entranceAddr] = CoverInstruction(endPointer, tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                            return coveredMap[entranceAddr] = CoverInstruction(endPointer, tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                         // For this basic block in finally, the branch type is OK
                         // The throw is caused by previous codes
                         return BranchType.OK;  // No need to set coveredMap[entranceAddr] because it's OK when covered
@@ -356,21 +361,21 @@ namespace Neo.Optimizer
                     //addr = ComputeJumpTarget(addr, instruction);
                     //continue;
                     // For the analysis of basic blocks, we launch a new recursion
-                    return coveredMap[entranceAddr] = CoverInstruction(ComputeJumpTarget(addr, instruction), tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                    return coveredMap[entranceAddr] = CoverInstruction(ComputeJumpTarget(addr, instruction), tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                 if (conditionalJump.Contains(instruction.OpCode) || conditionalJump_L.Contains(instruction.OpCode))
                 {
-                    BranchType noJump = CoverInstruction(addr + instruction.Size, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr);
-                    BranchType jump = CoverInstruction(ComputeJumpTarget(addr, instruction), tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr);
+                    BranchType noJump = CoverInstruction(addr + instruction.Size, tryStack, continueFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
+                    BranchType jump = CoverInstruction(ComputeJumpTarget(addr, instruction), tryStack, jumpFromBasicBlockEntranceAddr: entranceAddr, analysisDepth: analysisDepth + 1);
                     if (noJump == BranchType.OK || jump == BranchType.OK)
                     {
                         // See if we are in a try. There may still be runtime exceptions
-                        HandleThrow(entranceAddr, addr, tryStack);
+                        HandleThrow(entranceAddr, addr, tryStack, analysisDepth);
                         return BranchType.OK;  // No need to set coveredMap[entranceAddr] because it's OK when covered
                     }
                     if (noJump == BranchType.ABORT && jump == BranchType.ABORT)
-                        return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack);
+                        return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack, analysisDepth);
                     if (noJump == BranchType.THROW || jump == BranchType.THROW)  // THROW, ABORT => THROW
-                        return coveredMap[entranceAddr] = HandleThrow(entranceAddr, addr, tryStack);
+                        return coveredMap[entranceAddr] = HandleThrow(entranceAddr, addr, tryStack, analysisDepth);
                     throw new Exception($"Unknown {nameof(BranchType)} {noJump} {jump}");
                 }
 

--- a/src/Neo.Compiler.CSharp/Optimizer/Analysers/JumpTarget.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Analysers/JumpTarget.cs
@@ -111,7 +111,7 @@ namespace Neo.Optimizer
                 if ((SingleJumpInOperand(i) && i.OpCode != CALLA) || (includePUSHA && i.OpCode == PUSHA))
                 {
                     int targetAddr = ComputeJumpTarget(a, i);
-                    Instruction target = addressToInstruction[targetAddr];
+                    Instruction target = GetTargetInstruction(addressToInstruction, targetAddr, a, i);
                     jumpSourceToTargets[i] = target;
                     if (!targetToSources.TryGetValue(target, out HashSet<Instruction>? sources))
                     {
@@ -125,7 +125,9 @@ namespace Neo.Optimizer
                     (int a1, int a2) = i.OpCode == TRY ?
                         (a + i.TokenI8, a + i.TokenI8_1) :
                         (a + i.TokenI32, a + i.TokenI32_1);
-                    (Instruction t1, Instruction t2) = (addressToInstruction[a1], addressToInstruction[a2]);
+                    (Instruction t1, Instruction t2) = (
+                        GetTargetInstruction(addressToInstruction, a1, a, i),
+                        GetTargetInstruction(addressToInstruction, a2, a, i));
                     trySourceToTargets.TryAdd(i, (t1, t2));
                     if (!targetToSources.TryGetValue(t1, out HashSet<Instruction>? sources1))
                     {
@@ -142,6 +144,17 @@ namespace Neo.Optimizer
                 }
             }
             return (jumpSourceToTargets, trySourceToTargets, targetToSources);
+        }
+
+        private static Instruction GetTargetInstruction(
+            Dictionary<int, Instruction> addressToInstruction,
+            int targetAddr,
+            int sourceAddr,
+            Instruction sourceInstruction)
+        {
+            if (!addressToInstruction.TryGetValue(targetAddr, out Instruction? target))
+                throw new BadScriptException($"{sourceInstruction.OpCode} at address {sourceAddr} targets invalid address {targetAddr}");
+            return target;
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/ControlFlowValidationTests.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/ControlFlowValidationTests.cs
@@ -1,0 +1,123 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ControlFlowValidationTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Optimizer;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.VM;
+using System;
+using System.Collections.Generic;
+using OptimizerJumpTarget = Neo.Optimizer.JumpTarget;
+
+namespace Neo.Compiler.CSharp.UnitTests.Optimizer
+{
+    [TestClass]
+    public class ControlFlowValidationTests
+    {
+        [TestMethod]
+        public void FindAllJumpAndTrySourceToTargets_ThrowsBadScriptForInvalidJumpTarget()
+        {
+            var script = new Script(new byte[] { (byte)OpCode.JMP, 0x03, (byte)OpCode.RET });
+
+            var exception = Assert.ThrowsException<BadScriptException>(() =>
+                OptimizerJumpTarget.FindAllJumpAndTrySourceToTargets(script));
+
+            StringAssert.Contains(exception.Message, "JMP");
+            StringAssert.Contains(exception.Message, "3");
+        }
+
+        [TestMethod]
+        public void FindAllJumpAndTrySourceToTargets_ThrowsBadScriptForInvalidTryTarget()
+        {
+            var script = new Script(new byte[] { (byte)OpCode.TRY, 0x02, 0x00, (byte)OpCode.RET });
+
+            var exception = Assert.ThrowsException<BadScriptException>(() =>
+                OptimizerJumpTarget.FindAllJumpAndTrySourceToTargets(script));
+
+            StringAssert.Contains(exception.Message, "TRY");
+            StringAssert.Contains(exception.Message, "2");
+        }
+
+        [TestMethod]
+        public void InstructionCoverage_ThrowsBadScriptForTooDeepCallChain()
+        {
+            var script = new List<byte>();
+            for (int i = 0; i <= InstructionCoverage.MaxControlFlowAnalysisDepth; i++)
+            {
+                script.Add((byte)OpCode.CALL);
+                script.Add(0x02);
+            }
+            script.Add((byte)OpCode.RET);
+
+            var exception = Assert.ThrowsException<BadScriptException>(() =>
+                new InstructionCoverage(CreateNefFile(script.ToArray()), CreateManifest()));
+
+            StringAssert.Contains(exception.Message, "Control flow analysis depth");
+        }
+
+        [TestMethod]
+        public void InstructionCoverage_AllowsReasonableCallChain()
+        {
+            byte[] script =
+            [
+                (byte)OpCode.CALL, 0x02,
+                (byte)OpCode.CALL, 0x02,
+                (byte)OpCode.RET
+            ];
+
+            var coverage = new InstructionCoverage(CreateNefFile(script), CreateManifest());
+
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[0]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[2]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[4]);
+        }
+
+        private static NefFile CreateNefFile(byte[] script)
+        {
+            return new NefFile
+            {
+                Compiler = "test",
+                Source = "test.cs",
+                Tokens = Array.Empty<MethodToken>(),
+                Script = script
+            };
+        }
+
+        private static ContractManifest CreateManifest()
+        {
+            return new ContractManifest
+            {
+                Name = "TestContract",
+                Groups = Array.Empty<ContractGroup>(),
+                SupportedStandards = Array.Empty<string>(),
+                Abi = new ContractAbi
+                {
+                    Methods =
+                    [
+                        new ContractMethodDescriptor
+                        {
+                            Name = "main",
+                            Offset = 0,
+                            Parameters = Array.Empty<ContractParameterDefinition>(),
+                            ReturnType = ContractParameterType.Void,
+                            Safe = false
+                        }
+                    ],
+                    Events = Array.Empty<ContractEventDescriptor>()
+                },
+                Permissions = Array.Empty<ContractPermission>(),
+                Trusts = WildcardContainer<ContractPermissionDescriptor>.Create(),
+                Extra = null
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- report invalid jump, CALL, PUSHA, and TRY targets as BadScriptException instead of raw KeyNotFoundException
- cap recursive instruction coverage analysis depth to avoid unbounded recursion on very deep control-flow chains
- add regression coverage for invalid control-flow targets and deep CALL chains

## Testing
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "ControlFlowValidationTests" --no-restore
- dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter "FullyQualifiedName~Optimizer|ControlFlowValidationTests|UnitTest_OptimizedScriptBuilder|UnitTest_BasicOptimizer" --no-restore
- dotnet format neo-devpack-dotnet.sln --verify-no-changes --no-restore --include src/Neo.Compiler.CSharp/Optimizer/Analysers/InstructionCoverage.cs src/Neo.Compiler.CSharp/Optimizer/Analysers/JumpTarget.cs tests/Neo.Compiler.CSharp.UnitTests/Optimizer/ControlFlowValidationTests.cs
