### PR TITLE
Reject contracts exceeding the static slot limit

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
@@ -742,7 +742,7 @@ namespace Neo.Compiler
         {
             if (!_staticFields.TryGetValue(symbol, out byte index))
             {
-                index = (byte)StaticFieldCount;
+                index = GetNextStaticSlot(symbol);
                 _staticFields.Add(symbol, index);
             }
             return index;
@@ -750,7 +750,7 @@ namespace Neo.Compiler
 
         internal byte AddAnonymousStaticField()
         {
-            byte index = (byte)StaticFieldCount;
+            byte index = GetNextStaticSlot();
             _anonymousStaticFields.Add(index);
             return index;
         }
@@ -761,7 +761,7 @@ namespace Neo.Compiler
             {
                 return field;
             }
-            byte index = (byte)StaticFieldCount;
+            byte index = GetNextStaticSlot(symbol);
             _anonymousStaticFields.Add(index);
             _capturedStaticFields.TryAdd(symbol, index);
             return index;
@@ -776,10 +776,22 @@ namespace Neo.Compiler
         {
             if (!_vtables.TryGetValue(type, out byte index))
             {
-                index = (byte)StaticFieldCount;
+                index = GetNextStaticSlot(type);
                 _vtables.Add(type, index);
             }
             return index;
+        }
+
+        private byte GetNextStaticSlot(ISymbol? symbol = null)
+        {
+            if (StaticFieldCount >= byte.MaxValue)
+            {
+                string message = $"Contracts with more than {byte.MaxValue} static slots are not supported.";
+                throw symbol is null
+                    ? new CompilationException(DiagnosticId.SyntaxNotSupported, message)
+                    : new CompilationException(symbol, DiagnosticId.SyntaxNotSupported, message);
+            }
+            return (byte)StaticFieldCount;
         }
 
         internal void AssociateCapturedStaticField(ISymbol symbol, byte index)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SlotLimits.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SlotLimits.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.Compiler;
 using Neo.Compiler.CSharp.UnitTests.Syntax;
+using Neo.VM;
 using System;
 using System.IO;
 using System.Linq;
@@ -27,6 +28,27 @@ public class UnitTest_SlotLimits
         var context = TestHelper.CompileSingleContract(BuildLocalOverflowSource(256));
         Assert.IsFalse(context.Success, "Compilation should fail cleanly when local count exceeds the VM slot limit.");
         StringAssert.Contains(string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())), "255 local");
+    }
+
+    [TestMethod]
+    public void Contracts_With255StaticSlots_CompileSuccessfully()
+    {
+        var context = TestHelper.CompileSingleContract(BuildStaticSlotSource(255));
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var initialize = context.CreateManifest().Abi.GetMethod("_initialize", 0);
+        Assert.IsNotNull(initialize);
+        var instruction = ((Script)context.CreateExecutable().Script).GetInstruction(initialize.Offset);
+        Assert.AreEqual(OpCode.INITSSLOT, instruction.OpCode);
+        Assert.AreEqual(byte.MaxValue, instruction.Operand.Span[0]);
+    }
+
+    [TestMethod]
+    public void Contracts_WithMoreThan255StaticSlots_FailCompilationCleanly()
+    {
+        var context = TestHelper.CompileSingleContract(BuildStaticSlotSource(256));
+        Assert.IsFalse(context.Success, "Compilation should fail cleanly when the static slot count exceeds the VM limit.");
+        StringAssert.Contains(string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())), "255 static slots");
     }
 
     private static string BuildParameterOverflowSource(int parameterCount)
@@ -61,6 +83,30 @@ public class Contract : SmartContract
     public static int Main()
     {
 {{body}}        return 0;
+    }
+}
+""";
+    }
+
+    private static string BuildStaticSlotSource(int staticSlotCount)
+    {
+        var fields = new StringBuilder();
+        var body = new StringBuilder("        int sum = 0;\n");
+        for (var i = 0; i < staticSlotCount; i++)
+        {
+            fields.Append("    private static int Field").Append(i).AppendLine(";");
+            body.Append("        sum += Field").Append(i).AppendLine(";");
+        }
+
+        return $$"""
+using Neo.SmartContract.Framework;
+
+public class Contract : SmartContract
+{
+{{fields}}
+    public static int Main()
+    {
+{{body}}        return sum;
     }
 }
 """;


### PR DESCRIPTION
## Summary

- Reject static slot allocation after the VM's 255-slot limit.
- Apply the same boundary to declared, captured, anonymous, and vtable slots.
- Cover both the valid 255-slot boundary and the 256-slot failure.

## Root cause

Static slot indexes and the `INITSSLOT` count are byte-sized, but new slots were allocated by casting the total count directly to `byte`. At 256 slots, the count wrapped and slot indexes could alias.

## Validation

- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --filter FullyQualifiedName~UnitTest_SlotLimits --no-restore`
- `dotnet build src/Neo.Compiler.CSharp/Neo.Compiler.CSharp.csproj -c Release --no-restore`
- Scoped `dotnet format --verify-no-changes`