### PR TITLE
Fix: resolve NC4023 field types semantically

### DIFF
--- a/src/Neo.SmartContract.Analyzer/KnownFrameworkTypes.cs
+++ b/src/Neo.SmartContract.Analyzer/KnownFrameworkTypes.cs
@@ -1,0 +1,47 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// KnownFrameworkTypes.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.CodeAnalysis;
+using System.Linq;
+
+namespace Neo.SmartContract.Analyzer
+{
+    internal sealed class KnownFrameworkTypes
+    {
+        private const string FrameworkAssemblyName = "Neo.SmartContract.Framework";
+
+        private KnownFrameworkTypes(IAssemblySymbol frameworkAssembly)
+        {
+            UInt160 = GetTypeByMetadataName(frameworkAssembly, "UInt160");
+            UInt256 = GetTypeByMetadataName(frameworkAssembly, "UInt256");
+            ECPoint = GetTypeByMetadataName(frameworkAssembly, "ECPoint");
+        }
+
+        public INamedTypeSymbol? UInt160 { get; }
+
+        public INamedTypeSymbol? UInt256 { get; }
+
+        public INamedTypeSymbol? ECPoint { get; }
+
+        public static KnownFrameworkTypes? Create(Compilation compilation)
+        {
+            var frameworkAssembly = compilation.SourceModule.ReferencedAssemblySymbols
+                .FirstOrDefault(static assembly => assembly.Identity.Name == FrameworkAssemblyName);
+
+            return frameworkAssembly is null ? null : new KnownFrameworkTypes(frameworkAssembly);
+        }
+
+        private static INamedTypeSymbol? GetTypeByMetadataName(IAssemblySymbol frameworkAssembly, string typeName)
+        {
+            return frameworkAssembly.GetTypeByMetadataName($"{FrameworkAssemblyName}.{typeName}");
+        }
+    }
+}

