### PR TITLE
Fix: preserve supported standards arguments

### DIFF
--- a/src/Neo.SmartContract.Analyzer/NepStandardAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/NepStandardAnalyzer.cs
@@ -28,6 +28,7 @@ namespace Neo.SmartContract.Analyzer
     public class SupportedStandardsAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "NC4021";
+        internal const string StandardPropertyName = "Standard";
         private static readonly string Title = "Supported Standards";
         private static readonly string MessageFormat = "Standard format suggestion: '{0}'";
         private static readonly string Description = "Checks for the usage of supported NEP standards.";
@@ -59,31 +60,33 @@ namespace Neo.SmartContract.Analyzer
                 if (attributeName == "SupportedStandards")
                 {
                     var argumentList = attributeSyntax.ArgumentList;
-                    if (argumentList != null && argumentList.Arguments.Count > 0)
+                    if (argumentList != null)
                     {
-                        var argument = argumentList.Arguments[0].Expression;
-                        if (argument is LiteralExpressionSyntax literalExpression)
+                        foreach (var attributeArgument in argumentList.Arguments)
                         {
-                            var standardValue = literalExpression.Token.ValueText.ToUpper();
+                            if (attributeArgument.Expression is not LiteralExpressionSyntax literalExpression ||
+                                !literalExpression.IsKind(SyntaxKind.StringLiteralExpression))
+                            {
+                                continue;
+                            }
+
+                            var standardValue = literalExpression.Token.ValueText.ToUpperInvariant();
                             if (standardValue is "NEP11" or "NEP-11" or "NEP17" or "NEP-17")
                             {
                                 var standard = standardValue is "NEP11" or "NEP-11" ? NepStandard.Nep11 : NepStandard.Nep17;
-                                var expectedSyntax = SyntaxFactory.AttributeArgument(
-                                    SyntaxFactory.MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression,
-                                        SyntaxFactory.IdentifierName("NepStandard"),
-                                        SyntaxFactory.IdentifierName(standard.ToString())));
-
-                                if (!argumentList.Arguments[0].Expression.IsEquivalentTo(expectedSyntax.Expression))
-                                {
-                                    var suggestionMessage = $"Consider using [SupportedStandards(NepStandard.{standard})]";
-                                    var diagnostic = Diagnostic.Create(Rule, attributeSyntax.GetLocation(), suggestionMessage);
-                                    context.ReportDiagnostic(diagnostic);
-                                }
+                                var suggestionMessage = $"Consider using [SupportedStandards(NepStandard.{standard})]";
+                                var properties = ImmutableDictionary<string, string?>.Empty
+                                    .Add(StandardPropertyName, standard.ToString());
+                                var diagnostic = Diagnostic.Create(
+                                    Rule,
+                                    attributeArgument.Expression.GetLocation(),
+                                    properties,
+                                    suggestionMessage);
+                                context.ReportDiagnostic(diagnostic);
                             }
                             else if (!IsSupportedStandard(standardValue))
                             {
-                                var diagnostic = Diagnostic.Create(Rule, attributeSyntax.GetLocation(), standardValue);
+                                var diagnostic = Diagnostic.Create(Rule, attributeArgument.Expression.GetLocation(), standardValue);
                                 context.ReportDiagnostic(diagnostic);
                             }
                         }
@@ -95,11 +98,6 @@ namespace Neo.SmartContract.Analyzer
         private static bool IsSupportedStandard(string value)
         {
             return Enum.TryParse<NepStandard>(value, ignoreCase: true, out _);
-        }
-
-        private string GetSuggestionMessage(NepStandard standard)
-        {
-            return $"Consider using [SupportedStandards(NepStandard.{standard})]";
         }
     }
 
@@ -117,42 +115,38 @@ namespace Neo.SmartContract.Analyzer
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
-            var attributeSyntax = root?.FindNode(diagnosticSpan)?.AncestorsAndSelf()?.OfType<AttributeSyntax>()?.FirstOrDefault();
+            var attributeArgument = root?.FindNode(diagnosticSpan, getInnermostNodeForTie: true)
+                .AncestorsAndSelf()
+                .OfType<AttributeArgumentSyntax>()
+                .FirstOrDefault();
 
