### PR TITLE
Preserve debug method records after optimization

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/DebugInfoBuilder.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/AssetBuilder/DebugInfoBuilder.cs
@@ -42,10 +42,9 @@ namespace Neo.Optimizer
             {
                 GroupCollection rangeGroups = RangeRegex.Match(method!["range"]!.AsString()).Groups;
                 (int oldMethodStart, int oldMethodEnd) = (int.Parse(rangeGroups[1].ToString()), int.Parse(rangeGroups[2].ToString()));
-                int methodStart;
-                if (simplifiedInstructionsToAddress.Contains(oldAddressToInstruction[oldMethodStart]))
-                    methodStart = (int)simplifiedInstructionsToAddress[oldAddressToInstruction[oldMethodStart]]!;
-                else if (oldSequencePointAddressToNew?.TryGetValue(oldMethodStart, out methodStart) != true)
+                if (!TryResolveInstructionOffset(
+                    oldMethodStart, oldMethodEnd, simplifiedInstructionsToAddress, oldAddressToInstruction,
+                    oldSequencePointAddressToNew, out int methodStart))
                 {
                     methodsToRemove.Add(method);
                     continue;
@@ -55,11 +54,14 @@ namespace Neo.Optimizer
                 if (oldSequencePointAddressToNew?.TryGetValue(oldMethodEnd, out var methodEnd) != true)
                 {
                     //int methodEnd = (int)simplifiedInstructionsToAddress[oldAddressToInstruction[oldMethodEnd]]!;
-                    int oldMethodEndNotDeleted = oldAddressToInstruction.Where(kv =>
-                    kv.Key >= oldMethodStart && kv.Key <= oldMethodEnd &&
-                    simplifiedInstructionsToAddress.Contains(kv.Value)
-                    ).Max(kv => kv.Key);
-                    methodEnd = (int)simplifiedInstructionsToAddress[oldAddressToInstruction[oldMethodEndNotDeleted]]!;
+                    int? oldMethodEndNotDeleted = oldAddressToInstruction.Where(kv =>
+                        kv.Key >= oldMethodStart && kv.Key <= oldMethodEnd &&
+                        simplifiedInstructionsToAddress.Contains(kv.Value))
+                        .Select(kv => (int?)kv.Key)
+                        .Max();
+                    methodEnd = oldMethodEndNotDeleted is null
+                        ? methodStart
+                        : (int)simplifiedInstructionsToAddress[oldAddressToInstruction[oldMethodEndNotDeleted.Value]]!;
                 }
                 method["range"] = $"{methodStart}-{methodEnd}";
 
@@ -143,17 +145,48 @@ namespace Neo.Optimizer
                 if (method["abi"] is JObject abi && abi["offset"] != null)
                 {
                     int offset = int.Parse(abi["offset"]!.ToString());
-                    if (simplifiedInstructionsToAddress.Contains(oldAddressToInstruction[offset]))
-                        offset = (int)simplifiedInstructionsToAddress[oldAddressToInstruction[offset]]!;
-                    else
-                        oldSequencePointAddressToNew?.TryGetValue(offset, out offset);
-                    abi["offset"] = offset;
+                    if (TryResolveInstructionOffset(
+                        offset, oldMethodEnd, simplifiedInstructionsToAddress, oldAddressToInstruction,
+                        oldSequencePointAddressToNew, out int newOffset))
+                        abi["offset"] = newOffset;
                 }
             }
             JArray methods = (JArray)debugInfo["methods"]!;
             foreach (JToken method in methodsToRemove)
                 methods.Remove(method);
             return debugInfo;
+        }
+
+        private static bool TryResolveInstructionOffset(
+            int oldOffset,
+            int oldMethodEnd,
+            System.Collections.Specialized.OrderedDictionary simplifiedInstructionsToAddress,
+            Dictionary<int, Instruction> oldAddressToInstruction,
+            Dictionary<int, int>? oldSequencePointAddressToNew,
+            out int newOffset)
+        {
+            if (oldAddressToInstruction.TryGetValue(oldOffset, out Instruction? oldInstruction) &&
+                simplifiedInstructionsToAddress.Contains(oldInstruction))
+            {
+                newOffset = (int)simplifiedInstructionsToAddress[oldInstruction]!;
+                return true;
+            }
+            if (oldSequencePointAddressToNew?.TryGetValue(oldOffset, out newOffset) == true)
+                return true;
+
+            for (int currentOffset = oldOffset;
+                currentOffset <= oldMethodEnd && oldAddressToInstruction.TryGetValue(currentOffset, out Instruction? instruction);
+                currentOffset += instruction.Size)
+            {
+                if (simplifiedInstructionsToAddress.Contains(instruction))
+                {
+                    newOffset = (int)simplifiedInstructionsToAddress[instruction]!;
+                    return true;
+                }
+            }
+
+            newOffset = oldOffset;
+            return false;
         }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OptimizedDebugMethods.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Peripheral/UnitTest_OptimizedDebugMethods.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_OptimizedDebugMethods.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests.Peripheral;
+
+[TestClass]
+public class UnitTest_OptimizedDebugMethods
+{
+    [TestMethod]
+    public void OptimizedDebugInfoRetainsAllAbiMethods()
+    {
+        var testContractPath = new FileInfo("../../../../Neo.Compiler.CSharp.TestContracts/Contract_Types.cs").FullName;
+        var results = new CompilationEngine(new CompilationOptions
+        {
+            Debug = CompilationOptions.DebugType.Extended,
+            Optimize = CompilationOptions.OptimizationType.Experimental,
+            Nullable = NullableContextOptions.Enable
+        }).CompileSources(testContractPath);
+
+        Assert.AreEqual(1, results.Count);
+        Assert.IsTrue(results[0].Success, string.Join(System.Environment.NewLine, results[0].Diagnostics));
+
+        var (_, manifest, debugInfo) = results[0].CreateResults();
+        HashSet<int> debugAbiOffsets = ((JArray)debugInfo["methods"]!)
+            .Select(method => method?["abi"] as JObject)
+            .Where(abi => abi is not null)
+            .Select(abi => int.Parse(abi!["offset"]!.ToString()))
+            .ToHashSet();
+
+        Assert.AreEqual(manifest.Abi.Methods.Length, debugAbiOffsets.Count);
+        foreach (var method in manifest.Abi.Methods)
+            Assert.IsTrue(debugAbiOffsets.Contains(method.Offset), $"Missing debug information for ABI method '{method.Name}'.");
+    }
+}


### PR DESCRIPTION
## Summary

- Resolve deleted method entry instructions to the first surviving instruction within the original method range.
- Apply the same resolution to debug ranges and ABI offsets.
- Add a regression test covering Experimental optimization.

## Why

When a method entry instruction was removed without an explicit sequence-point mapping, the optimizer removed the entire debug method record. Contract_Types retained 34 manifest methods but only 12 ABI debug records with Experimental optimization.

## Tests

- Verified Contract_Types retains 34 manifest methods and 34 ABI debug records through the CLI.
- Full Neo.Compiler.CSharp.UnitTests Release suite (1360 passed)
