### PR TITLE
Fix: support stored exception construction

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.cs
@@ -235,6 +235,23 @@ internal partial class MethodConvert
     /// <returns>True if system constructors are successfully processed; otherwise, false.</returns>
     private bool TryProcessSystemConstructors(SemanticModel model, IMethodSymbol symbol, IReadOnlyList<ArgumentSyntax> arguments)
     {
+        if (symbol.ContainingType.DeclaringSyntaxReferences.IsEmpty &&
+            symbol.ContainingType.IsSubclassOf(nameof(Exception), includeThisClass: true))
+        {
+            switch (arguments.Count)
+            {
+                case 0:
+                    Push("exception");
+                    break;
+                case 1:
+                    ConvertExpression(model, arguments[0].Expression);
+                    break;
+                default:
+                    throw new CompilationException(arguments[1], DiagnosticId.MultiplyThrows, "Only a single parameter is supported for exceptions.");
+            }
+            return true;
+        }
+
         if (TryProcessStringConstructor(model, symbol, arguments))
             return true;
 

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Throw.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Throw.cs
@@ -19,5 +19,37 @@ namespace Neo.Compiler.CSharp.TestContracts
         {
             string first = args.Length >= 1 ? args[0] : throw new ArgumentException("Please supply at least one argument.");
         }
+
+        public static void StoreAndThrowException()
+        {
+            Exception exception = new Exception("boom");
+            throw exception;
+        }
+
+        public static string StoreThrowAndCatchException()
+        {
+            try
+            {
+                Exception exception = new Exception("boom");
+                throw exception;
+            }
+            catch (Exception exception)
+            {
+                return "caught:" + exception;
+            }
+        }
+
+        public static string StoreParameterlessExceptionAndCatch()
+        {
+            try
+            {
+                Exception exception = new Exception();
+                throw exception;
+            }
+            catch (Exception exception)
+            {
+                return "caught:" + exception;
+            }
+        }
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Throw.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Throw.cs
@@ -13,16 +13,74 @@ public abstract class Contract_Throw(Neo.SmartContract.Testing.SmartContractInit
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Throw"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testMain"",""parameters"":[{""name"":""args"",""type"":""Array""}],""returntype"":""Void"",""offset"":0,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Throw"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testMain"",""parameters"":[{""name"":""args"",""type"":""Array""}],""returntype"":""Void"",""offset"":0,""safe"":false},{""name"":""storeAndThrowException"",""parameters"":[],""returntype"":""Void"",""offset"":55,""safe"":false},{""name"":""storeThrowAndCatchException"",""parameters"":[],""returntype"":""String"",""offset"":67,""safe"":false},{""name"":""storeParameterlessExceptionAndCatch"",""parameters"":[],""returntype"":""String"",""offset"":99,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.0"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADdXAQF4yhG4Jgd4EM4iKQwkUGxlYXNlIHN1cHBseSBhdCBsZWFzdCBvbmUgYXJndW1lbnQuOnBA2o6Ljg==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIhXAQF4yhG4Jgd4EM4iKQwkUGxlYXNlIHN1cHBseSBhdCBsZWFzdCBvbmUgYXJndW1lbnQuOnBAVwEADARib29tcGg6VwEAOwwADARib29tcGg6cAwHY2F1Z2h0OmiL2yg9AkBXAQA7EQAMCWV4Y2VwdGlvbnBoOnAMB2NhdWdodDpoi9soPQJAzUk5uA==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
     #region Unsafe methods
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEADARib29tcGg6
+    /// INITSLOT 0100 [64 datoshi]
+    /// PUSHDATA1 626F6F6D 'boom' [8 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// </remarks>
+    [DisplayName("storeAndThrowException")]
+    public abstract void StoreAndThrowException();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEAOxEADAlleGNlcHRpb25waDpwDAdjYXVnaHQ6aIvbKD0CQA==
+    /// INITSLOT 0100 [64 datoshi]
+    /// TRY 1100 [4 datoshi]
+    /// PUSHDATA1 657863657074696F6E 'exception' [8 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// PUSHDATA1 6361756768743A 'caught:' [8 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// CAT [2048 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// ENDTRY 02 [4 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("storeParameterlessExceptionAndCatch")]
+    public abstract string? StoreParameterlessExceptionAndCatch();
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEAOwwADARib29tcGg6cAwHY2F1Z2h0OmiL2yg9AkA=
+    /// INITSLOT 0100 [64 datoshi]
+    /// TRY 0C00 [4 datoshi]
+    /// PUSHDATA1 626F6F6D 'boom' [8 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// THROW [512 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// PUSHDATA1 6361756768743A 'caught:' [8 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// CAT [2048 datoshi]
+    /// CONVERT 28 'ByteString' [8192 datoshi]
+    /// ENDTRY 02 [4 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("storeThrowAndCatchException")]
+    public abstract string? StoreThrowAndCatchException();
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Throw.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Throw.cs
@@ -12,6 +12,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.SmartContract.Testing;
 using Neo.SmartContract.Testing.Exceptions;
+using System;
+using System.Linq;
 
 namespace Neo.Compiler.CSharp.UnitTests
 {
@@ -31,6 +33,48 @@ namespace Neo.Compiler.CSharp.UnitTests
         {
             Contract.TestMain(["test"]);
             AssertGasConsumed(1111290);
+        }
+
+        [TestMethod]
+        public void Test_StoredExceptionCanBeThrown()
+        {
+            var exception = Assert.ThrowsException<TestException>(Contract.StoreAndThrowException);
+            StringAssert.Contains(exception.Message, "boom");
+        }
+
+        [TestMethod]
+        public void Test_StoredExceptionCanBeCaught()
+        {
+            Assert.AreEqual("caught:boom", Contract.StoreThrowAndCatchException());
+        }
+
+        [TestMethod]
+        public void Test_StoredParameterlessExceptionCanBeCaught()
+        {
+            Assert.AreEqual("caught:exception", Contract.StoreParameterlessExceptionAndCatch());
+        }
+
+        [TestMethod]
+        public void Test_StoredExceptionWithInnerExceptionReportsDiagnostic()
+        {
+            var context = TestHelper.CompileSingleContract("""
+                using Neo.SmartContract.Framework;
+                using System;
+
+                public class Contract : SmartContract
+                {
+                    public static void Test()
+                    {
+                        Exception exception = new Exception("outer", new Exception("inner"));
+                        throw exception;
+                    }
+                }
+                """);
+
+            var diagnostics = string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString()));
+            Assert.IsFalse(context.Success, diagnostics);
+            Assert.IsTrue(context.Diagnostics.Any(d => d.Id == DiagnosticId.MultiplyThrows), diagnostics);
+            Assert.IsFalse(context.Diagnostics.Any(d => d.Id == DiagnosticId.UnexpectedCompilerError), diagnostics);
         }
     }
 }


### PR DESCRIPTION
## Summary
- emit a VM exception value when an exception instance is created outside a throw expression
- support both parameterless and single-message exception construction
- preserve the existing direct throw lowering
- report the existing diagnostic for unsupported multi-parameter constructors
- add runtime and diagnostic coverage for every constructor path

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --configuration Release --filter "FullyQualifiedName~UnitTest_Throw"` (6 passed)
- collected Cobertura coverage confirming all three constructor branches are exercised
- `dotnet format tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --no-restore --verify-no-changes --include src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.cs tests/Neo.Compiler.CSharp.TestContracts/Contract_Throw.cs tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Throw.cs`