-            if (attributeSyntax != null)
-            {
-                context.RegisterCodeFix(
-                    CodeAction.Create(
-                        title: Title,
-                        createChangedDocument: c => UpdateSupportedStandards(context.Document, attributeSyntax, c),
-                        equivalenceKey: Title),
-                    diagnostic);
-            }
+            if (attributeArgument is null ||
+                !diagnostic.Properties.TryGetValue(SupportedStandardsAnalyzer.StandardPropertyName, out var standardName) ||
+                !Enum.TryParse(standardName, out NepStandard standard))
+                return;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: c => UpdateSupportedStandards(context.Document, attributeArgument, standard, c),
+                    equivalenceKey: Title),
+                diagnostic);
         }
 
-        private async Task<Document> UpdateSupportedStandards(Document document, AttributeSyntax attributeSyntax, CancellationToken cancellationToken)
+        private static async Task<Document> UpdateSupportedStandards(
+            Document document,
+            AttributeArgumentSyntax attributeArgument,
+            NepStandard standard,
+            CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken);
-            var newAttributeSyntax = attributeSyntax;
-            var argumentList = attributeSyntax.ArgumentList;
-            if (argumentList != null && argumentList.Arguments.Count > 0)
-            {
-                var argument = argumentList.Arguments[0].Expression;
-                if (argument is LiteralExpressionSyntax literalExpression)
-                {
-                    var standardValue = literalExpression.Token.ValueText;
-                    if (standardValue == "NEP11")
-                    {
-                        newAttributeSyntax = attributeSyntax.WithArgumentList(SyntaxFactory.AttributeArgumentList().AddArguments(SyntaxFactory.AttributeArgument(SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("NepStandard"), SyntaxFactory.IdentifierName("Nep11")))));
-                    }
-                    else if (standardValue == "NEP17")
-                    {
-                        newAttributeSyntax = attributeSyntax.WithArgumentList(SyntaxFactory.AttributeArgumentList().AddArguments(SyntaxFactory.AttributeArgument(SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("NepStandard"), SyntaxFactory.IdentifierName("Nep17")))));
-                    }
-                }
-            }
-
-            var newRoot = root!.ReplaceNode(attributeSyntax, newAttributeSyntax);
+            var replacementExpression = SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("NepStandard"),
+                    SyntaxFactory.IdentifierName(standard.ToString()))
+                .WithTriviaFrom(attributeArgument.Expression);
+            var newArgument = attributeArgument.WithExpression(replacementExpression);
+            var newRoot = root!.ReplaceNode(attributeArgument, newArgument);
             return document.WithSyntaxRoot(newRoot);
         }
     }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/SupportedStandardsAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/SupportedStandardsAnalyzerUnitTest.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
     Neo.SmartContract.Analyzer.SupportedStandardsAnalyzer,
@@ -58,7 +60,7 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                                                         """;
 
             var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
-                .WithSpan(22, 2, 22, 28).WithArguments("NEP5");
+                .WithSpan(22, 21, 22, 27).WithArguments("NEP5");
 
             await Verifier.VerifyAnalyzerAsync(originalCode, expectedDiagnostic).ConfigureAwait(false);
         }
@@ -78,7 +80,7 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                                                         """;
 
             var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
-                .WithSpan(22, 2, 22, 29).WithArguments("Consider using [SupportedStandards(NepStandard.Nep11)]");
+                .WithSpan(22, 21, 22, 28).WithArguments("Consider using [SupportedStandards(NepStandard.Nep11)]");
 
             await Verifier.VerifyAnalyzerAsync(originalCode, expectedDiagnostic).ConfigureAwait(false);
         }
@@ -98,7 +100,7 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                                                         """;
 
             var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
-                .WithSpan(22, 2, 22, 29).WithArguments("Consider using [SupportedStandards(NepStandard.Nep17)]");
+                .WithSpan(22, 21, 22, 28).WithArguments("Consider using [SupportedStandards(NepStandard.Nep17)]");
 
             await Verifier.VerifyAnalyzerAsync(originalCode, expectedDiagnostic).ConfigureAwait(false);
         }
@@ -129,7 +131,7 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                                                      """;
 
             var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
-                .WithSpan(22, 2, 22, 29).WithArguments("Consider using [SupportedStandards(NepStandard.Nep11)]");
+                .WithSpan(22, 21, 22, 28).WithArguments("Consider using [SupportedStandards(NepStandard.Nep11)]");
 
             await Verifier.VerifyCodeFixAsync(originalCode, expectedDiagnostic, fixedCode).ConfigureAwait(false);
         }
