### PR TITLE
Distinguish contracts with identical simple names

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
@@ -448,7 +448,9 @@ namespace Neo.Compiler
                     break;
                 case ClassDeclarationSyntax @class:
                     INamedTypeSymbol symbol = model.GetDeclaredSymbol(@class)!;
-                    if (symbol.Name != _targetContract.Name && _nonDependencies != null && _nonDependencies.Contains(symbol))
+                    if (!SymbolEqualityComparer.Default.Equals(symbol, _targetContract) &&
+                        _nonDependencies != null &&
+                        _nonDependencies.Contains(symbol, SymbolEqualityComparer.Default))
                         return;
                     if (processed.Add(symbol)) ProcessClass(model, symbol);
                     break;
@@ -470,7 +472,7 @@ namespace Neo.Compiler
                 // As a result, we must stop the process if the current contract class is not the target contract
                 // For example, if the target contract is "Contract1" and the project contains "Contract1" and "Contract2"
                 // the process must skip when the "Contract2" class is processed
-                if (_targetContract.Name != symbol.Name)
+                if (!SymbolEqualityComparer.Default.Equals(_targetContract, symbol))
                 {
                     return;
                 }

--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -267,13 +267,44 @@ namespace Neo.Compiler
 
         private CompilationContext CompileProjectContractWithPrepare(List<INamedTypeSymbol> sortedClasses, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols, string targetContractName)
         {
-            var c = sortedClasses.FirstOrDefault(p => p.Name.Equals(targetContractName, StringComparison.InvariantCulture))
-                ?? throw new ArgumentException($"targetContractName '{targetContractName}' was not found");
+            var c = ResolveTargetContract(sortedClasses, targetContractName);
             var dependencies = classDependencies.TryGetValue(c, out var dependency) ? dependency : [];
-            var classesNotInDependencies = allClassSymbols.Except(dependencies).ToList();
-            var context = new CompilationContext(this, c, classesNotInDependencies!, allowBaseName: true);
+            var classesNotInDependencies = GetClassesNotInDependencies(allClassSymbols, dependencies);
+            var context = new CompilationContext(this, c, classesNotInDependencies, allowBaseName: true);
             context.Compile();
             return context;
+        }
+
+        private static INamedTypeSymbol ResolveTargetContract(List<INamedTypeSymbol> sortedClasses, string targetContractName)
+        {
+            var qualifiedMatch = sortedClasses.FirstOrDefault(contract =>
+                string.Equals(GetContractIdentity(contract), targetContractName, StringComparison.Ordinal));
+            if (qualifiedMatch != null)
+                return qualifiedMatch;
+
+            var simpleMatches = sortedClasses
+                .Where(contract => string.Equals(contract.Name, targetContractName, StringComparison.Ordinal))
+                .OrderBy(GetContractIdentity, StringComparer.Ordinal)
+                .ToArray();
+
+            if (simpleMatches.Length == 1)
+                return simpleMatches[0];
+            if (simpleMatches.Length == 0)
+                throw new ArgumentException($"targetContractName '{targetContractName}' was not found");
+
+            throw new ArgumentException(
+                $"targetContractName '{targetContractName}' is ambiguous. Use one of: {string.Join(", ", simpleMatches.Select(GetContractIdentity))}");
+        }
+
+        internal static string GetContractIdentity(INamedTypeSymbol contract)
+        {
+            return contract.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+        }
+
+        private static List<INamedTypeSymbol> GetClassesNotInDependencies(List<INamedTypeSymbol?> allClassSymbols, List<INamedTypeSymbol> dependencies)
+        {
+            var dependencySet = new HashSet<INamedTypeSymbol>(dependencies, SymbolEqualityComparer.Default);
+            return allClassSymbols.OfType<INamedTypeSymbol>().Where(symbol => !dependencySet.Contains(symbol)).ToList();
         }
 
         private List<CompilationContext> CompileProjectContractsWithPrepare(List<INamedTypeSymbol> sortedClasses, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols)
