### PR TITLE
Isolate compilation state between projects

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -36,7 +36,10 @@ namespace Neo.Compiler
         internal Compilation? Compilation;
         internal CompilationOptions Options { get; private set; } = options;
         private static readonly MetadataReference[] CommonReferences;
+        private static readonly StringComparison ProjectPathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         private readonly Dictionary<string, MetadataReference> MetaReferences = new();
+        private string? PreparedProjectPath;
+        private string? ProjectPath;
         private string? ProjectVersion;
         private string? ProjectVersionPrefix;
         private string? ProjectVersionSuffix;
@@ -194,9 +197,34 @@ namespace Neo.Compiler
 
         public List<CompilationContext> CompileProject(string csproj)
         {
+            var compilation = LoadProjectCompilation(csproj, forceReload: true);
+            return CompileProjectContracts(compilation);
+        }
+
+        private Compilation LoadProjectCompilation(string csproj, bool forceReload)
+        {
+            string projectPath = Path.GetFullPath(csproj);
+            if (!forceReload && Compilation is not null && string.Equals(ProjectPath, projectPath, ProjectPathComparison))
+            {
+                return Compilation;
+            }
+
+            ResetProjectState();
+            Compilation = GetCompilation(projectPath);
+            ProjectPath = projectPath;
+            return Compilation;
+        }
+
+        private void ResetProjectState()
+        {
+            Compilation = null;
+            MetaReferences.Clear();
+            PreparedProjectPath = null;
+            ProjectPath = null;
+            ProjectVersion = null;
+            ProjectVersionPrefix = null;
+            ProjectVersionSuffix = null;
             Contexts.Clear();
-            Compilation ??= GetCompilation(csproj);
-            return CompileProjectContracts(Compilation);
         }
 
         public List<CompilationContext> CompileProject(string csproj, List<INamedTypeSymbol> sortedClasses, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols, string? targetContractName = null)
@@ -205,21 +233,28 @@ namespace Neo.Compiler
             {
                 throw new InvalidOperationException("Please call PrepareProjectContracts before calling CompileProject with sortedClasses, classDependencies and allClassSymbols parameters.");
             }
+
+            string projectPath = Path.GetFullPath(csproj);
+            if (Compilation is null || PreparedProjectPath is null || !string.Equals(PreparedProjectPath, projectPath, ProjectPathComparison))
+            {
+                throw new InvalidOperationException($"Project '{projectPath}' is not the project currently prepared by this compilation engine. Call {nameof(PrepareProjectContracts)} for this project before calling the prepared {nameof(CompileProject)} overload.");
+            }
+
             Contexts.Clear();
