### PR TITLE
Feature: add the Neo C# contract profile schema

### DIFF
--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,57 @@
+# Neo C# Contract Profiles
+
+This directory contains the machine-readable compatibility contract shared by
+the Neo C# compiler, analyzers, documentation, and tests.
+
+`neo-csharp-profile.schema.json` is a JSON Schema Draft 2020-12 document. It
+defines the shape and minimum evidence for a profile inventory; it does not
+itself claim that any C# capability is currently supported.
+
+## Document shape
+
+A profile document contains:
+
+- `schemaVersion`: the structural version of the profile format;
+- `profileVersion`: the semantic version of the classified contract surface;
+- `devpackVersion`: the matching DevPack release;
+- `capabilities`: an object keyed by stable profile IDs.
+
+Using capability IDs as object keys prevents duplicate IDs in a valid JSON
+object. IDs are independent of diagnostic IDs so that supported capabilities
+and capabilities without diagnostics still have stable identities.
+
+## Support states
+
+The schema recognizes four states:
+
+- `supported` requires analyzer-positive, compiler, and runtime evidence;
+- `unsupported` requires an error diagnostic plus analyzer-negative and
+  compiler evidence;
+- `partially-supported` requires explicit allowed and excluded contexts,
+  positive and negative analysis, compiler evidence, and runtime evidence;
+- `supported-with-different-semantics` requires implementation, a documented
+  semantic difference, and analyzer-positive, compiler, runtime, and
+  differential evidence.
+
+All capabilities also identify an exact matching surface through syntax kinds,
+operation kinds, metadata names, member signatures, ABI elements, or compiler
+invariants.
+
+## Validation
+
+The schema tests use a fixture that exercises every support state, mutate it to
+verify that missing evidence, invalid IDs, unsafe severities, unknown states,
+and undeclared properties are rejected, and exercise valid and invalid SemVer
+2.0 versions directly.
+
+Run them with:
+
+```shell
+cd tests/Neo.SmartContract.Analyzer.UnitTests
+dotnet test Neo.SmartContract.Analyzer.UnitTests.csproj \
+  --filter "FullyQualifiedName~ContractProfileSchemaTests"
+```
+
+The complete capability inventory will be added separately after existing
+compiler, analyzer, syntax-probe, and semantic-difference sources are
+reconciled.

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -52,6 +52,37 @@ dotnet test Neo.SmartContract.Analyzer.UnitTests.csproj \
   --filter "FullyQualifiedName~ContractProfileSchemaTests"
 ```
 
+## Updating the schema
+
+Treat the schema, its complete fixture, and its tests as one versioned
+contract. A schema change should follow this process:
+
+1. Update `neo-csharp-profile.schema.json` from the latest `master-n3`.
+2. Keep `schemaVersion` unchanged for descriptions, examples, and test-only
+   changes that do not change which profile documents are accepted. Increment
+   it when the accepted document shape or the meaning of a field changes,
+   including new or removed properties, enum values, evidence kinds, or
+   state-specific requirements.
+3. Update `ContractProfile.valid.json` so the complete fixture exercises every
+   new field, state, or evidence rule.
+4. Add both a valid case and a focused invalid mutation to
+   `ContractProfileSchemaTests` for every new rule. A rule that can only be
+   demonstrated by an invalid document still needs a valid fixture path that
+   reaches it.
+5. Preserve strict validation unless the format intentionally changes. In
+   particular, do not weaken `additionalProperties`, stable capability ID
+   syntax, semantic-version validation, or the evidence required by each
+   support state.
+6. Run the focused schema tests above and describe the compatibility impact in
+   the pull request. If `schemaVersion` changes, include migration guidance for
+   existing profile documents and consumers.
+
+`profileVersion` and `devpackVersion` belong to profile documents, not to the
+schema definition. A schema-only clarification does not change them. A future
+capability inventory change should keep existing capability IDs stable, update
+the relevant evidence references, and advance `profileVersion` when the
+classified contract surface changes.
+
 The complete capability inventory will be added separately after existing
 compiler, analyzer, syntax-probe, and semantic-difference sources are
 reconciled.

--- a/profiles/neo-csharp-profile.schema.json
+++ b/profiles/neo-csharp-profile.schema.json
@@ -1,0 +1,511 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/neo-project/neo-devpack-dotnet/master-n3/profiles/neo-csharp-profile.schema.json",
+  "title": "Neo C# Contract Compatibility Profile",
+  "description": "Machine-readable compatibility contract shared by the Neo C# compiler, analyzers, documentation, and tests.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "profileVersion",
+    "devpackVersion",
+    "capabilities"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "profileVersion": {
+      "$ref": "#/$defs/semanticVersion"
+    },
+    "devpackVersion": {
+      "$ref": "#/$defs/semanticVersion"
+    },
+    "capabilities": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[.-][a-z0-9][a-z0-9-]*)*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/capability"
+      }
+    }
+  },
+  "$defs": {
+    "semanticVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "nonEmptyUniqueStrings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "match": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "syntaxKinds": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "operationKinds": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "metadataNames": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "memberSignatures": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "abiElements": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "compilerInvariants": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        }
+      }
+    },
+    "contexts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed",
+        "excluded"
+      ],
+      "properties": {
+        "allowed": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "excluded": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "severity",
+        "guidance",
+        "helpLink"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^NC[0-9]{4}$"
+        },
+        "severity": {
+          "enum": [
+            "Error",
+            "Warning",
+            "Info"
+          ]
+        },
+        "guidance": {
+          "type": "string",
+          "minLength": 1
+        },
+        "helpLink": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "semanticDifference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "summary",
+        "rationale",
+        "documentation"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "documentation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "reference"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "analyzer-positive",
+            "analyzer-negative",
+            "compiler",
+            "runtime",
+            "differential",
+            "boundary",
+            "fuzz",
+            "package-consumer",
+            "documentation"
+          ]
+        },
+        "reference": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "state",
+        "summary",
+        "match",
+        "since",
+        "evidence"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "syntax",
+            "type",
+            "api",
+            "abi",
+            "semantic-difference",
+            "security",
+            "resource-usage",
+            "compiler-invariant"
+          ]
+        },
+        "state": {
+          "enum": [
+            "supported",
+            "unsupported",
+            "partially-supported",
+            "supported-with-different-semantics"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "contexts": {
+          "$ref": "#/$defs/contexts"
+        },
+        "implementation": {
+          "$ref": "#/$defs/nonEmptyUniqueStrings"
+        },
+        "diagnostic": {
+          "$ref": "#/$defs/diagnostic"
+        },
+        "semanticDifference": {
+          "$ref": "#/$defs/semanticDifference"
+        },
+        "since": {
+          "$ref": "#/$defs/semanticVersion"
+        },
+        "until": {
+          "$ref": "#/$defs/semanticVersion"
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "supported"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "required": [
+              "implementation"
+            ],
+            "properties": {
+              "evidence": {
+                "allOf": [
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "analyzer-positive"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "compiler"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "runtime"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "unsupported"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "required": [
+              "diagnostic"
+            ],
+            "properties": {
+              "diagnostic": {
+                "properties": {
+                  "severity": {
+                    "const": "Error"
+                  }
+                }
+              },
+              "evidence": {
+                "allOf": [
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "analyzer-negative"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "compiler"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "partially-supported"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "required": [
+              "contexts",
+              "implementation",
+              "diagnostic"
+            ],
+            "properties": {
+              "diagnostic": {
+                "properties": {
+                  "severity": {
+                    "const": "Error"
+                  }
+                }
+              },
+              "evidence": {
+                "allOf": [
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "analyzer-positive"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "analyzer-negative"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "compiler"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "runtime"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "supported-with-different-semantics"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "required": [
+              "implementation",
+              "semanticDifference"
+            ],
+            "properties": {
+              "evidence": {
+                "allOf": [
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "analyzer-positive"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "compiler"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "runtime"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "kind": {
+                          "const": "differential"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/ContractProfileSchemaTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/ContractProfileSchemaTests.cs
@@ -1,0 +1,197 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ContractProfileSchemaTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Neo.SmartContract.Analyzer.UnitTests
+{
+    [TestClass]
+    public class ContractProfileSchemaTests
+    {
+        private static readonly string RepositoryRoot = FindRepositoryRoot();
+        private static readonly JsonSchema ProfileSchema = LoadSchema();
+        private static readonly string ValidProfile = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "tests",
+            "Neo.SmartContract.Analyzer.UnitTests",
+            "Fixtures",
+            "ContractProfile.valid.json"));
+
+        public static IEnumerable<object[]> InvalidProfileMutations()
+        {
+            yield return ["unknown support state"];
+            yield return ["invalid capability id"];
+            yield return ["undeclared capability property"];
+            yield return ["unsupported capability without diagnostic"];
+            yield return ["unsupported capability with warning severity"];
+            yield return ["supported capability without runtime evidence"];
+            yield return ["partial capability without excluded contexts"];
+            yield return ["semantic difference without differential evidence"];
+        }
+
+        public static IEnumerable<object[]> ValidSemanticVersions()
+        {
+            yield return ["0.0.0"];
+            yield return ["1.2.3"];
+            yield return ["1.0.0-0.3.7"];
+            yield return ["1.0.0-alpha.1"];
+            yield return ["1.0.0-01a"];
+            yield return ["1.0.0-x.7.z.92"];
+            yield return ["1.0.0+001"];
+            yield return ["1.0.0-alpha.1+build.001"];
+        }
+
+        public static IEnumerable<object[]> InvalidSemanticVersions()
+        {
+            yield return ["01.0.0"];
+            yield return ["1.01.0"];
+            yield return ["1.0.01"];
+            yield return ["1.0.0-01"];
+            yield return ["1.0.0-alpha.01"];
+            yield return ["1.0.0-"];
+            yield return ["1.0.0-.alpha"];
+            yield return ["1.0.0-alpha..1"];
+            yield return ["1.0.0-alpha."];
+            yield return ["1.0.0+"];
+            yield return ["1.0.0+.build"];
+            yield return ["1.0.0+build..1"];
+            yield return ["1.0.0+build."];
+        }
+
+        [TestMethod]
+        public void CompleteProfileFixture_ShouldSatisfySchema()
+        {
+            var result = Evaluate(JsonNode.Parse(ValidProfile)!);
+
+            Assert.IsTrue(result.IsValid, FormatResult(result));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(InvalidProfileMutations), DynamicDataSourceType.Method)]
+        public void IncompleteOrUnknownProfileData_ShouldFailSchema(string mutation)
+        {
+            var profile = JsonNode.Parse(ValidProfile)!.AsObject();
+            ApplyMutation(profile, mutation);
+
+            var result = Evaluate(profile);
+
+            Assert.IsFalse(result.IsValid, $"Mutation '{mutation}' unexpectedly satisfied the schema.");
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(ValidSemanticVersions), DynamicDataSourceType.Method)]
+        public void ValidSemanticVersion_ShouldSatisfySchema(string semanticVersion)
+        {
+            var profile = JsonNode.Parse(ValidProfile)!.AsObject();
+            profile["profileVersion"] = semanticVersion;
+
+            var result = Evaluate(profile);
+
+            Assert.IsTrue(result.IsValid, $"Semantic version '{semanticVersion}' was rejected.\n{FormatResult(result)}");
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(InvalidSemanticVersions), DynamicDataSourceType.Method)]
+        public void InvalidSemanticVersion_ShouldFailSchema(string semanticVersion)
+        {
+            var profile = JsonNode.Parse(ValidProfile)!.AsObject();
+            profile["profileVersion"] = semanticVersion;
+
+            var result = Evaluate(profile);
+
+            Assert.IsFalse(result.IsValid, $"Semantic version '{semanticVersion}' unexpectedly satisfied the schema.");
+        }
+
+        private static void ApplyMutation(JsonObject profile, string mutation)
+        {
+            var capabilities = profile["capabilities"]!.AsObject();
+            switch (mutation)
+            {
+                case "unknown support state":
+                    capabilities["type.system-single"]!["state"] = "unknown";
+                    break;
+                case "invalid capability id":
+                    capabilities["Invalid capability id"] = capabilities["type.system-single"]!.DeepClone();
+                    break;
+                case "undeclared capability property":
+                    capabilities["type.system-single"]!["unexpected"] = true;
+                    break;
+                case "unsupported capability without diagnostic":
+                    capabilities["type.system-single"]!.AsObject().Remove("diagnostic");
+                    break;
+                case "unsupported capability with warning severity":
+                    capabilities["type.system-single"]!["diagnostic"]!["severity"] = "Warning";
+                    break;
+                case "supported capability without runtime evidence":
+                    RemoveEvidence(capabilities["syntax.expression-bodied-member"]!, "runtime");
+                    break;
+                case "partial capability without excluded contexts":
+                    capabilities["syntax.range-byte-string"]!["contexts"]!.AsObject().Remove("excluded");
+                    break;
+                case "semantic difference without differential evidence":
+                    RemoveEvidence(capabilities["semantic.bool-try-parse"]!, "differential");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mutation), mutation, "Unknown profile mutation.");
+            }
+        }
+
+        private static void RemoveEvidence(JsonNode capability, string kind)
+        {
+            var evidence = capability["evidence"]!.AsArray();
+            for (var index = evidence.Count - 1; index >= 0; index--)
+            {
+                if (evidence[index]?["kind"]?.GetValue<string>() == kind)
+                {
+                    evidence.RemoveAt(index);
+                }
+            }
+        }
+
+        private static EvaluationResults Evaluate(JsonNode profile)
+        {
+            using var document = JsonDocument.Parse(profile.ToJsonString());
+            return ProfileSchema.Evaluate(
+                document.RootElement,
+                new EvaluationOptions { OutputFormat = OutputFormat.Hierarchical });
+        }
+
+        private static JsonSchema LoadSchema()
+        {
+            var schemaPath = Path.Combine(RepositoryRoot, "profiles", "neo-csharp-profile.schema.json");
+            using var document = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            return JsonSchema.Build(document.RootElement.Clone());
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory is not null)
+            {
+                var schemaPath = Path.Combine(directory.FullName, "profiles", "neo-csharp-profile.schema.json");
+                if (File.Exists(schemaPath)) return directory.FullName;
+
+                directory = directory.Parent;
+            }
+
+            throw new DirectoryNotFoundException("Unable to locate the Neo C# contract profile schema.");
+        }
+
+        private static string FormatResult(EvaluationResults result) =>
+            JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/Fixtures/ContractProfile.valid.json
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/Fixtures/ContractProfile.valid.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "../../../profiles/neo-csharp-profile.schema.json",
+  "schemaVersion": 1,
+  "profileVersion": "3.10.0",
+  "devpackVersion": "3.10.0",
+  "capabilities": {
+    "syntax.expression-bodied-member": {
+      "kind": "syntax",
+      "state": "supported",
+      "summary": "Expression-bodied members preserve their documented C# behavior.",
+      "match": {
+        "syntaxKinds": [
+          "ArrowExpressionClause"
+        ]
+      },
+      "implementation": [
+        "src/Neo.Compiler.CSharp/MethodConvert"
+      ],
+      "since": "3.10.0",
+      "evidence": [
+        {
+          "kind": "analyzer-positive",
+          "reference": "docs/csharp-syntax/csharp-6.md#expression_bodied_members"
+        },
+        {
+          "kind": "compiler",
+          "reference": "Neo.Compiler.CSharp.UnitTests.Syntax.SyntaxTests"
+        },
+        {
+          "kind": "runtime",
+          "reference": "Neo.Compiler.CSharp.UnitTests"
+        }
+      ]
+    },
+    "type.system-single": {
+      "kind": "type",
+      "state": "unsupported",
+      "summary": "Neo contracts do not support System.Single values.",
+      "match": {
+        "metadataNames": [
+          "System.Single"
+        ]
+      },
+      "diagnostic": {
+        "id": "NC4002",
+        "severity": "Error",
+        "guidance": "Use integer or BigInteger fixed-point arithmetic with an explicit scale.",
+        "helpLink": "docs/diagnostics/NC4002.md"
+      },
+      "since": "3.9.1",
+      "evidence": [
+        {
+          "kind": "analyzer-negative",
+          "reference": "FloatUsageAnalyzerUnitTest"
+        },
+        {
+          "kind": "compiler",
+          "reference": "DiagnosticId.FloatingPointNumber"
+        }
+      ]
+    },
+    "syntax.range-byte-string": {
+      "kind": "syntax",
+      "state": "partially-supported",
+      "summary": "Range expressions are supported only for documented byte-string receivers.",
+      "match": {
+        "syntaxKinds": [
+          "RangeExpression"
+        ]
+      },
+      "contexts": {
+        "allowed": [
+          "receiver is byte[] or string"
+        ],
+        "excluded": [
+          "all other receiver types"
+        ]
+      },
+      "implementation": [
+        "MethodConvert.Expression.RangeExpression"
+      ],
+      "diagnostic": {
+        "id": "NC2010",
+        "severity": "Error",
+        "guidance": "Use ranges only with a supported byte-string receiver.",
+        "helpLink": "docs/diagnostics/NC2010.md"
+      },
+      "since": "3.10.0",
+      "evidence": [
+        {
+          "kind": "analyzer-positive",
+          "reference": "range_receiver_positive"
+        },
+        {
+          "kind": "analyzer-negative",
+          "reference": "range_receiver_negative"
+        },
+        {
+          "kind": "compiler",
+          "reference": "DiagnosticId.ArrayRange"
+        },
+        {
+          "kind": "runtime",
+          "reference": "UnitTest_Range"
+        }
+      ]
+    },
+    "semantic.bool-try-parse": {
+      "kind": "semantic-difference",
+      "state": "supported-with-different-semantics",
+      "summary": "bool.TryParse accepts additional Neo contract literals.",
+      "match": {
+        "memberSignatures": [
+          "System.Boolean.TryParse(System.String,System.Boolean@)"
+        ]
+      },
+      "implementation": [
+        "MethodConvert.System.SystemCall.Boolean"
+      ],
+      "semanticDifference": {
+        "summary": "Neo accepts additional true and false literals.",
+        "rationale": "The behavior is retained for contract compatibility.",
+        "documentation": "docs/csharp-syntax/SemanticDifferences.md#booltryparse"
+      },
+      "since": "3.10.0",
+      "evidence": [
+        {
+          "kind": "analyzer-positive",
+          "reference": "bool_try_parse_analyzer"
+        },
+        {
+          "kind": "compiler",
+          "reference": "SystemCall.Boolean"
+        },
+        {
+          "kind": "runtime",
+          "reference": "UnitTest_Boolean.TryParse"
+        },
+        {
+          "kind": "differential",
+          "reference": "UnitTest_Boolean.TryParseSemanticDifference"
+        }
+      ]
+    }
+  }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/Neo.SmartContract.Analyzer.UnitTests.csproj
@@ -8,6 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="JsonSchema.Net" Version="9.2.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary

- add a Draft 2020-12 schema for the Neo C# contract profile
- require state-specific diagnostics, implementation references, and evidence
- enforce SemVer 2.0 syntax for profile versions
- add a complete fixture and valid and invalid schema test matrices

## Motivation

Compiler support, analyzer enforcement, tests, and documentation currently have no shared compatibility contract. This schema defines stable capability IDs, support states, matching surfaces, diagnostics, semantic differences, and the evidence required before a capability enters the profile.

This pull request defines and validates the format only. It does not claim that the current C# capability inventory is complete.

## Validation

- 30 focused schema tests
- valid and invalid SemVer matrices, including prerelease and build metadata edge cases
- schema and fixture JSON parsing
- 230 analyzer tests with the seven audited fixes combined
- combined Release solution build
- combined full solution test run: 2,117 passed
- focused format and diff checks

Part of #1841.
