### PR TITLE
Align examples package version property

### DIFF
--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -34,13 +34,13 @@
         <EnableDefaultNoneItems>true</EnableDefaultNoneItems>
         <UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
         
-        <NeoPackageVersion>3.10.0</NeoPackageVersion>
+        <NeoCorePackageVersion>3.10.0</NeoCorePackageVersion>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-        <PackageReference Include="Neo.SmartContract.Framework" Version="$(NeoPackageVersion)"/>
-        <PackageReference Include="Neo.SmartContract.Testing" Version="$(NeoPackageVersion)"/>
-        <PackageReference Include="Neo.SmartContract.Analyzer" Version="$(NeoPackageVersion)">
+        <PackageReference Include="Neo.SmartContract.Framework" Version="$(NeoCorePackageVersion)"/>
+        <PackageReference Include="Neo.SmartContract.Testing" Version="$(NeoCorePackageVersion)"/>
+        <PackageReference Include="Neo.SmartContract.Analyzer" Version="$(NeoCorePackageVersion)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary
- Rename the examples package version property to `NeoCorePackageVersion`.
- Update the shared example package references to use the aligned property name.

## Why
The examples props file used a separate version property name for the same package version value used elsewhere in the repository.

## Validation
- Ran `dotnet list ./examples/Example.SmartContract.HelloWorld/Example.SmartContract.HelloWorld.csproj package` and confirmed the shared packages resolve to 3.10.0.