@@ -160,7 +162,106 @@ namespace Neo.SmartContract.Analyzer.UnitTests
                                                      """;
 
             var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
-                .WithSpan(22, 2, 22, 29).WithArguments("Consider using [SupportedStandards(NepStandard.Nep17)]");
+                .WithSpan(22, 21, 22, 28).WithArguments("Consider using [SupportedStandards(NepStandard.Nep17)]");
+
+            await Verifier.VerifyCodeFixAsync(originalCode, expectedDiagnostic, fixedCode).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task SupportedStandardsAnalyzer_UpdateMultipleStandards_ShouldPreserveEveryArgument()
+        {
+            const string originalCode = TestNamespace + """
+
+                                                        [SupportedStandards({|#0:"NEP11"|}, {|#1:"NEP17"|})]
+                                                        public class TestContract
+                                                        {
+                                                            public static void Main()
+                                                            {
+                                                            }
+                                                        }
+                                                        """;
+
+            const string fixedCode = TestNamespace + """
+
+                                                     [SupportedStandards(NepStandard.Nep11, NepStandard.Nep17)]
+                                                     public class TestContract
+                                                     {
+                                                         public static void Main()
+                                                         {
+                                                         }
+                                                     }
+                                                     """;
+
+            var expectedDiagnostics = new[]
+            {
+                Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
+                    .WithLocation(0)
+                    .WithArguments("Consider using [SupportedStandards(NepStandard.Nep11)]"),
+                Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
+                    .WithLocation(1)
+                    .WithArguments("Consider using [SupportedStandards(NepStandard.Nep17)]")
+            };
+
+            var test = new CSharpCodeFixTest<SupportedStandardsAnalyzer, SupportedStandardsCodeFixProvider, DefaultVerifier>
+            {
+                TestCode = originalCode,
+                FixedCode = fixedCode,
+                BatchFixedCode = fixedCode
+            };
+            test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+
+            await test.RunAsync().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task SupportedStandardsAnalyzer_UnsupportedLaterArgument_ShouldReportDiagnostic()
+        {
+            const string originalCode = TestNamespace + """
+
+                                                        [SupportedStandards("NEP24", {|#0:"NEP5"|})]
+                                                        public class TestContract
+                                                        {
+                                                            public static void Main()
+                                                            {
+                                                            }
+                                                        }
+                                                        """;
+
+            var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("NEP5");
+
+            await Verifier.VerifyAnalyzerAsync(originalCode, expectedDiagnostic).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task SupportedStandardsAnalyzer_UpdateHyphenatedLowercaseStandard_ShouldFixCode()
+        {
+            const string originalCode = TestNamespace + """
+
+                                                        [SupportedStandards({|#0:"nep-11"|})]
+                                                        public class TestContract
+                                                        {
+                                                            public static void Main()
+                                                            {
+                                                            }
+                                                        }
+                                                        """;
+
+            const string fixedCode = TestNamespace + """
+
+                                                     [SupportedStandards(NepStandard.Nep11)]
+                                                     public class TestContract
+                                                     {
+                                                         public static void Main()
+                                                         {
+                                                         }
+                                                     }
+                                                     """;
+
+            var expectedDiagnostic = Verifier.Diagnostic(SupportedStandardsAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("Consider using [SupportedStandards(NepStandard.Nep11)]");
 
             await Verifier.VerifyCodeFixAsync(originalCode, expectedDiagnostic, fixedCode).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Problem

`SupportedStandardsAnalyzer` only examines the first attribute argument. Its code fix then rebuilds the entire argument list, so fixing `[SupportedStandards("NEP11", "NEP17")]` silently removes the second declared standard.

## Fix

- Analyze every string argument independently.
- Report each diagnostic on the corresponding argument expression.
- Store the intended enum replacement in diagnostic properties.
- Replace only the diagnosed argument and preserve every sibling argument.
- Do not offer a no-op code fix for unknown standards.

## Validation

- Controlled regression reproduced one diagnostic instead of two.
- Focused analyzer and code-fix tests: 8 passed.
- Incremental and Fix All behavior both preserve two standards.
- Complete analyzer tests: 182 passed.
- Complete solution tests: 2,060 passed.
- A standalone consumer reports two NC4021 errors for two string arguments and builds cleanly with the corresponding enum arguments.
- Focused formatting verification passed.
