### PR TITLE
Initialize late-discovered static slots

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
@@ -72,28 +72,16 @@ internal partial class MethodConvert
     {
         HashSet<INamedTypeSymbol> initializedClasses = new(SymbolEqualityComparer.Default);
         HashSet<ITypeSymbol> initializedVTables = new(SymbolEqualityComparer.Default);
+        int staticFieldInitializationStart = _instructions.Count;
         bool initializedAny;
 
         // Converting initializers and vtable methods can discover more static slots.
-        // Snapshot each collection and keep emitting new work in slot order.
+        // Keep vtable initialization ahead of every static field initializer.
         do
         {
             initializedAny = false;
-            foreach (INamedTypeSymbol @class in _context.StaticFieldSymbols.Select(p => p.ContainingType).Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default).ToArray())
-            {
-                if (!initializedClasses.Add(@class)) continue;
-                initializedAny = true;
-                foreach (IFieldSymbol field in @class.GetAllMembers().OfType<IFieldSymbol>())
-                {
-                    if (field.IsConst || !field.IsStatic) continue;
-                    ProcessFieldInitializer(model, field, null, () =>
-                    {
-                        byte index = _context.AddStaticField(field);
-                        AccessSlot(OpCode.STSFLD, index);
-                    });
-                }
-            }
 
+            int vTableInitializationStart = _instructions.Count;
             foreach (var (fieldIndex, type) in _context.VTables.ToArray())
             {
                 if (!initializedVTables.Add(type)) continue;
@@ -114,6 +102,29 @@ internal partial class MethodConvert
                 Push(virtualMethods.Length);
                 AddInstruction(OpCode.PACK);
                 AccessSlot(OpCode.STSFLD, fieldIndex);
+            }
+
+            if (vTableInitializationStart < _instructions.Count)
+            {
+                var vTableInitialization = _instructions[vTableInitializationStart..];
+                _instructions.RemoveRange(vTableInitializationStart, vTableInitialization.Count);
+                _instructions.InsertRange(staticFieldInitializationStart, vTableInitialization);
+                staticFieldInitializationStart += vTableInitialization.Count;
+            }
+
+            foreach (INamedTypeSymbol @class in _context.StaticFieldSymbols.Select(p => p.ContainingType).Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default).ToArray())
+            {
+                if (!initializedClasses.Add(@class)) continue;
+                initializedAny = true;
+                foreach (IFieldSymbol field in @class.GetAllMembers().OfType<IFieldSymbol>())
+                {
+                    if (field.IsConst || !field.IsStatic) continue;
+                    ProcessFieldInitializer(model, field, null, () =>
+                    {
+                        byte index = _context.AddStaticField(field);
+                        AccessSlot(OpCode.STSFLD, index);
+                    });
+                }
             }
         }
         while (initializedAny);

--- a/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Neo.IO;
 using Neo.VM;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Neo.Compiler;
@@ -69,36 +70,52 @@ internal partial class MethodConvert
 
     private void ProcessStaticFields(SemanticModel model)
     {
-        foreach (INamedTypeSymbol @class in _context.StaticFieldSymbols.Select(p => p.ContainingType).Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default).ToArray())
+        HashSet<INamedTypeSymbol> initializedClasses = new(SymbolEqualityComparer.Default);
+        HashSet<ITypeSymbol> initializedVTables = new(SymbolEqualityComparer.Default);
+        bool initializedAny;
+
+        // Converting initializers and vtable methods can discover more static slots.
+        // Snapshot each collection and keep emitting new work in slot order.
+        do
         {
-            foreach (IFieldSymbol field in @class.GetAllMembers().OfType<IFieldSymbol>())
+            initializedAny = false;
+            foreach (INamedTypeSymbol @class in _context.StaticFieldSymbols.Select(p => p.ContainingType).Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default).ToArray())
             {
-                if (field.IsConst || !field.IsStatic) continue;
-                ProcessFieldInitializer(model, field, null, () =>
+                if (!initializedClasses.Add(@class)) continue;
+                initializedAny = true;
+                foreach (IFieldSymbol field in @class.GetAllMembers().OfType<IFieldSymbol>())
                 {
-                    byte index = _context.AddStaticField(field);
-                    AccessSlot(OpCode.STSFLD, index);
-                });
-            }
-        }
-        foreach (var (fieldIndex, type) in _context.VTables)
-        {
-            IMethodSymbol[] virtualMethods = type.GetAllMembers().OfType<IMethodSymbol>().Where(p => p.IsVirtualMethod()).ToArray();
-            for (int i = virtualMethods.Length - 1; i >= 0; i--)
-            {
-                IMethodSymbol method = virtualMethods[i];
-                if (method.IsAbstract)
-                {
-                    Push((object?)null);
-                }
-                else
-                {
-                    InvokeMethod(model, method);
+                    if (field.IsConst || !field.IsStatic) continue;
+                    ProcessFieldInitializer(model, field, null, () =>
+                    {
+                        byte index = _context.AddStaticField(field);
+                        AccessSlot(OpCode.STSFLD, index);
+                    });
                 }
             }
-            Push(virtualMethods.Length);
-            AddInstruction(OpCode.PACK);
-            AccessSlot(OpCode.STSFLD, fieldIndex);
+
+            foreach (var (fieldIndex, type) in _context.VTables.ToArray())
+            {
+                if (!initializedVTables.Add(type)) continue;
+                initializedAny = true;
+                IMethodSymbol[] virtualMethods = type.GetAllMembers().OfType<IMethodSymbol>().Where(p => p.IsVirtualMethod()).ToArray();
+                for (int i = virtualMethods.Length - 1; i >= 0; i--)
+                {
+                    IMethodSymbol method = virtualMethods[i];
+                    if (method.IsAbstract)
+                    {
+                        Push((object?)null);
+                    }
+                    else
+                    {
+                        InvokeMethod(model, method);
+                    }
+                }
+                Push(virtualMethods.Length);
+                AddInstruction(OpCode.PACK);
+                AccessSlot(OpCode.STSFLD, fieldIndex);
+            }
         }
