### PR TITLE
Fix: correct analyzer severity configuration

### DIFF
--- a/src/Neo.SmartContract.Analyzer/README.md
+++ b/src/Neo.SmartContract.Analyzer/README.md
@@ -79,9 +79,22 @@ When the analyzer lives in the same repo, reference it directly so you can debug
 dotnet build /warnaserror
 ```
 
-```
-dotnet_analyzer_diagnostic.category-Nsc = error
-dotnet_diagnostic.NSC001.severity = warning
+Add the following to `.editorconfig` to promote all seven shipped analyzer
+categories (`Usage`, `Syntax`, `Security`, `Naming`, `Type`, `Method`, and
+`Namespace`) to errors while keeping selected rules at a different severity:
+
+```ini
+[*.cs]
+dotnet_analyzer_diagnostic.category-Usage.severity = error
+dotnet_analyzer_diagnostic.category-Syntax.severity = error
+dotnet_analyzer_diagnostic.category-Security.severity = error
+dotnet_analyzer_diagnostic.category-Naming.severity = error
+dotnet_analyzer_diagnostic.category-Type.severity = error
+dotnet_analyzer_diagnostic.category-Method.severity = error
+dotnet_analyzer_diagnostic.category-Namespace.severity = error
+
+# Override individual rules after setting category defaults when needed.
+dotnet_diagnostic.NC4014.severity = warning
 ```
 
 3. Only suppress warnings with `#pragma warning disable` when you fully understand the trade-off.


### PR DESCRIPTION
## Problem

The analyzer README used an incomplete `.editorconfig` category example. Copying it left rules in the shipped `Type`, `Method`, and `Namespace` categories unchanged.

## Fix

- identify the snippet as `.editorconfig` configuration
- list all seven shipped analyzer categories
- retain a valid per-rule severity override example

## Validation

- verified the categories against the analyzer descriptors
- combined Release solution build
- 230 analyzer tests with the seven audited fixes combined
- combined full solution test run: 2,117 passed
- focused format and diff checks