-            Compilation ??= GetCompilation(csproj);
             return targetContractName == null ? CompileProjectContractsWithPrepare(sortedClasses, classDependencies, allClassSymbols) : [CompileProjectContractWithPrepare(sortedClasses, classDependencies, allClassSymbols, targetContractName)];
         }
 
         public (List<INamedTypeSymbol> sortedClasses, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols) PrepareProjectContracts(string csproj)
         {
-            Compilation ??= GetCompilation(csproj);
+            var compilation = LoadProjectCompilation(csproj, forceReload: false);
+            PreparedProjectPath = null;
             var classDependencies = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
             var allSmartContracts = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             var allClassSymbols = new List<INamedTypeSymbol?>();
             var classSymbols = new List<INamedTypeSymbol>();
-            foreach (var tree in Compilation.SyntaxTrees)
+            foreach (var tree in compilation.SyntaxTrees)
             {
-                var semanticModel = Compilation.GetSemanticModel(tree);
+                var semanticModel = compilation.GetSemanticModel(tree);
                 var classNodes = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>();
 
                 foreach (var classNode in classNodes)
@@ -262,6 +297,7 @@ namespace Neo.Compiler
             // Check contract dependencies, make sure there is no cycle in the dependency graph
             var sortedClasses = TopologicalSort(classDependencies);
 
+            PreparedProjectPath = ProjectPath;
             return (sortedClasses, classDependencies, allClassSymbols);
         }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReuse.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_CompilationEngineReuse.cs
@@ -1,0 +1,130 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_CompilationEngineReuse
+{
+    [TestMethod]
+    public void CompileProject_ReusedEngineCompilesEachProjectSources()
+    {
+        using var firstProject = TempContractProject.Create("FirstContract", 1);
+        using var secondProject = TempContractProject.Create("SecondContract", 2);
+        var engine = CreateEngine();
+
+        var firstResult = engine.CompileProject(firstProject.ProjectFile).Single();
+        var secondResult = engine.CompileProject(secondProject.ProjectFile).Single();
+
+        Assert.AreEqual("FirstContract", firstResult.ContractName);
+        Assert.AreEqual("SecondContract", secondResult.ContractName);
+    }
+
+    [TestMethod]
+    public void PrepareProjectContracts_ReusedEnginePreparesEachProjectSources()
+    {
+        using var firstProject = TempContractProject.Create("FirstContract", 1);
+        using var secondProject = TempContractProject.Create("SecondContract", 2);
+        var engine = CreateEngine();
+
+        var (firstClasses, _, _) = engine.PrepareProjectContracts(firstProject.ProjectFile);
+        var (secondClasses, _, _) = engine.PrepareProjectContracts(secondProject.ProjectFile);
+
+        CollectionAssert.AreEqual(new[] { "FirstContract" }, firstClasses.Select(p => p.Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "SecondContract" }, secondClasses.Select(p => p.Name).ToArray());
+    }
+
+    [TestMethod]
+    public void CompileProject_PreparedOverloadRejectsDifferentPreparedProject()
+    {
+        using var firstProject = TempContractProject.Create("FirstContract", 1);
+        using var secondProject = TempContractProject.Create("SecondContract", 2);
+        var engine = CreateEngine();
+
+        var (firstClasses, firstDependencies, firstSymbols) = engine.PrepareProjectContracts(firstProject.ProjectFile);
+        var (secondClasses, secondDependencies, secondSymbols) = engine.PrepareProjectContracts(secondProject.ProjectFile);
+
+        var exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            engine.CompileProject(firstProject.ProjectFile, firstClasses, firstDependencies, firstSymbols));
+
+        StringAssert.Contains(exception.Message, firstProject.ProjectFile);
+        StringAssert.Contains(exception.Message, nameof(CompilationEngine.PrepareProjectContracts));
+
+        var secondResult = engine.CompileProject(secondProject.ProjectFile, secondClasses, secondDependencies, secondSymbols).Single();
+        Assert.AreEqual("SecondContract", secondResult.ContractName);
+    }
+
+    [TestMethod]
+    public void CompileSources_ReusedEngineRefreshesTemporaryProject()
+    {
+        using var firstProject = TempContractProject.Create("FirstContract", 1);
+        using var secondProject = TempContractProject.Create("SecondContract", 2);
+        var engine = CreateEngine();
+
+        var firstResult = engine.CompileSources(firstProject.SourceFile).Single();
+        var secondResult = engine.CompileSources(secondProject.SourceFile).Single();
+
+        Assert.AreEqual("FirstContract", firstResult.ContractName);
+        Assert.AreEqual("SecondContract", secondResult.ContractName);
+    }
+
+    private static CompilationEngine CreateEngine() => new(new CompilationOptions
+    {
+        SkipRestoreIfAssetsPresent = true
+    });
+
+    private sealed class TempContractProject : IDisposable
+    {
+        private readonly string _projectDirectory;
+
+        public string ProjectFile { get; }
+        public string SourceFile { get; }
+
+        private TempContractProject(string projectDirectory, string projectFile, string sourceFile)
+        {
+            _projectDirectory = projectDirectory;
+            ProjectFile = projectFile;
+            SourceFile = sourceFile;
+        }
+
+        public static TempContractProject Create(string contractName, int returnValue)
+        {
+            var projectDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDirectory);
+            var projectFile = Path.Combine(projectDirectory, "ContractProject.csproj");
+            var sourceFile = Path.Combine(projectDirectory, $"{contractName}.cs");
+            var repoRoot = Syntax.SyntaxProbeLoader.GetRepositoryRoot();
+            var frameworkProject = Path.Combine(repoRoot, "src", "Neo.SmartContract.Framework", "Neo.SmartContract.Framework.csproj");
+
+            File.WriteAllText(projectFile, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{{frameworkProject}}" />
+  </ItemGroup>
+</Project>
+""");
+            File.WriteAllText(sourceFile, $$"""
+using Neo.SmartContract.Framework;
+
+public class {{contractName}} : SmartContract
+{
+    public static int Main() => {{returnValue}};
+}
+""");
+
+            return new TempContractProject(projectDirectory, projectFile, sourceFile);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(_projectDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Track the normalized project identity held by a compilation engine.
- Reset compilation, metadata references, versions, and contexts when projects change.
- Require prepared symbols to match the project passed to the prepared compile overload.

## Root cause

The engine cached `Compilation` with `??=`. Reusing one engine for another project could continue compiling the first project's syntax and references.

## Validation

- Dedicated engine-reuse tests: 4 passed
- Existing prepared-overload tests: 2 passed
- Scoped `dotnet format --verify-no-changes`