### PR TITLE
Fix Runtime random documentation typo

### DIFF
--- a/src/Neo.SmartContract.Framework/Services/Runtime.cs
+++ b/src/Neo.SmartContract.Framework/Services/Runtime.cs
@@ -184,7 +184,7 @@ namespace Neo.SmartContract.Framework.Services
         public static extern void BurnGas(long gas);
 
         /// <summary>
-        /// Gets the next random number. The random number is determinstic.
+        /// Gets the next random number. The random number is deterministic.
         /// </summary>
         [Syscall("System.Runtime.GetRandom")]
         public static extern BigInteger GetRandom();


### PR DESCRIPTION
## Summary
- Correct the spelling of deterministic in the `Runtime.GetRandom` XML documentation.

## Why
The public framework documentation should not carry spelling errors.

## Validation
- Verified the old misspelling is no longer present in `Runtime.cs`.