+        while (initializedAny);
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InitSlot.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InitSlot.cs
@@ -160,6 +160,53 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.AreEqual(new BigInteger(21), contract.Get());
         }
 
+        [TestMethod]
+        public void EmitInitSlot_InitializesSlotsDiscoveredFromVTableMethods()
+        {
+            const string source = """
+                using Neo.SmartContract.Framework;
+                using System.ComponentModel;
+
+                public class Contract : SmartContract
+                {
+                    [DisplayName("read")]
+                    public static int Read()
+                    {
+                        return new Outer().Read();
+                    }
+                }
+
+                public class Outer
+                {
+                    public virtual int Read()
+                    {
+                        return new Inner().Read();
+                    }
+                }
+
+                public static class NestedState
+                {
+                    public static readonly int Value = 42;
+                }
+
+                public class Inner
+                {
+                    public virtual int Read()
+                    {
+                        return NestedState.Value;
+                    }
+                }
+                """;
+
+            var context = TestHelper.CompileSingleContract(source);
+            var nef = context.CreateExecutable();
+            var manifest = context.CreateManifest();
+
+            var engine = new TestEngine(true);
+            var contract = engine.Deploy<LateDiscoveredInitializerContract>(nef, manifest);
+            Assert.AreEqual(new BigInteger(42), contract.Read());
+        }
+
         private static CompilationContext CompileSource(
             string source,
             CompilationOptions.OptimizationType optimize = CompilationOptions.OptimizationType.Basic)
@@ -227,6 +274,13 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             [DisplayName("get")]
             public abstract BigInteger? Get();
+        }
+
+        public abstract class LateDiscoveredInitializerContract(SmartContractInitialize initialize)
+            : SmartContract.Testing.SmartContract(initialize)
+        {
+            [DisplayName("read")]
+            public abstract BigInteger? Read();
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InitSlot.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_InitSlot.cs
@@ -186,14 +186,22 @@ namespace Neo.Compiler.CSharp.UnitTests
 
                 public static class NestedState
                 {
-                    public static readonly int Value = 42;
+                    public static readonly Base Value = new();
+                }
+
+                public class Base
+                {
+                    public virtual int Read()
+                    {
+                        return 42;
+                    }
                 }
 
                 public class Inner
                 {
                     public virtual int Read()
                     {
-                        return NestedState.Value;
+                        return NestedState.Value.Read();
                     }
                 }
                 """;


### PR DESCRIPTION
## Summary

- Process static-field classes and vtables to a deterministic fixed point.
- Initialize each discovered class and vtable once, in slot order.
- Cover nested vtable methods that discover additional vtables and static fields.

## Root cause

Static fields and vtables were each enumerated from a single snapshot. Converting a vtable method could allocate later slots after their initialization pass had already finished, leaving those slots included in `INITSSLOT` but uninitialized.

## Validation

- `UnitTest_InitSlot`: 4 passed
- Polymorphism and static-variable tests: 9 passed
- Scoped `dotnet format --verify-no-changes`