### PR TITLE
Fix: resolve Notify event names by parameter

### DIFF
--- a/src/Neo.SmartContract.Analyzer/NotifyEventNameAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/NotifyEventNameAnalyzer.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -55,21 +56,17 @@ namespace Neo.SmartContract.Analyzer
             if (memberAccessExpr.Name.Identifier.ValueText != "Notify")
                 return;
 
-            if (!(invocationExpr.ArgumentList?.Arguments.Count > 0))
+            if (context.SemanticModel.GetOperation(invocationExpr, context.CancellationToken) is not IInvocationOperation operation ||
+                !IsRuntimeNotify(operation.TargetMethod))
                 return;
 
-            // Only a string literal event name can be checked statically.
-            if (invocationExpr.ArgumentList.Arguments[0].Expression is not LiteralExpressionSyntax firstArgument ||
+            var eventNameArgument = operation.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0);
+            if (eventNameArgument?.Syntax is not ArgumentSyntax argumentSyntax ||
+                argumentSyntax.Expression is not LiteralExpressionSyntax firstArgument ||
                 !firstArgument.IsKind(SyntaxKind.StringLiteralExpression))
                 return;
 
             var passedName = firstArgument.Token.ValueText;
-
-            // Only analyze calls that actually bind to the framework's Runtime.Notify; a method
-            // merely named "Notify" on some unrelated type must not be flagged.
-            if (context.SemanticModel.GetSymbolInfo(invocationExpr).Symbol is not IMethodSymbol method ||
-                !IsRuntimeNotify(method))
-                return;
 
             // Resolve event names the way the compiler does: an event's [DisplayName] when present,
             // otherwise the event field name. Events inherited from base types count as well.

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/NotifyEventNameAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/NotifyEventNameAnalyzerUnitTest.cs
@@ -181,6 +181,49 @@ class Contract
         }
 
         [TestMethod]
+        public async Task Notify_WithReorderedNamedArguments_ShouldReportDiagnostic()
+        {
+            var test = @"
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+
+class Contract
+{
+    [DisplayName(""Transfer"")]
+    public static event System.Action<int> OnTransfer;
+
+    public void Main() => Runtime.Notify(
+        state: new object[] { 1 },
+        eventName: {|#0:""Tranfser""|});
+}" + FrameworkStubs;
+
+            var expected = VerifyCS.Diagnostic(NotifyEventNameAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("Tranfser");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task Notify_WithMatchingReorderedNamedArguments_ShouldNotReportDiagnostic()
+        {
+            var test = @"
+using Neo.SmartContract.Framework.Services;
+using System.ComponentModel;
+
+class Contract
+{
+    [DisplayName(""Transfer"")]
+    public static event System.Action<int> OnTransfer;
+
+    public void Main() => Runtime.Notify(
+        state: new object[] { 1 },
+        eventName: ""Transfer"");
+}" + FrameworkStubs;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
         public async Task Notify_WithCustomDisplayNameAttribute_ShouldReportDiagnostic()
         {
             var test = @"


### PR DESCRIPTION
## Problem

`NotifyEventNameAnalyzer` reads the first syntactic argument as the event name. A valid call can reorder named arguments, causing the analyzer to inspect `state` and miss an invalid `eventName`.

## Fix

- Resolve the invocation through `IInvocationOperation`.
- Select the event-name argument by parameter ordinal instead of source position.
- Keep the existing exact `Runtime.Notify` target check and literal-only analysis.

## Validation

- Focused `NotifyEventNameAnalyzer` tests: 10 passed.
- Complete analyzer tests: 181 passed.
- Complete solution tests: 2,059 passed.
- A standalone consumer build reports NC4019 for a misspelled reordered named argument.
- The same consumer build succeeds for a matching reordered named argument.
- Focused formatting verification passed.
