### PR TITLE
Fix: treat ABORT as uncatchable in control-flow analysis

### DIFF
--- a/src/Neo.Compiler.CSharp/ControlFlow/InstructionCoverage.cs
+++ b/src/Neo.Compiler.CSharp/ControlFlow/InstructionCoverage.cs
@@ -61,8 +61,8 @@ namespace Neo.Compiler.ControlFlow
     public enum BranchType
     {
         OK = 1,     // One of the branches may return without exception
-        THROW = 2,  // All branches surely have exceptions, but can be catched
-        ABORT = 3,  // All branches abort, and cannot be catched
+        THROW = 2,  // All branches surely have exceptions, but can be caught
+        ABORT = 3,  // All branches abort, and cannot be caught
         UNCOVERED = 4,
     }
 
@@ -177,17 +177,13 @@ namespace Neo.Compiler.ControlFlow
             return BranchType.THROW;
         }
 
+        /// <summary>
+        /// ABORT and ABORTMSG terminate execution without being caught.
+        /// Exception handlers are still covered conservatively for other faults in the protected region.
+        /// </summary>
         public BranchType HandleAbort(int entranceAddr, int abortFromAddr, Stack<TryState> stack, int analysisDepth = 0)
         {
-            // See if we are in a try or catch. There may still be runtime exceptions
-            (int catchAddr, int finallyAddr, TryType stackType, _) = stack.Peek();
-            if (stackType == TryType.TRY && catchAddr != -1 ||
-                stackType == TryType.CATCH && finallyAddr != -1)
-            {
-                // Visit catchAddr because there may still be exceptions at runtime
-                if (HandleThrow(entranceAddr, abortFromAddr, stack, analysisDepth) == BranchType.OK)
-                    return BranchType.OK;  // No need to set coveredMap[entranceAddr] because it's OK when covered
-            }
+            HandleThrow(entranceAddr, abortFromAddr, stack, analysisDepth);
             return BranchType.ABORT;
         }
 
@@ -271,7 +267,7 @@ namespace Neo.Compiler.ControlFlow
                     instructions.Add(addr, instruction);
                 }
 
-                // ABORT may also THROW in execution; this has been handled in HandleAbort
+                // ABORT and ABORTMSG terminate execution and cannot be caught.
                 if (instruction.OpCode == OpCode.ABORT || instruction.OpCode == OpCode.ABORTMSG)
                     return coveredMap[entranceAddr] = HandleAbort(entranceAddr, addr, tryStack, analysisDepth);
                 if (callWithJump.Contains(instruction.OpCode))

--- a/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/ControlFlowValidationTests.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/Optimizer/ControlFlowValidationTests.cs
@@ -82,6 +82,65 @@ namespace Neo.Compiler.CSharp.UnitTests.Optimizer
             Assert.AreEqual(BranchType.OK, coverage.coveredMap[4]);
         }
 
+        [TestMethod]
+        public void InstructionCoverage_AbortRemainsTerminalInsideTry()
+        {
+            AssertAbortRemainsTerminalInsideTry(OpCode.ABORT);
+        }
+
+        [TestMethod]
+        public void InstructionCoverage_AbortMsgRemainsTerminalInsideTry()
+        {
+            AssertAbortRemainsTerminalInsideTry(OpCode.ABORTMSG);
+        }
+
+        [TestMethod]
+        public void InstructionCoverage_ThrowEntersExceptionHandlers()
+        {
+            var coverage = CreateTryCatchFinallyCoverage(OpCode.THROW);
+
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[0]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[6]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[9]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[11]);
+        }
+
+        private static void AssertAbortRemainsTerminalInsideTry(OpCode abortOpCode)
+        {
+            var coverage = CreateTryCatchFinallyCoverage(abortOpCode);
+
+            Assert.AreEqual(BranchType.ABORT, coverage.coveredMap[0]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[6]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[9]);
+            Assert.AreEqual(BranchType.OK, coverage.coveredMap[11]);
+
+            var (optimizedNef, optimizedManifest, _) = Reachability.RemoveUncoveredInstructions(
+                CreateNefFile(CreateTryCatchFinallyScript(abortOpCode)), CreateManifest());
+            var optimizedCoverage = new InstructionCoverage(optimizedNef, optimizedManifest);
+
+            Assert.AreEqual(BranchType.ABORT, optimizedCoverage.coveredMap[0]);
+        }
+
+        private static InstructionCoverage CreateTryCatchFinallyCoverage(OpCode terminatingOpCode)
+            => new(CreateNefFile(CreateTryCatchFinallyScript(terminatingOpCode)), CreateManifest());
+
+        private static byte[] CreateTryCatchFinallyScript(OpCode terminatingOpCode)
+        {
+            byte[] script =
+            [
+                (byte)OpCode.TRY, 0x06, 0x09,
+                (byte)terminatingOpCode,
+                (byte)OpCode.ENDTRY, 0x07,
+                (byte)OpCode.NOP,
+                (byte)OpCode.ENDTRY, 0x04,
+                (byte)OpCode.NOP,
+                (byte)OpCode.ENDFINALLY,
+                (byte)OpCode.RET
+            ];
+
+            return script;
+        }
+
         private static NefFile CreateNefFile(byte[] script)
         {
             return new NefFile


### PR DESCRIPTION
## Summary
- keep `ABORT` and `ABORTMSG` terminal even inside protected regions
- preserve exception-handler coverage for other possible VM faults and valid `TRY` targets
- keep ordinary `THROW` traversal through catch and finally handlers
- add focused control-flow and optimizer regressions for all three termination paths

## Testing
- `dotnet test tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --configuration Release --filter "FullyQualifiedName~ControlFlowValidationTests|FullyQualifiedName~UnitTest_Abort"` (13 passed)
- `dotnet format tests/Neo.Compiler.CSharp.UnitTests/Neo.Compiler.CSharp.UnitTests.csproj --no-restore --verify-no-changes --include src/Neo.Compiler.CSharp/ControlFlow/InstructionCoverage.cs tests/Neo.Compiler.CSharp.UnitTests/Optimizer/ControlFlowValidationTests.cs`