### PR TITLE
Use MSTest verifiers in analyzer tests

### DIFF
--- a/tests/Neo.SmartContract.Analyzer.UnitTests/BanCastMethodAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/BanCastMethodAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.BanCastMethodAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.Test

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerCreationAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerCreationAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.BigIntegerCreationAnalyzer,
     Neo.SmartContract.Analyzer.BigIntegerCreationCodeFixProvider>;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerUsageAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Neo.SmartContract.Analyzer.BigIntegerUsageAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.BigIntegerUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.Test
 {

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerUsingUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerUsingUsageAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.BigIntegerUsingUsageAnalyzer,
     Neo.SmartContract.Analyzer.BigIntegerUsingUsageCodeFixProvider>;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/CharMethodsUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/CharMethodsUsageAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.CharMethodsUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/CollectionTypesUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/CollectionTypesUsageAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.CollectionTypesUsageAnalyzer,
     Neo.SmartContract.Analyzer.CollectionTypesUsageCodeFixProvider>;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs
@@ -12,7 +12,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VerifyCS =
-    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<Neo.SmartContract.Analyzer.DecimalUsageAnalyzer,
+    Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<Neo.SmartContract.Analyzer.DecimalUsageAnalyzer,
         Neo.SmartContract.Analyzer.DecimalUsageCodeFixProvider>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
@@ -14,7 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Verifier =
-    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<Neo.SmartContract.Analyzer.DoubleUsageAnalyzer,
+    Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<Neo.SmartContract.Analyzer.DoubleUsageAnalyzer,
         Neo.SmartContract.Analyzer.DoubleUsageCodeFixProvider>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/EnumMethodsUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/EnumMethodsUsageAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.EnumMethodsUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
@@ -14,7 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Verifier =
-    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<Neo.SmartContract.Analyzer.FloatUsageAnalyzer,
+    Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<Neo.SmartContract.Analyzer.FloatUsageAnalyzer,
         Neo.SmartContract.Analyzer.FloatUsageCodeFixProvider>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/InitialValueAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/InitialValueAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.InitialValueAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/KeywordUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/KeywordUsageAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.KeywordUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/MethodNamingAnalyzerUnderlineUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/MethodNamingAnalyzerUnderlineUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Neo.SmartContract.Analyzer.SmartContractMethodNamingAnalyzerUnderline>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.SmartContractMethodNamingAnalyzerUnderline>;
 
 namespace Neo.SmartContract.Analyzer.Test
 {

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/MethodNamingAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/MethodNamingAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Neo.SmartContract.Analyzer.SmartContractMethodNamingAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.SmartContractMethodNamingAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.Test
 {

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/MultipleCatchBlockAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/MultipleCatchBlockAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Neo.SmartContract.Analyzer.MultipleCatchBlockAnalyzer>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.MultipleCatchBlockAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests
 {

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj
@@ -8,15 +8,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
-	<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/NepStandardImplementationAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/NepStandardImplementationAnalyzerUnitTest.cs
@@ -12,7 +12,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.NepStandardImplementationAnalyzer,
     Neo.SmartContract.Analyzer.NepStandardImplementationCodeFixProvider>;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/RefKeywordUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/RefKeywordUsageAnalyzerUnitTest.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.RefKeywordUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StaticFieldInitializationAnalyzerTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StaticFieldInitializationAnalyzerTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Neo.SmartContract.Analyzer.StaticFieldInitializationAnalyzer>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.StaticFieldInitializationAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests
 {

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StringMethodUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StringMethodUsageAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Neo.SmartContract.Analyzer.StringMethodUsageAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.StringMethodUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.Test
 {

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/SupportedStandardsAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/SupportedStandardsAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.SupportedStandardsAnalyzer,
     Neo.SmartContract.Analyzer.SupportedStandardsCodeFixProvider>;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/SystemDiagnosticsUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/SystemDiagnosticsUsageAnalyzerUnitTests.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.SystemDiagnosticsUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/SystemMathUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/SystemMathUsageAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
     Neo.SmartContract.Analyzer.SystemMathUsageAnalyzer>;
 
 namespace Neo.SmartContract.Analyzer.UnitTests

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/VolatileKeywordUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/VolatileKeywordUsageAnalyzerUnitTest.cs
@@ -11,7 +11,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.VolatileKeywordUsageAnalyzer,
     Neo.SmartContract.Analyzer.VolatileKeywordRemovalCodeFixProvider>;
 


### PR DESCRIPTION
## Summary
- Replace analyzer test verifier aliases with MSTest verifier namespaces.
- Remove stale xUnit package references from the Analyzer unit test project.

## Why
The Analyzer test project uses MSTest attributes and MSTest verifier packages, but still carried xUnit verifier aliases and package references.

## Validation
- Ran `dotnet test ./tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj`.