### PR TITLE
Fix: avoid NC4017 for user-defined Cast methods

### DIFF
--- a/src/Neo.SmartContract.Analyzer/BanCastMethodAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/BanCastMethodAnalyzer.cs
@@ -47,12 +47,23 @@ namespace Neo.SmartContract.Analyzer
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var invocationExpr = (InvocationExpressionSyntax)context.Node;
-            if (invocationExpr.Expression is MemberAccessExpressionSyntax memberAccessExpr &&
-                memberAccessExpr.Name.Identifier.ValueText == "Cast" &&
-                memberAccessExpr.Expression != null)
+            if (invocationExpr.Expression is not MemberAccessExpressionSyntax memberAccessExpr)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, memberAccessExpr.Name.GetLocation()));
+                return;
             }
+
+            var method = context.SemanticModel.GetSymbolInfo(invocationExpr, context.CancellationToken).Symbol as IMethodSymbol;
+            method = method?.ReducedFrom ?? method;
+
+            var enumerableType = context.Compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+            if (method?.Name != "Cast" ||
+                enumerableType is null ||
+                !SymbolEqualityComparer.Default.Equals(method.ContainingType, enumerableType))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, memberAccessExpr.Name.GetLocation()));
         }
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/BanCastMethodAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/BanCastMethodAnalyzerUnitTests.cs
@@ -45,5 +45,26 @@ namespace Neo.SmartContract.Analyzer.Test
 
             await VerifyCS.VerifyAnalyzerAsync(test, expectedDiagnostic);
         }
+
+        [TestMethod]
+        public async Task UserDefinedCastMethod_ShouldNotReportDiagnostic()
+        {
+            var test = """
+                       namespace TestNamespace
+                       {
+                           public static class Converter
+                           {
+                               public static int Cast(int value) => value;
+                           }
+
+                           public class TestClass
+                           {
+                               public int TestMethod() => Converter.Cast(42);
+                           }
+                       }
+                       """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- resolve invocation symbols before reporting `NC4017`
- limit the diagnostic to `System.Linq.Enumerable.Cast<T>`
- allow unrelated user-defined methods named `Cast`

## Rationale

The analyzer previously matched only the method name text, so valid contract methods such as `Converter.Cast(42)` were rejected even though the compiler supports them. Exact symbol matching keeps the intended LINQ restriction without blocking unrelated APIs.

## Validation

- controlled false-positive reproduction
- `BanCastMethodAnalyzerUnitTests`: 2 passed
- all analyzer unit tests: 180 passed
- real analyzer-enabled contract build: 0 warnings and 0 errors
- real `nccs` compilation produced NEF and manifest files
- `dotnet build neo-devpack-dotnet.sln -c Release`
- focused `dotnet format --verify-no-changes`
