### PR TITLE
Add symbol packages for distributable libraries

### DIFF
--- a/src/Neo.Disassembler.CSharp/Neo.Disassembler.CSharp.csproj
+++ b/src/Neo.Disassembler.CSharp/Neo.Disassembler.CSharp.csproj
@@ -11,6 +11,8 @@
         <PackageTags>NEO;Blockchain;Smart Contract</PackageTags>
         <Description>Disassembler for NEO smart contract.</Description>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <IncludeContentInPack>true</IncludeContentInPack>
         <ContentTargetFolders>content</ContentTargetFolders>
         <Nullable>enable</Nullable>

--- a/src/Neo.SmartContract.Analyzer/Neo.SmartContract.Analyzer.csproj
+++ b/src/Neo.SmartContract.Analyzer/Neo.SmartContract.Analyzer.csproj
@@ -13,6 +13,8 @@
     <Product>Neo.SmartContract.Analyzer.CSharp</Product>
     <Description>Neo.SmartContract.Analyzer.CSharp</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Neo.SmartContract.Testing/Neo.SmartContract.Testing.csproj
+++ b/src/Neo.SmartContract.Testing/Neo.SmartContract.Testing.csproj
@@ -11,6 +11,8 @@
         <PackageTags>NEO;Blockchain;Smart Contract</PackageTags>
         <Description>TestEngine for NEO smart contract testing.</Description>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <IncludeContentInPack>true</IncludeContentInPack>
         <ContentTargetFolders>content</ContentTargetFolders>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- Enable `snupkg` symbol package generation for Disassembler, Analyzer, and Testing packages.
- Leave the content-only Template package unchanged because it does not produce useful symbol package content.

## Why
Published library packages should consistently provide symbol packages for debugging.

## Validation
- Ran `dotnet pack` for Neo.Disassembler.CSharp, Neo.SmartContract.Analyzer, and Neo.SmartContract.Testing in Release configuration.
- Confirmed each changed project produced both `.nupkg` and `.snupkg` outputs.
- Neo.SmartContract.Analyzer still reports the existing NU5128 packaging warning.