@@ -283,8 +314,8 @@ namespace Neo.Compiler
             Parallel.ForEach(sortedClasses, c =>
             {
                 var dependencies = classDependencies.TryGetValue(c, out var dependency) ? dependency : [];
-                var classesNotInDependencies = allClassSymbols.Except(dependencies).ToList();
-                var context = new CompilationContext(this, c, classesNotInDependencies!, allowBaseName);
+                var classesNotInDependencies = GetClassesNotInDependencies(allClassSymbols, dependencies);
+                var context = new CompilationContext(this, c, classesNotInDependencies, allowBaseName);
                 context.Compile();
                 // Process the target contract add this compilation context
                 Contexts.TryAdd(c, context);
@@ -349,8 +380,8 @@ namespace Neo.Compiler
             Parallel.ForEach(sortedClasses, c =>
             {
                 var dependencies = classDependencies.TryGetValue(c, out var dependency) ? dependency : [];
-                var classesNotInDependencies = allClassSymbols.Except(dependencies).ToList();
-                var context = new CompilationContext(this, c, classesNotInDependencies!, allowBaseName);
+                var classesNotInDependencies = GetClassesNotInDependencies(allClassSymbols, dependencies);
+                var context = new CompilationContext(this, c, classesNotInDependencies, allowBaseName);
                 context.Compile();
                 // Process the target contract add this compilation context
                 Contexts.TryAdd(c, context);

--- a/src/Neo.Compiler.CSharp/Program.cs
+++ b/src/Neo.Compiler.CSharp/Program.cs
@@ -521,6 +521,24 @@ namespace Neo.Compiler
 
         private static int ProcessOutputs(Options options, string folder, List<CompilationContext> contexts)
         {
+            var outputNameCollisions = contexts
+                .Where(context => context.Success && context.ContractName != null)
+                .GroupBy(context => context.ContractName!, StringComparer.OrdinalIgnoreCase)
+                .Where(group => group.Count() > 1)
+                .Select(group => new
+                {
+                    OutputName = group.Select(context => context.ContractName!).OrderBy(name => name, StringComparer.Ordinal).First(),
+                    Contracts = group.Select(context => CompilationEngine.GetContractIdentity(context.TargetContract)).OrderBy(name => name, StringComparer.Ordinal).ToArray()
+                })
+                .OrderBy(collision => collision.OutputName, StringComparer.Ordinal)
+                .ToArray();
+            if (outputNameCollisions.Length > 0)
+            {
+                foreach (var collision in outputNameCollisions)
+                    Console.Error.WriteLine($"Output base name '{collision.OutputName}' is shared by contracts: {string.Join(", ", collision.Contracts)}.");
+                return 1;
+            }
+
             int result = 0;
             List<CompilationException> exceptions = new();
             foreach (CompilationContext context in contexts)

--- a/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OutputNameSecurity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OutputNameSecurity.cs
@@ -88,6 +88,50 @@ public class Contract : SmartContract
             Assert.IsFalse(Directory.EnumerateFiles(workspace.ProjectDirectory, "*.nef", SearchOption.AllDirectories).Any());
         }
 
+        [TestMethod]
+        public void TestDuplicateContractNamesAreRejectedBeforeWritingOutputs()
+        {
+            using var workspace = TempWorkspace.Create();
+            string projectPath = workspace.CreateProject("""
+using Neo.SmartContract.Framework;
+
+namespace First
+{
+    public class SharedContract : SmartContract
+    {
+        public static int First() => 1;
+    }
+}
+
+namespace Second
+{
+    public class SharedContract : SmartContract
+    {
+        public static int Second() => 2;
+    }
+}
+""");
+
+            string outputPath = Path.Combine(workspace.ProjectDirectory, "out");
+
+            using var error = new StringWriter();
+            var previousError = Console.Error;
+            int exitCode;
+            try
+            {
+                Console.SetError(error);
+                exitCode = Program.Main([projectPath, "--debug", "None", "-o", outputPath]);
+            }
+            finally
+            {
+                Console.SetError(previousError);
+            }
+
+            Assert.AreEqual(1, exitCode);
+            StringAssert.Contains(error.ToString(), "Output base name 'SharedContract' is shared by contracts: First.SharedContract, Second.SharedContract.");
+            Assert.IsFalse(Directory.Exists(outputPath) && Directory.EnumerateFiles(outputPath).Any());
+        }
+
         private sealed class TempWorkspace : IDisposable
         {
             public string Root { get; }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractIdentity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ContractIdentity.cs
@@ -1,0 +1,131 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_ContractIdentity
+{
+    [TestMethod]
+    public void CompileProject_DistinguishesContractsWithSameSimpleName()
+    {
+        using var project = TempContractProject.Create();
+        project.WriteSource("Contracts.cs", """
+using Neo.SmartContract.Framework;
+using System.ComponentModel;
+
+namespace First
+{
+    public class SharedContract : SmartContract
+    {
+        [DisplayName("first")]
+        public static int First() => 1;
+    }
+}
+
+namespace Second
+{
+    public class SharedContract : SmartContract
+    {
+        [DisplayName("second")]
+        public static int Second() => 2;
+    }
+}
+
+namespace Third
+{
+    public class UniqueContract : SmartContract
+    {
+        [DisplayName("unique")]
+        public static int Unique() => 3;
+    }
+}
+""");
+
+        var engine = new CompilationEngine(new CompilationOptions());
+        var contexts = engine.CompileProject(project.ProjectFile);
+
+        Assert.AreEqual(3, contexts.Count);
+        var first = contexts.Single(context => context.TargetContract.ToDisplayString() == "First.SharedContract");
+        var second = contexts.Single(context => context.TargetContract.ToDisplayString() == "Second.SharedContract");
+        var unique = contexts.Single(context => context.TargetContract.ToDisplayString() == "Third.UniqueContract");
+        Assert.IsTrue(first.Success, string.Join(Environment.NewLine, first.Diagnostics));
+        Assert.IsTrue(second.Success, string.Join(Environment.NewLine, second.Diagnostics));
+        Assert.IsTrue(unique.Success, string.Join(Environment.NewLine, unique.Diagnostics));
+        CollectionAssert.AreEqual(new[] { "first" }, first.CreateManifest().Abi.Methods.Select(method => method.Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "second" }, second.CreateManifest().Abi.Methods.Select(method => method.Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "unique" }, unique.CreateManifest().Abi.Methods.Select(method => method.Name).ToArray());
+
+        var (sortedClasses, classDependencies, allClassSymbols) = engine.PrepareProjectContracts(project.ProjectFile);
+        var exception = Assert.ThrowsException<ArgumentException>(() =>
+            engine.CompileProject(project.ProjectFile, sortedClasses, classDependencies, allClassSymbols, "SharedContract"));
+        StringAssert.Contains(exception.Message, "First.SharedContract");
+        StringAssert.Contains(exception.Message, "Second.SharedContract");
+
+        var selected = engine.CompileProject(
+            project.ProjectFile,
+            sortedClasses,
+            classDependencies,
+            allClassSymbols,
+            "First.SharedContract").Single();
+        Assert.AreEqual("First.SharedContract", selected.TargetContract.ToDisplayString());
+        CollectionAssert.AreEqual(new[] { "first" }, selected.CreateManifest().Abi.Methods.Select(method => method.Name).ToArray());
+
+        var selectedBySimpleName = engine.CompileProject(
+            project.ProjectFile,
+            sortedClasses,
+            classDependencies,
+            allClassSymbols,
+            "UniqueContract").Single();
+        Assert.AreEqual("Third.UniqueContract", selectedBySimpleName.TargetContract.ToDisplayString());
+        CollectionAssert.AreEqual(new[] { "unique" }, selectedBySimpleName.CreateManifest().Abi.Methods.Select(method => method.Name).ToArray());
+    }
+
+    private sealed class TempContractProject : IDisposable
+    {
+        public string ProjectDirectory { get; }
+        public string ProjectFile { get; }
+
+        private TempContractProject(string projectDirectory, string projectFile)
+        {
+            ProjectDirectory = projectDirectory;
+            ProjectFile = projectFile;
+        }
+
+        public static TempContractProject Create()
+        {
+            var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempFolder);
+            var projectFile = Path.Combine(tempFolder, "ContractProject.csproj");
+            var repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            File.WriteAllText(projectFile, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{{frameworkProject}}" />
+  </ItemGroup>
+</Project>
+""");
+
+            return new TempContractProject(tempFolder, projectFile);
+        }
+
+        public void WriteSource(string name, string source)
+        {
+            File.WriteAllText(Path.Combine(ProjectDirectory, name), source);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(ProjectDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Use Roslyn symbol identity when selecting and filtering contracts.
- Accept fully qualified target names and reject ambiguous simple names.
- Reject duplicate output base names before writing any artifacts.

## Root cause

Contract selection compared only the simple class name. Contracts in different namespaces could be compiled into the same context, and their default output names could overwrite each other in nondeterministic order.

## Validation

- Contract identity and output tests: 5 passed
- Existing prepared-contract selection tests
- Scoped `dotnet format --verify-no-changes`