### PR TITLE
Guard NEP11 burn token lookup

### DIFF
--- a/src/Neo.SmartContract.Framework/Nep11Token.cs
+++ b/src/Neo.SmartContract.Framework/Nep11Token.cs
@@ -127,7 +127,8 @@ namespace Neo.SmartContract.Framework
         protected static void Burn(ByteString tokenId)
         {
             var tokenMap = new LocalStorageMap(Prefix_Token);
-            TokenState token = (TokenState)StdLib.Deserialize(tokenMap[tokenId]!);
+            var tokenKey = tokenMap[tokenId] ?? throw new Exception("The token with given \"tokenId\" does not exist.");
+            TokenState token = (TokenState)StdLib.Deserialize(tokenKey);
             tokenMap.Delete(tokenId);
             UpdateBalance(token.Owner, tokenId, -1);
             TotalSupply--;

--- a/tests/Neo.SmartContract.Framework.UnitTests/Nep11MintUniquenessTest.cs
+++ b/tests/Neo.SmartContract.Framework.UnitTests/Nep11MintUniquenessTest.cs
@@ -42,6 +42,20 @@ public class Nep11MintUniquenessTest
         Assert.AreEqual(firstOwner, contract.OwnerOf(tokenId));
     }
 
+    [TestMethod]
+    public void Nep11Burn_RejectsMissingTokenIds()
+    {
+        var (nef, manifest) = CompileContract();
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<Nep11MintUniquenessContract>(nef, manifest);
+
+        var tokenId = new byte[] { 0x43 };
+
+        var exception = Assert.ThrowsException<TestException>(() => contract.Burn(tokenId));
+        Assert.IsTrue(exception.Message.Contains("does not exist."));
+        Assert.AreEqual(BigInteger.Zero, contract.TotalSupply);
+    }
+
     private static (NefFile nef, ContractManifest manifest) CompileContract()
     {
         const string source = @"using Neo.SmartContract.Framework;
@@ -60,6 +74,12 @@ public class Contract : Nep11Token<TestTokenState>
             Owner = owner,
             Name = ""token""
         });
+    }
+
+    [DisplayName(""burn"")]
+    public static void Burn(byte[] tokenId)
+    {
+        Nep11Token<TestTokenState>.Burn((ByteString)tokenId);
     }
 }
 
@@ -114,5 +134,8 @@ public class TestTokenState : Nep11TokenState
 
         [DisplayName("mint")]
         public abstract void Mint(byte[] tokenId, UInt160 owner);
+
+        [DisplayName("burn")]
+        public abstract void Burn(byte[] tokenId);
     }
 }


### PR DESCRIPTION
## Summary
- Add an explicit missing-token check before deserializing NEP-11 token state in `Burn`.
- Add a focused framework test for burning a missing token through a compiled test contract.

## Why
`Burn` should report the same clear missing-token error as `OwnerOf`, `Properties`, and `Transfer` instead of relying on a null-forgiving lookup.

## Validation
- Ran `dotnet test ./tests/Neo.SmartContract.Framework.UnitTests/Neo.SmartContract.Framework.UnitTests.csproj --filter Nep11MintUniquenessTest`.