### PR TITLE
Make optimizer strategy discovery deterministic

### DIFF
--- a/src/Neo.Compiler.CSharp/Optimizer/README.md
+++ b/src/Neo.Compiler.CSharp/Optimizer/README.md
@@ -147,7 +147,11 @@ Optimizer/
 1. Create a new class in `Strategies/`
 2. Implement the optimization logic
 3. Add the `[Strategy]` attribute
-4. Register in `BasicOptimizer.cs`
+4. Use the standard public static strategy signature
+
+Valid attributed methods are discovered automatically when the optimizer is initialized.
+Strategies run by descending priority. Equal priorities are ordered by assembly, declaring
+type, method name, and metadata token so execution order does not depend on reflection order.
 
 ## Performance Impact
 

--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/Optimizer.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/Optimizer.cs
@@ -16,7 +16,6 @@ using Neo.SmartContract.Manifest;
 using Neo.VM;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Neo.Optimizer
@@ -48,11 +47,9 @@ namespace Neo.Optimizer
         private static void RegisterStrategies(IEnumerable<Type> types)
         {
             bool registeredAny = false;
-            foreach (Type type in types.OrderBy(type => type.FullName ?? type.Name, StringComparer.Ordinal))
+            foreach (Type type in types)
             {
-                foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                    .OrderBy(method => method.Name, StringComparer.Ordinal)
-                    .ThenBy(method => method.MetadataToken))
+                foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
                 {
                     StrategyAttribute? attribute = method.GetCustomAttribute<StrategyAttribute>();
                     if (attribute is null || !HasValidStrategySignature(method))

--- a/src/Neo.Compiler.CSharp/Optimizer/Strategies/Optimizer.cs
+++ b/src/Neo.Compiler.CSharp/Optimizer/Strategies/Optimizer.cs
@@ -32,9 +32,7 @@ namespace Neo.Optimizer
         static Optimizer()
         {
             var assembly = Assembly.GetExecutingAssembly();
-            foreach (Type type in assembly.GetTypes())
-                RegisterStrategies(type);
-            DiscoverAndOrderStrategies(assembly);
+            RegisterStrategies(assembly.GetTypes());
             foreach (FieldInfo field in typeof(OpCode).GetFields(BindingFlags.Public | BindingFlags.Static))
             {
                 OperandSizeAttribute? attribute = field.GetCustomAttribute<OperandSizeAttribute>();
@@ -45,61 +43,42 @@ namespace Neo.Optimizer
             }
         }
 
-        public static void RegisterStrategies(Type type)
+        public static void RegisterStrategies(Type type) => RegisterStrategies([type]);
+
+        private static void RegisterStrategies(IEnumerable<Type> types)
         {
-            foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            bool registeredAny = false;
+            foreach (Type type in types.OrderBy(type => type.FullName ?? type.Name, StringComparer.Ordinal))
             {
-                StrategyAttribute? attribute = method.GetCustomAttribute<StrategyAttribute>();
-                if (attribute is null) continue;
-
-                // Validate method signature
-                if (method.ReturnType != typeof((NefFile, ContractManifest, JObject?)) ||
-                    method.GetParameters().Length != 3 ||
-                    method.GetParameters()[0].ParameterType != typeof(NefFile) ||
-                    method.GetParameters()[1].ParameterType != typeof(ContractManifest) ||
-                    method.GetParameters()[2].ParameterType != typeof(JObject))
+                foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .OrderBy(method => method.Name, StringComparer.Ordinal)
+                    .ThenBy(method => method.MetadataToken))
                 {
-                    continue; // Skip methods with incorrect signature
+                    StrategyAttribute? attribute = method.GetCustomAttribute<StrategyAttribute>();
+                    if (attribute is null || !HasValidStrategySignature(method))
+                        continue;
+
+                    if (!RegisterStrategyMethod(method, attribute))
+                        continue;
+
+                    string name = string.IsNullOrEmpty(attribute.Name) ? method.Name.ToLowerInvariant() : attribute.Name;
+                    strategies[name] = method.CreateDelegate<Func<NefFile, ContractManifest, JObject, (NefFile nef, ContractManifest manifest, JObject debugInfo)>>();
+                    registeredAny = true;
                 }
-
-                if (!RegisterStrategyMethod(method, attribute))
-                    continue;
-
-                string name = string.IsNullOrEmpty(attribute.Name) ? method.Name.ToLowerInvariant() : attribute.Name;
-                strategies[name] = method.CreateDelegate<Func<NefFile, ContractManifest, JObject, (NefFile nef, ContractManifest manifest, JObject debugInfo)>>();
             }
 
-            // Sort strategies by priority (highest priority first)
-            orderedStrategies.Sort((a, b) => b.attribute.Priority.CompareTo(a.attribute.Priority));
+            if (registeredAny)
+                orderedStrategies.Sort(CompareStrategies);
         }
 
-        private static void DiscoverAndOrderStrategies(Assembly assembly)
+        private static bool HasValidStrategySignature(MethodInfo method)
         {
-            var strategyMethods = new List<(MethodInfo method, StrategyAttribute attribute)>();
-
-            foreach (Type type in assembly.GetTypes())
-            {
-                foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
-                {
-                    var attribute = method.GetCustomAttribute<StrategyAttribute>();
-                    if (attribute != null)
-                    {
-                        // Verify method signature matches expected optimization strategy signature
-                        var parameters = method.GetParameters();
-                        if (parameters.Length == 3 &&
-                            parameters[0].ParameterType == typeof(NefFile) &&
-                            parameters[1].ParameterType == typeof(ContractManifest) &&
-                            parameters[2].ParameterType == typeof(JObject))
-                        {
-                            strategyMethods.Add((method, attribute));
-                        }
-                    }
-                }
-            }
-
-            // Order by priority (higher priority first)
-            foreach (var (method, attribute) in strategyMethods.OrderByDescending(s => s.attribute.Priority))
-                RegisterStrategyMethod(method, attribute);
+            ParameterInfo[] parameters = method.GetParameters();
+            return method.ReturnType == typeof((NefFile, ContractManifest, JObject?)) &&
+                parameters.Length == 3 &&
+                parameters[0].ParameterType == typeof(NefFile) &&
+                parameters[1].ParameterType == typeof(ContractManifest) &&
+                parameters[2].ParameterType == typeof(JObject);
         }
 
         private static bool RegisterStrategyMethod(MethodInfo method, StrategyAttribute attribute)
@@ -114,6 +93,23 @@ namespace Neo.Optimizer
 
         private static (Guid moduleVersionId, int metadataToken) GetStrategyMethodId(MethodInfo method) =>
             (method.Module.ModuleVersionId, method.MetadataToken);
+
+        private static int CompareStrategies(
+            (MethodInfo method, StrategyAttribute attribute) left,
+            (MethodInfo method, StrategyAttribute attribute) right)
+        {
+            int comparison = right.attribute.Priority.CompareTo(left.attribute.Priority);
+            if (comparison != 0) return comparison;
+
+            comparison = StringComparer.Ordinal.Compare(left.method.DeclaringType?.Assembly.FullName, right.method.DeclaringType?.Assembly.FullName);
+            if (comparison != 0) return comparison;
+
+            comparison = StringComparer.Ordinal.Compare(left.method.DeclaringType?.FullName, right.method.DeclaringType?.FullName);
+            if (comparison != 0) return comparison;
+
+            comparison = StringComparer.Ordinal.Compare(left.method.Name, right.method.Name);
+            return comparison != 0 ? comparison : left.method.MetadataToken.CompareTo(right.method.MetadataToken);
+        }
 
         public static (NefFile, ContractManifest, JObject?) Optimize(NefFile nef, ContractManifest manifest, JObject? debugInfo = null, CompilationOptions.OptimizationType optimizationType = CompilationOptions.OptimizationType.All)
         {

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_OptimizerAutomation.cs
@@ -67,6 +67,29 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         [TestMethod]
+        public void Test_StrategyTieBreakersAreDeterministic()
+        {
+            var optimizerType = typeof(OptimizerClass);
+            var field = optimizerType.GetField("orderedStrategies", BindingFlags.NonPublic | BindingFlags.Static);
+            var orderedStrategies = field!.GetValue(null) as List<(MethodInfo method, StrategyAttribute attribute)>;
+            Assert.IsNotNull(orderedStrategies);
+
+            var expected = orderedStrategies!
+                .OrderByDescending(strategy => strategy.attribute.Priority)
+                .ThenBy(strategy => strategy.method.DeclaringType!.Assembly.FullName, StringComparer.Ordinal)
+                .ThenBy(strategy => strategy.method.DeclaringType!.FullName, StringComparer.Ordinal)
+                .ThenBy(strategy => strategy.method.Name, StringComparer.Ordinal)
+                .ThenBy(strategy => strategy.method.MetadataToken)
+                .Select(strategy => $"{strategy.method.DeclaringType!.FullName}.{strategy.method.Name}")
+                .ToArray();
+            var actual = orderedStrategies
+                .Select(strategy => $"{strategy.method.DeclaringType!.FullName}.{strategy.method.Name}")
+                .ToArray();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
         public void Test_RegisteredStrategiesDoNotContainDuplicates()
         {
             var optimizerType = typeof(OptimizerClass);


### PR DESCRIPTION
## Summary

- Discover optimizer strategies in a single batch.
- Apply deterministic ordering for strategies with equal priority.
- Preserve dynamic strategy registration and document the discovery rules.

## Why

The optimizer scanned the assembly twice during initialization. Duplicate registration was suppressed, but the second scan did no useful work, and equal-priority execution depended on reflection order.

## Tests

- Added a regression test for equal-priority ordering.
- Full `Neo.Compiler.CSharp.UnitTests` Release suite (1360 passed).