### PR TITLE
Refresh the debug hash after optimization

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/AssetBuilder.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/AssetBuilder.cs
@@ -59,6 +59,8 @@ namespace Neo.Optimizer
             debugInfo = DebugInfoBuilder.ModifyDebugInfo(
                 debugInfo, simplifiedInstructionsToAddress, oldAddressToInstruction,
                 oldSequencePointAddressToNew: oldSequencePointAddressToNew);
+            if (debugInfo is not null)
+                debugInfo["hash"] = nef.Script.Span.ToScriptHash().ToString();
             return (nef, manifest, debugInfo);
         }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_DebugInfo.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_DebugInfo.cs
@@ -58,5 +58,28 @@ namespace Neo.Compiler.CSharp.UnitTests.Peripheral
             Assert.IsTrue(debugInfo.ContainsProperty("static-variables"));
             Assert.AreEqual("MyStaticVar1,Integer,0;MyStaticVar2,Boolean,1", string.Join(';', (debugInfo["static-variables"] as JArray)!.Select(u => u!.AsString())));
         }
+
+        [TestMethod]
+        public void Test_OptimizedDebugInfoHash()
+        {
+            var options = TestHelper.CreateDefaultOptions();
+            options.Debug = CompilationOptions.DebugType.Extended;
+            var context = TestHelper.CompileSingleContract("""
+                using Neo.SmartContract.Framework;
+
+                public class Contract : SmartContract
+                {
+                    public static int Increment(int value) => value + 1;
+                }
+                """, options);
+            Assert.IsTrue(context.Success, string.Join(System.Environment.NewLine, context.Diagnostics));
+
+            var unoptimizedHash = context.CreateExecutable().Script.Span.ToScriptHash().ToString();
+            var (nef, _, debugInfo) = context.CreateResults();
+            var optimizedHash = nef.Script.Span.ToScriptHash().ToString();
+
+            Assert.AreNotEqual(unoptimizedHash, optimizedHash, "The test contract must exercise an optimizer rewrite.");
+            Assert.AreEqual(optimizedHash, debugInfo["hash"]!.GetString());
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Refresh the debug information hash after rebuilding an optimized script.
- Add a regression test that verifies the fixture is rewritten and the final hashes match.

## Why

The optimizer updated the NEF script and checksum but left the top-level debug hash unchanged. Tools validating debug information against the final NEF could therefore reject a valid optimized build.

## Tests

- Debug info, optimizer automation, and DumpNef tests (30 passed)
