### PR TITLE
Validate engine checkpoint lengths

### DIFF
--- a/src/Neo.SmartContract.Testing/Storage/EngineCheckpoint.cs
+++ b/src/Neo.SmartContract.Testing/Storage/EngineCheckpoint.cs
@@ -22,6 +22,9 @@ namespace Neo.SmartContract.Testing.Storage
 {
     public class EngineCheckpoint
     {
+        private const int MaxCheckpointKeyLength = 1024 * 1024;
+        private const int MaxCheckpointValueLength = 16 * 1024 * 1024;
+
         /// <summary>
         /// Data
         /// </summary>
@@ -52,18 +55,14 @@ namespace Neo.SmartContract.Testing.Storage
             var list = new List<(byte[], byte[])>();
             var buffer = new byte[sizeof(int)];
 
-            while (stream.Read(buffer) == sizeof(int))
+            while (TryReadExactly(stream, buffer))
             {
-                var length = BinaryPrimitives.ReadInt32LittleEndian(buffer);
-                var key = new byte[length];
+                var key = ReadCheckpointField(stream, buffer, MaxCheckpointKeyLength, "key");
+                if (key is null) break;
+                if (!TryReadExactly(stream, buffer)) break;
 
-                if (stream.Read(key) != length) break;
-                if (stream.Read(buffer) != sizeof(int)) break;
-
-                length = BinaryPrimitives.ReadInt32LittleEndian(buffer);
-                var data = new byte[length];
-
-                if (stream.Read(data) != length) break;
+                var data = ReadCheckpointField(stream, buffer, MaxCheckpointValueLength, "value");
+                if (data is null) break;
 
                 list.Add((key, data));
             }
@@ -141,6 +140,29 @@ namespace Neo.SmartContract.Testing.Storage
                 stream.Write(buffer);
                 stream.Write(entry.value);
             }
+        }
+
+        private static byte[]? ReadCheckpointField(Stream stream, byte[] lengthBuffer, int maxLength, string fieldName)
+        {
+            var length = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
+            if (length < 0 || length > maxLength)
+                throw new InvalidDataException($"Invalid checkpoint {fieldName} length: {length}.");
+
+            var data = new byte[length];
+            return TryReadExactly(stream, data) ? data : null;
+        }
+
+        private static bool TryReadExactly(Stream stream, Span<byte> buffer)
+        {
+            var offset = 0;
+            while (offset < buffer.Length)
+            {
+                var read = stream.Read(buffer[offset..]);
+                if (read == 0) return false;
+                offset += read;
+            }
+
+            return true;
         }
     }
 }

--- a/tests/Neo.SmartContract.Testing.UnitTests/Storage/EngineCheckpointTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Storage/EngineCheckpointTests.cs
@@ -1,0 +1,112 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// EngineCheckpointTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing.Storage;
+using System;
+using System.Buffers.Binary;
+using System.IO;
+
+namespace Neo.SmartContract.Testing.UnitTests.Storage
+{
+    [TestClass]
+    public class EngineCheckpointTests
+    {
+        private const int MaxCheckpointKeyLength = 1024 * 1024;
+        private const int MaxCheckpointValueLength = 16 * 1024 * 1024;
+
+        [TestMethod]
+        public void LoadCheckpointRejectsNegativeKeyLength()
+        {
+            using var stream = CreateStream(-1);
+
+            var exception = Assert.ThrowsException<InvalidDataException>(() => new EngineCheckpoint(stream));
+            StringAssert.Contains(exception.Message, "key");
+        }
+
+        [TestMethod]
+        public void LoadCheckpointRejectsOversizedKeyLength()
+        {
+            using var stream = CreateStream(MaxCheckpointKeyLength + 1);
+
+            var exception = Assert.ThrowsException<InvalidDataException>(() => new EngineCheckpoint(stream));
+            StringAssert.Contains(exception.Message, "key");
+        }
+
+        [TestMethod]
+        public void LoadCheckpointRejectsNegativeValueLength()
+        {
+            using var stream = CreateStream(writer =>
+            {
+                WriteLength(writer, 1);
+                writer.WriteByte(0x01);
+                WriteLength(writer, -1);
+            });
+
+            var exception = Assert.ThrowsException<InvalidDataException>(() => new EngineCheckpoint(stream));
+            StringAssert.Contains(exception.Message, "value");
+        }
+
+        [TestMethod]
+        public void LoadCheckpointRejectsOversizedValueLength()
+        {
+            using var stream = CreateStream(writer =>
+            {
+                WriteLength(writer, 1);
+                writer.WriteByte(0x01);
+                WriteLength(writer, MaxCheckpointValueLength + 1);
+            });
+
+            var exception = Assert.ThrowsException<InvalidDataException>(() => new EngineCheckpoint(stream));
+            StringAssert.Contains(exception.Message, "value");
+        }
+
+        [TestMethod]
+        public void LoadCheckpointReadsValidData()
+        {
+            byte[] key = [0x01, 0x02, 0x03];
+            byte[] value = [0x04, 0x05];
+            using var stream = CreateStream(writer =>
+            {
+                WriteLength(writer, key.Length);
+                writer.Write(key);
+                WriteLength(writer, value.Length);
+                writer.Write(value);
+            });
+
+            var checkpoint = new EngineCheckpoint(stream);
+
+            Assert.AreEqual(1, checkpoint.Data.Length);
+            CollectionAssert.AreEqual(key, checkpoint.Data[0].key);
+            CollectionAssert.AreEqual(value, checkpoint.Data[0].value);
+        }
+
+        private static MemoryStream CreateStream(int length)
+        {
+            return CreateStream(writer => WriteLength(writer, length));
+        }
+
+        private static MemoryStream CreateStream(Action<MemoryStream> write)
+        {
+            var stream = new MemoryStream();
+            write(stream);
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static void WriteLength(Stream stream, int length)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, length);
+            stream.Write(buffer);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- reject negative and oversized checkpoint key/value lengths before allocation
- keep valid checkpoint streams loading normally
- add regression coverage for malformed checkpoint length fields

## Testing
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --filter "EngineCheckpointTests" --no-restore
- dotnet test tests/Neo.SmartContract.Testing.UnitTests/Neo.SmartContract.Testing.UnitTests.csproj --no-restore
- dotnet format neo-devpack-dotnet.sln --verify-no-changes --no-restore --include src/Neo.SmartContract.Testing/Storage/EngineCheckpoint.cs tests/Neo.SmartContract.Testing.UnitTests/Storage/EngineCheckpointTests.cs
- git diff --check