### PR TITLE
Initialize vtables before static fields

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ConstructorConvert.cs
@@ -69,6 +69,7 @@ internal partial class MethodConvert
 
     private void ProcessStaticFields(SemanticModel model)
     {
+        int staticFieldInitializationStart = _instructions.Count;
         foreach (INamedTypeSymbol @class in _context.StaticFieldSymbols.Select(p => p.ContainingType).Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default).ToArray())
         {
             foreach (IFieldSymbol field in @class.GetAllMembers().OfType<IFieldSymbol>())
@@ -81,6 +82,7 @@ internal partial class MethodConvert
                 });
             }
         }
+        int vTableInitializationStart = _instructions.Count;
         foreach (var (fieldIndex, type) in _context.VTables)
         {
             IMethodSymbol[] virtualMethods = type.GetAllMembers().OfType<IMethodSymbol>().Where(p => p.IsVirtualMethod()).ToArray();
@@ -99,6 +101,13 @@ internal partial class MethodConvert
             Push(virtualMethods.Length);
             AddInstruction(OpCode.PACK);
             AccessSlot(OpCode.STSFLD, fieldIndex);
+        }
+
+        if (vTableInitializationStart < _instructions.Count)
+        {
+            var vTableInitialization = _instructions[vTableInitializationStart..];
+            _instructions.RemoveRange(vTableInitializationStart, vTableInitialization.Count);
+            _instructions.InsertRange(staticFieldInitializationStart, vTableInitialization);
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_VTableInitialization.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_VTableInitialization.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_VTableInitialization.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing;
+using System.ComponentModel;
+using System.Numerics;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_VTableInitialization
+{
+    [TestMethod]
+    public void VTablesAreInitializedBeforeStaticObjects()
+    {
+        const string source = """
+            using Neo.SmartContract.Framework;
+            using System.ComponentModel;
+
+            public class Contract : SmartContract
+            {
+                private static int _order;
+                private static int _first = Record(1);
+                private static VirtualValue _indirectValue = CreateValue();
+                private static VirtualValue _directValue = new();
+                private static int _second = Record(2);
+
+                [DisplayName("run")]
+                public static int Run()
+                {
+                    return _order * 10000 + _indirectValue.GetValue() * 100 + _directValue.GetValue();
+                }
+
+                private static VirtualValue CreateValue() => new();
+
+                private static int Record(int value)
+                {
+                    _order = _order * 10 + value;
+                    return value;
+                }
+
+                public class VirtualValue
+                {
+                    public virtual int GetValue()
+                    {
+                        return 42;
+                    }
+                }
+            }
+            """;
+
+        var context = TestHelper.CompileSingleContract(source);
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<VTableInitializationContract>(
+            context.CreateExecutable(),
+            context.CreateManifest());
+
+        Assert.AreEqual(new BigInteger(124242), contract.Run());
+    }
+
+    public abstract class VTableInitializationContract(SmartContractInitialize initialize)
+        : SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("run")]
+        public abstract BigInteger? Run();
+    }
+}


### PR DESCRIPTION
## Summary

- Emit discovered vtable initialization before static-field initialization.
- Preserve the declared order and side effects of static-field initializers.
- Cover objects created both directly and through a helper method.

## Root cause

Static-field initializers ran before vtable slots were populated. An object created during initialization could capture a null vtable permanently and later fail during virtual dispatch.

## Validation

- Vtable initialization, slot, polymorphism, and static-variable tests: 13 passed
- Direct and helper-based object creation executed through the test VM
- Scoped `dotnet format --verify-no-changes`