--- a/src/Neo.SmartContract.Analyzer/StaticFieldInitializationAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StaticFieldInitializationAnalyzer.cs
@@ -24,6 +24,10 @@ namespace Neo.SmartContract.Analyzer
     {
         public const string DiagnosticId = "NC4023";
         private const string Category = "Usage";
+        private const string FrameworkAssemblyName = "Neo.SmartContract.Framework";
+        private const string UInt160MetadataName = FrameworkAssemblyName + ".UInt160";
+        private const string UInt256MetadataName = FrameworkAssemblyName + ".UInt256";
+        private const string ECPointMetadataName = FrameworkAssemblyName + ".ECPoint";
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId,
@@ -39,19 +43,50 @@ namespace Neo.SmartContract.Analyzer
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.FieldDeclaration);
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                var frameworkAssembly = compilationContext.Compilation.SourceModule.ReferencedAssemblySymbols
+                    .FirstOrDefault(static assembly => assembly.Identity.Name == FrameworkAssemblyName);
+                if (frameworkAssembly is null)
+                    return;
+
+                var uint160Type = frameworkAssembly.GetTypeByMetadataName(UInt160MetadataName);
+                var uint256Type = frameworkAssembly.GetTypeByMetadataName(UInt256MetadataName);
+                var ecPointType = frameworkAssembly.GetTypeByMetadataName(ECPointMetadataName);
+
+                compilationContext.RegisterSyntaxNodeAction(
+                    nodeContext => AnalyzeNode(nodeContext, uint160Type, uint256Type, ecPointType),
+                    SyntaxKind.FieldDeclaration);
+            });
         }
 
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private void AnalyzeNode(
+            SyntaxNodeAnalysisContext context,
+            INamedTypeSymbol? uint160Type,
+            INamedTypeSymbol? uint256Type,
+            INamedTypeSymbol? ecPointType)
         {
             var fieldDeclaration = (FieldDeclarationSyntax)context.Node;
 
             if (!fieldDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
                 return;
 
+            var variableType = context.SemanticModel.GetTypeInfo(
+                fieldDeclaration.Declaration.Type,
+                context.CancellationToken).Type as INamedTypeSymbol;
+            if (variableType is null)
+            {
+                return;
+            }
+
+            var isUInt160 = SymbolEqualityComparer.Default.Equals(variableType, uint160Type);
+            var isUInt256 = SymbolEqualityComparer.Default.Equals(variableType, uint256Type);
+            var isECPoint = SymbolEqualityComparer.Default.Equals(variableType, ecPointType);
+            if (!isUInt160 && !isUInt256 && !isECPoint)
+                return;
+
             foreach (var variable in fieldDeclaration.Declaration.Variables)
             {
-                var variableTypeName = fieldDeclaration.Declaration.Type.ToString();
                 var initializer = variable.Initializer;
 
                 if (initializer == null)
@@ -63,7 +98,7 @@ namespace Neo.SmartContract.Analyzer
 
                 var literalValue = literalExpression.Token.ValueText;
 
-                if (variableTypeName == "UInt256")
+                if (isUInt256)
                 {
                     if (!IsValidUInt256(literalValue))
                     {
@@ -71,7 +106,7 @@ namespace Neo.SmartContract.Analyzer
                         context.ReportDiagnostic(diagnostic);
                     }
                 }
-                else if (variableTypeName == "UInt160")
+                else if (isUInt160)
                 {
                     if (!IsValidUInt160(literalValue))
                     {
@@ -79,7 +114,7 @@ namespace Neo.SmartContract.Analyzer
                         context.ReportDiagnostic(diagnostic);
                     }
                 }
-                else if (variableTypeName == "ECPoint")
+                else if (isECPoint)
                 {
                     if (!IsValidECPoint(literalValue))
                     {

--- a/src/Neo.SmartContract.Analyzer/StaticFieldInitializationAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StaticFieldInitializationAnalyzer.cs
@@ -24,10 +24,6 @@ namespace Neo.SmartContract.Analyzer
     {
         public const string DiagnosticId = "NC4023";
         private const string Category = "Usage";
-        private const string FrameworkAssemblyName = "Neo.SmartContract.Framework";
-        private const string UInt160MetadataName = FrameworkAssemblyName + ".UInt160";
-        private const string UInt256MetadataName = FrameworkAssemblyName + ".UInt256";
-        private const string ECPointMetadataName = FrameworkAssemblyName + ".ECPoint";
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId,
@@ -45,26 +41,19 @@ namespace Neo.SmartContract.Analyzer
             context.EnableConcurrentExecution();
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var frameworkAssembly = compilationContext.Compilation.SourceModule.ReferencedAssemblySymbols
-                    .FirstOrDefault(static assembly => assembly.Identity.Name == FrameworkAssemblyName);
-                if (frameworkAssembly is null)
+                var knownTypes = KnownFrameworkTypes.Create(compilationContext.Compilation);
+                if (knownTypes is null)
                     return;
 
-                var uint160Type = frameworkAssembly.GetTypeByMetadataName(UInt160MetadataName);
-                var uint256Type = frameworkAssembly.GetTypeByMetadataName(UInt256MetadataName);
-                var ecPointType = frameworkAssembly.GetTypeByMetadataName(ECPointMetadataName);
-
                 compilationContext.RegisterSyntaxNodeAction(
-                    nodeContext => AnalyzeNode(nodeContext, uint160Type, uint256Type, ecPointType),
+                    nodeContext => AnalyzeNode(nodeContext, knownTypes),
                     SyntaxKind.FieldDeclaration);
             });
         }
 
         private void AnalyzeNode(
             SyntaxNodeAnalysisContext context,
-            INamedTypeSymbol? uint160Type,
-            INamedTypeSymbol? uint256Type,
-            INamedTypeSymbol? ecPointType)
+            KnownFrameworkTypes knownTypes)
         {
             var fieldDeclaration = (FieldDeclarationSyntax)context.Node;
 
@@ -79,9 +68,9 @@ namespace Neo.SmartContract.Analyzer
                 return;
             }
 
-            var isUInt160 = SymbolEqualityComparer.Default.Equals(variableType, uint160Type);
-            var isUInt256 = SymbolEqualityComparer.Default.Equals(variableType, uint256Type);
-            var isECPoint = SymbolEqualityComparer.Default.Equals(variableType, ecPointType);
+            var isUInt160 = SymbolEqualityComparer.Default.Equals(variableType, knownTypes.UInt160);
+            var isUInt256 = SymbolEqualityComparer.Default.Equals(variableType, knownTypes.UInt256);
+            var isECPoint = SymbolEqualityComparer.Default.Equals(variableType, knownTypes.ECPoint);
             if (!isUInt160 && !isUInt256 && !isECPoint)
                 return;
 

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StaticFieldInitializationAnalyzerTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StaticFieldInitializationAnalyzerTests.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<Neo.SmartContract.Analyzer.StaticFieldInitializationAnalyzer>;
 
@@ -18,132 +20,229 @@ namespace Neo.SmartContract.Analyzer.UnitTests
     [TestClass]
     public class StaticFieldInitializationAnalyzerUnitTest
     {
+        private const string FrameworkProjectName = "Neo.SmartContract.Framework";
+
+        private const string FrameworkTypes = """
+            namespace Neo.SmartContract.Framework
+            {
+                public abstract class UInt160
+                {
+                    public static extern implicit operator UInt160(string value);
+                }
+
+                public abstract class UInt256
+                {
+                    public static extern implicit operator UInt256(string value);
+                }
+
+                public abstract class ECPoint
+                {
+                    public static extern implicit operator ECPoint(string value);
+                }
+            }
+            """;
+
         [TestMethod]
         public async Task ValidUInt256Initialization_NoDiagnostic()
         {
-            const string code = """
-                                 public abstract class UInt256
-                                 {
-                                     public static extern implicit operator UInt256(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly UInt256 validUInt256 = "edcf8679104ec2911a4fe29ad7db232a493e5b990fb1da7af0c7b989948c8925";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode(
+                "UInt256",
+                "validUInt256 = \"edcf8679104ec2911a4fe29ad7db232a493e5b990fb1da7af0c7b989948c8925\"");
 
-            await Verifier.VerifyAnalyzerAsync(code);
+            await VerifyAnalyzerAsync(code);
         }
 
         [TestMethod]
         public async Task InvalidUInt256Initialization_ReportsDiagnostic()
         {
-            const string code = """
-                                 public abstract class UInt256
-                                 {
-                                     public static extern implicit operator UInt256(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly UInt256 invalidUInt256 = "invalid";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode("UInt256", """{|#0:invalidUInt256 = "invalid"|}""");
 
             var expectedDiagnostic = Verifier.Diagnostic("NC4023")
-                .WithSpan(7, 37, 7, 63).WithArguments("UInt256 must be initialized with a 64-character hex string.");
+                .WithLocation(0).WithArguments("UInt256 must be initialized with a 64-character hex string.");
 
-            await Verifier.VerifyAnalyzerAsync(code, expectedDiagnostic);
+            await VerifyAnalyzerAsync(code, expectedDiagnostic);
         }
 
         [TestMethod]
         public async Task ValidUInt160HexInitialization_NoDiagnostic()
         {
-            const string code = """
-                                 public abstract class UInt160
-                                 {
-                                     public static extern implicit operator UInt160(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly UInt160 validUInt160 = "1a4fe29ad7db232a493e5b990fb1da7af0c7b989";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode(
+                "UInt160",
+                "validUInt160 = \"1a4fe29ad7db232a493e5b990fb1da7af0c7b989\"");
 
-            await Verifier.VerifyAnalyzerAsync(code);
+            await VerifyAnalyzerAsync(code);
         }
 
         [TestMethod]
         public async Task ValidUInt160AddressInitialization_NoDiagnostic()
         {
-            const string code = """
-                                 public abstract class UInt160
-                                 {
-                                     public static extern implicit operator UInt160(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly UInt160 validUInt160 = "NXV7ZhHiyM1aHXwpVsRZC6BwNFP2jghXAq";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode(
+                "UInt160",
+                "validUInt160 = \"NXV7ZhHiyM1aHXwpVsRZC6BwNFP2jghXAq\"");
 
-            await Verifier.VerifyAnalyzerAsync(code);
+            await VerifyAnalyzerAsync(code);
         }
 
         [TestMethod]
         public async Task InvalidUInt160Initialization_ReportsDiagnostic()
         {
-            const string code = """
-                                 public abstract class UInt160
-                                 {
-                                     public static extern implicit operator UInt160(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly UInt160 invalidUInt160 = "invalid";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode("UInt160", """{|#0:invalidUInt160 = "invalid"|}""");
 
             var expectedDiagnostic = Verifier.Diagnostic("NC4023")
-                .WithSpan(7, 37, 7, 63).WithArguments("UInt160 must be initialized with a 40-character hex string or a 34-character string starting with 'N'.");
+                .WithLocation(0).WithArguments("UInt160 must be initialized with a 40-character hex string or a 34-character string starting with 'N'.");
 
-            await Verifier.VerifyAnalyzerAsync(code, expectedDiagnostic);
+            await VerifyAnalyzerAsync(code, expectedDiagnostic);
         }
 
         [TestMethod]
         public async Task ValidECPointInitialization_NoDiagnostic()
         {
-            const string code = """
-                                 public abstract class ECPoint
-                                 {
-                                     public static extern implicit operator ECPoint(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly ECPoint validECPoint = "024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode(
+                "ECPoint",
+                "validECPoint = \"024700db2e90d9f02c4f9fc862abaca92725f95b4fddcc8d7ffa538693ecf463a9\"");
 
-            await Verifier.VerifyAnalyzerAsync(code);
+            await VerifyAnalyzerAsync(code);
         }
 
         [TestMethod]
         public async Task InvalidECPointInitialization_ReportsDiagnostic()
         {
-            const string code = """
-                                 public abstract class ECPoint
-                                 {
-                                     public static extern implicit operator ECPoint(string value);
-                                 }
-                                 public class Test
-                                 {
-                                     private static readonly ECPoint invalidECPoint = "invalid";
-                                 }
-                                 """;
+            var code = CreateFrameworkTypeCode("ECPoint", """{|#0:invalidECPoint = "invalid"|}""");
 
             var expectedDiagnostic = Verifier.Diagnostic("NC4023")
-                .WithSpan(7, 37, 7, 63).WithArguments("ECPoint must be initialized with a 66-character hex string.");
+                .WithLocation(0).WithArguments("ECPoint must be initialized with a 66-character hex string.");
 
-            await Verifier.VerifyAnalyzerAsync(code, expectedDiagnostic);
+            await VerifyAnalyzerAsync(code, expectedDiagnostic);
+        }
+
+        [TestMethod]
+        public async Task InvalidFullyQualifiedUInt160Initialization_ReportsDiagnostic()
+        {
+            const string code = """
+                                public class Test
+                                {
+                                    private static readonly Neo.SmartContract.Framework.UInt160 {|#0:invalidUInt160 = "invalid"|};
+                                }
+                                """;
+
+            var expectedDiagnostic = Verifier.Diagnostic(StaticFieldInitializationAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("UInt160 must be initialized with a 40-character hex string or a 34-character string starting with 'N'.");
+
+            await VerifyAnalyzerAsync(code, expectedDiagnostic);
+        }
+
+        [TestMethod]
+        public async Task InvalidAliasedUInt256Initialization_ReportsDiagnostic()
+        {
+            const string code = """
+                                using ContractHash = Neo.SmartContract.Framework.UInt256;
+
+                                public class Test
+                                {
+                                    private static readonly ContractHash {|#0:invalidUInt256 = "invalid"|};
+                                }
+                                """;
+
+            var expectedDiagnostic = Verifier.Diagnostic(StaticFieldInitializationAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("UInt256 must be initialized with a 64-character hex string.");
+
+            await VerifyAnalyzerAsync(code, expectedDiagnostic);
+        }
+
+        [TestMethod]
+        public async Task NestedFrameworkNamespaceUInt160_NoDiagnostic()
+        {
+            const string code = """
+                                namespace Neo.SmartContract.Framework
+                                {
+                                    public class Container
+                                    {
+                                        public abstract class UInt160
+                                        {
+                                            public static extern implicit operator UInt160(string value);
+                                        }
+                                    }
+                                }
+
+                                public class Test
+                                {
+                                    private static readonly Neo.SmartContract.Framework.Container.UInt160 nestedUInt160 = "invalid";
+                                }
+                                """;
+
+            await VerifyAnalyzerAsync(code);
+        }
+
+        [TestMethod]
+        public async Task SourceDefinedFrameworkUInt160_NoDiagnostic()
+        {
+            const string code = """
+                                #pragma warning disable CS0436
+
+                                namespace Neo.SmartContract.Framework
+                                {
+                                    public abstract class UInt160
+                                    {
+                                        public static extern implicit operator UInt160(string value);
+                                    }
+                                }
+
+                                public class Test
+                                {
+                                    private static readonly Neo.SmartContract.Framework.UInt160 sourceDefinedUInt160 = "invalid";
+                                }
+                                """;
+
+            await VerifyAnalyzerAsync(code);
+        }
+
+        [TestMethod]
+        public async Task UnrelatedUInt160Type_NoDiagnostic()
+        {
+            const string code = """
+                                namespace Example
+                                {
+                                    public abstract class UInt160
+                                    {
+                                        public static extern implicit operator UInt160(string value);
+                                    }
+                                }
+
+                                namespace Consumer
+                                {
+                                    using Example;
+
+                                    public class Test
+                                    {
+                                        private static readonly UInt160 unrelatedUInt160 = "invalid";
+                                    }
+                                }
+                                """;
+
+            await VerifyAnalyzerAsync(code);
+        }
+
+        private static string CreateFrameworkTypeCode(string typeName, string declaration) => $$"""
+            using Neo.SmartContract.Framework;
+
+            public class Test
+            {
+                private static readonly {{typeName}} {{declaration}};
+            }
+            """;
+
+        private static Task VerifyAnalyzerAsync(string code, params DiagnosticResult[] expectedDiagnostics)
+        {
+            var test = new CSharpAnalyzerTest<StaticFieldInitializationAnalyzer, DefaultVerifier>
+            {
+                TestCode = code
+            };
+            test.TestState.AdditionalProjects[FrameworkProjectName].Sources.Add(FrameworkTypes);
+            test.TestState.AdditionalProjectReferences.Add(FrameworkProjectName);
+            test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+            return test.RunAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary

- resolve static field types through the semantic model before applying `NC4023`
- recognize fully qualified and aliased Framework `UInt160`, `UInt256`, and `ECPoint` types
- compare exact referenced Framework symbols instead of source text or short names
- avoid rejecting nested, source-defined, and unrelated types with matching names

## Rationale

The analyzer previously compared field type source text with three short names. Qualified and aliased Framework types bypassed the rule, while unrelated same-named types could be rejected incorrectly.

## Validation

- 12 focused static-field tests
- qualified and aliased Framework positive cases
- nested and source-defined lookalike negative cases
- 230 analyzer tests with the seven audited fixes combined
- combined Release solution build
- combined full solution test run: 2,117 passed
- focused format and diff checks

Part of #1841.
