### PR TITLE
Remove stale benchmark target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,12 +249,6 @@ docs:
 	@$(DOTNET) tool restore
 	@$(DOTNET) docfx docs/docfx.json --serve
 
-# Benchmarks
-.PHONY: benchmark
-benchmark: build
-	@echo "Running benchmarks..."
-	@$(DOTNET) run --project tests/Neo.Compiler.CSharp.Benchmarks -c Release
-
 # Security scan
 .PHONY: security-scan
 security-scan:


### PR DESCRIPTION
## Summary
- Remove the Makefile benchmark target that points to a non-existent project.

## Why
The repository does not contain `tests/Neo.Compiler.CSharp.Benchmarks`, so the target cannot succeed.

## Validation
- Verified `Makefile` no longer references the missing benchmark project.