### PR TITLE
Let make test build the solution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ build:
 .PHONY: test
 test:
 	@echo "Running tests..."
-	@$(DOTNET) test ./neo-devpack-dotnet.sln --no-build -c Release
+	@$(DOTNET) test ./neo-devpack-dotnet.sln -c Release
 	@echo "All tests passed!"
 
 # Install nccs to system


### PR DESCRIPTION
## Summary
- Remove `--no-build` from the `make test` target.
- Keep the target focused on running the full solution tests in Release configuration.

## Why
The target should work from a clean checkout without requiring a prior manual build.

## Validation
- Ran `make -n test` to verify the command expansion.