### PR TITLE
Add linux-arm64 publish target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,17 +260,20 @@ jobs:
       run: |
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-win-x64
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r linux-x64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-linux-x64
+        dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r linux-arm64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-linux-arm64
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r osx-x64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-osx-x64
         dotnet publish ./src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release -r osx-arm64 --self-contained true /p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./nccs-osx-arm64
         [ -f "./nccs-win-x64/Neo.Compiler.CSharp.exe" ] && mv ./nccs-win-x64/Neo.Compiler.CSharp.exe ./nccs-win-x64/nccs.exe
         [ -f "./nccs-linux-x64/Neo.Compiler.CSharp" ] && mv ./nccs-linux-x64/Neo.Compiler.CSharp ./nccs-linux-x64/nccs
+        [ -f "./nccs-linux-arm64/Neo.Compiler.CSharp" ] && mv ./nccs-linux-arm64/Neo.Compiler.CSharp ./nccs-linux-arm64/nccs
         [ -f "./nccs-osx-x64/Neo.Compiler.CSharp" ] && mv ./nccs-osx-x64/Neo.Compiler.CSharp ./nccs-osx-x64/nccs
         [ -f "./nccs-osx-arm64/Neo.Compiler.CSharp" ] && mv ./nccs-osx-arm64/Neo.Compiler.CSharp ./nccs-osx-arm64/nccs
         cd nccs-win-x64 && zip -r ../nccs-win-x64.zip * && cd ..
         cd nccs-linux-x64 && tar -czf ../nccs-linux-x64.tar.gz * && cd ..
+        cd nccs-linux-arm64 && tar -czf ../nccs-linux-arm64.tar.gz * && cd ..
         cd nccs-osx-x64 && tar -czf ../nccs-osx-x64.tar.gz * && cd ..
         cd nccs-osx-arm64 && tar -czf ../nccs-osx-arm64.tar.gz * && cd ..
-        sha256sum nccs-win-x64.zip nccs-linux-x64.tar.gz nccs-osx-x64.tar.gz nccs-osx-arm64.tar.gz > checksums.txt
+        sha256sum nccs-win-x64.zip nccs-linux-x64.tar.gz nccs-linux-arm64.tar.gz nccs-osx-x64.tar.gz nccs-osx-arm64.tar.gz > checksums.txt
     - name: Create release and upload binaries
       if: steps.check_tag.outputs.statusCode == '404'
       uses: softprops/action-gh-release@v3
@@ -284,6 +287,7 @@ jobs:
         files: |
           nccs-win-x64.zip
           nccs-linux-x64.tar.gz
+          nccs-linux-arm64.tar.gz
           nccs-osx-x64.tar.gz
           nccs-osx-arm64.tar.gz
           checksums.txt

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ publish:
 .PHONY: publish-all
 publish-all:
 	@echo "Publishing for all platforms..."
-	@for rid in win-x64 linux-x64 osx-x64 osx-arm64; do \
+	@for rid in win-x64 linux-x64 linux-arm64 osx-x64 osx-arm64; do \
 		echo "Publishing for $$rid..."; \
 		$(DOTNET) publish $(NCCS_PROJECT) -c Release -r $$rid --self-contained true \
 			/p:PublishSingleFile=true /p:PublishReadyToRun=true -o ./publish/$$rid; \


### PR DESCRIPTION
## Summary
- Add linux-arm64 to the Makefile `publish-all` target.
- Add linux-arm64 to the release workflow publish, archive, checksum, and upload steps.

## Why
The repository already detects linux-arm64 for single-target publishing, but the all-platform publishing paths skipped that runtime.

## Validation
- Ran `make -n publish-all`.
- Reviewed the release workflow artifact list for matching publish, archive, checksum, and upload entries.