### PR TITLE
Fix: validate supported Math overloads

### DIFF
--- a/src/Neo.SmartContract.Analyzer/SystemMathUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/SystemMathUsageAnalyzer.cs
@@ -22,21 +22,35 @@ namespace Neo.SmartContract.Analyzer
     {
         public const string DiagnosticId = "NC4005";
 
-        private static readonly ImmutableHashSet<string> UnsupportedMathMethods = ImmutableHashSet.Create(
-            "Acos", "Asin", "Atan", "Atan2", "Ceiling", "Cos", "Cosh",
-            "Exp", "Floor", "IEEERemainder", "Log", "Log10", "Pow", "Round",
-            "Sin", "Sinh", "Sqrt", "Tan", "Tanh",
-            "Truncate");
+        private static readonly ImmutableHashSet<SpecialType> SignedIntegralTypes = ImmutableHashSet.Create(
+            SpecialType.System_SByte,
+            SpecialType.System_Int16,
+            SpecialType.System_Int32,
+            SpecialType.System_Int64);
+
+        private static readonly ImmutableHashSet<SpecialType> IntegralTypes = SignedIntegralTypes
+            .Add(SpecialType.System_Byte)
+            .Add(SpecialType.System_UInt16)
+            .Add(SpecialType.System_UInt32)
+            .Add(SpecialType.System_UInt64);
+
+        private static readonly ImmutableHashSet<SpecialType> Int32Type =
+            ImmutableHashSet.Create(SpecialType.System_Int32);
 
         private static readonly SymbolDisplayFormat FullyQualifiedFormat =
             SymbolDisplayFormat.FullyQualifiedFormat;
+
+        private static readonly SymbolDisplayFormat DiagnosticDisplayFormat =
+            SymbolDisplayFormat.CSharpShortErrorMessageFormat
+                .WithParameterOptions(SymbolDisplayParameterOptions.IncludeType |
+                                      SymbolDisplayParameterOptions.IncludeParamsRefOut);
 
         private const string SystemMathTypeName = "global::System.Math";
 
         private static readonly DiagnosticDescriptor Rule = new(
             DiagnosticId,
-            "Unsupported Math method is used",
-            "Unsupported Math method: {0}",
+            "Unsupported Math method or overload is used",
+            "Unsupported Math method or overload: {0}",
             "Method",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
@@ -57,14 +71,48 @@ namespace Neo.SmartContract.Analyzer
 
             if (context.SemanticModel.GetSymbolInfo(invocationExpression).Symbol is not IMethodSymbol methodSymbol ||
                 methodSymbol.ContainingType?.ToDisplayString(FullyQualifiedFormat) != SystemMathTypeName ||
-                !UnsupportedMathMethods.Contains(methodSymbol.Name))
+                IsSupportedMathMethod(methodSymbol))
                 return;
 
             var diagnostic = Diagnostic.Create(Rule,
                 invocationExpression.GetLocation(),
-                methodSymbol.Name);
+                methodSymbol.ToDisplayString(DiagnosticDisplayFormat));
 
             context.ReportDiagnostic(diagnostic);
+        }
+
+        private static bool IsSupportedMathMethod(IMethodSymbol method)
+        {
+            return method.Name switch
+            {
+                "Abs" or "Sign" => HasUniformParameterType(method, 1, SignedIntegralTypes),
+                "Max" or "Min" or "DivRem" => HasUniformParameterType(method, 2, IntegralTypes),
+                "Clamp" => HasUniformParameterType(method, 3, IntegralTypes),
+                "BigMul" => HasUniformParameterType(method, 2, Int32Type),
+                _ => false
+            };
+        }
+
+        private static bool HasUniformParameterType(
+            IMethodSymbol method,
+            int parameterCount,
+            ImmutableHashSet<SpecialType> supportedTypes)
+        {
+            if (method.Parameters.Length != parameterCount)
+                return false;
+
+            var parameterType = method.Parameters[0].Type.SpecialType;
+            if (!supportedTypes.Contains(parameterType))
+                return false;
+
+            for (var i = 0; i < method.Parameters.Length; i++)
+            {
+                if (method.Parameters[i].Type.SpecialType != parameterType ||
+                    method.Parameters[i].RefKind != RefKind.None)
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/SystemMathUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/SystemMathUsageAnalyzerUnitTest.cs
@@ -35,7 +35,7 @@ class TestClass
 
             var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
                 .WithSpan(8, 22, 8, 36)
-                .WithArguments("Sqrt");
+                .WithArguments("Math.Sqrt(double)");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -55,7 +55,7 @@ class TestClass
 
             var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
                 .WithSpan(8, 22, 8, 43)
-                .WithArguments("Sqrt");
+                .WithArguments("Math.Sqrt(double)");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -76,7 +76,7 @@ class TestClass
 
             var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
                 .WithSpan(9, 22, 9, 33)
-                .WithArguments("Sqrt");
+                .WithArguments("Math.Sqrt(double)");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -96,7 +96,7 @@ class TestClass
 
             var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
                 .WithSpan(8, 22, 8, 31)
-                .WithArguments("Sqrt");
+                .WithArguments("Math.Sqrt(double)");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -136,7 +136,7 @@ class TestClass
 
             var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
                 .WithSpan(8, 22, 8, 35)
-                .WithArguments("Cos");
+                .WithArguments("Math.Cos(double)");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -156,7 +156,30 @@ class TestClass
 
             var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
                 .WithSpan(8, 22, 8, 36)
-                .WithArguments("Log");
+                .WithArguments("Math.Log(double)");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task UnsupportedMathDivRemOverload_ShouldReportDiagnostic()
+        {
+            var test = """
+                using System;
+
+                class TestClass
+                {
+                    void TestMethod()
+                    {
+                        int remainder;
+                        var result = {|#0:Math.DivRem(7, 3, out remainder)|};
+                    }
+                }
+                """;
+
+            var expected = VerifyCS.Diagnostic(SystemMathUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("Math.DivRem(int, int, out int)");
+
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -174,6 +197,8 @@ class TestClass
         var result2 = Math.Min(1, 2);
         var result3 = Math.Abs(-1);
         var result4 = Math.Sign(-5);
+        var result5 = Math.Clamp(5, 0, 10);
+        var result6 = Math.BigMul(3, 4);
     }
 }";
 


### PR DESCRIPTION
## Summary

- validate `System.Math` calls against the exact integer overloads registered by the compiler
- reject unsupported overloads even when another overload with the same method name is supported
- include the resolved signature in `NC4005` diagnostics

## Reason

The previous method-name blacklist allowed unregistered overloads such as `Math.DivRem(int, int, out int)` to pass analysis and fail later in compiler lowering.

## Validation

- confirmed the new overload regression test expected one diagnostic and received none before the change
- confirmed `nccs` independently rejected the same overload with `NC1002`
- passed 9 focused Math analyzer tests
- passed all 180 analyzer tests
- passed the Release solution build with no errors
- passed focused formatting verification
- compiled a `net10.0` consumer covering all 41 registered Math overloads with no warnings or errors
- compiled the same 41-overload contract with `nccs --optimize All` and generated its NEF and manifest

Related to #1841.
