### PR TITLE
List supported Makefile contract templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,11 @@ ifndef TYPE
 	$(eval TYPE := nep17)
 endif
 	@echo "Creating new $(TYPE) contract: $(NAME)..."
-	@$(DOTNET) new neocontract$(TYPE) -n $(NAME) -o ./contracts/$(NAME)
+	@if [ "$(TYPE)" = "solution" ]; then \
+		$(DOTNET) new neocontract -n $(NAME) -o ./contracts/$(NAME); \
+	else \
+		$(DOTNET) new neocontract$(TYPE) -n $(NAME) -o ./contracts/$(NAME); \
+	fi
 	@echo "Contract created in ./contracts/$(NAME)/"
 
 # Compile and deploy helper (requires neo-express)
@@ -293,5 +297,7 @@ deploy: compile
 list-templates:
 	@echo "Available contract templates:"
 	@echo "  nep17  - NEP-17 token standard"
+	@echo "  nep11  - NEP-11 token standard"
 	@echo "  oracle - Oracle request contract"
 	@echo "  owner  - Ownable contract pattern"
+	@echo "  solution - Smart contract solution"


### PR DESCRIPTION
## Summary
- Add the NEP-11 and solution templates to `make list-templates`.
- Route `TYPE=solution` to the `neocontract` template short name.

## Why
The Makefile listed only a subset of the shipped templates and did not expose the solution template through `make new-contract`.

## Validation
- Ran `make -n list-templates`.
- Ran `make -n new-contract NAME=Sample TYPE=solution`.
- Ran `make -n new-contract NAME=Sample TYPE=nep11`.