### PR TITLE
Fix: make Span ref probe valid C#

### DIFF
--- a/docs/csharp-syntax/csharp-7.md
+++ b/docs/csharp-syntax/csharp-7.md
@@ -115,11 +115,11 @@ Status: unsupported
 Scope: class
 Notes: The compiler also forbids forwarding `Span<T>` indexers as ref/out arguments. The element must flow through a ref local first to compile successfully.
 ```csharp
-Span<int> values = new int[] { 1, 2, 3 };
 static void Increment(ref int value) => value++;
 
 public static void Update()
 {
+    Span<int> values = new int[] { 1, 2, 3 };
     Increment(ref values[1]);
 }
 ```

--- a/docs/csharp-syntax/csharp-7.md
+++ b/docs/csharp-syntax/csharp-7.md
@@ -113,7 +113,7 @@ public static void Update(int[] values)
 
 Status: unsupported
 Scope: class
-Notes: The compiler also forbids forwarding `Span<T>` indexers as ref/out arguments. The element must flow through a ref local first to compile successfully.
+Notes: `Span<T>` is supported in other contexts, but the compiler forbids forwarding a `Span<T>` indexer directly as a ref/out argument. The element must flow through a ref local first to compile successfully.
 ```csharp
 static void Increment(ref int value) => value++;
 


### PR DESCRIPTION
## Summary

- keep the `Span<T>` value local to the method in the C# 7 ref-argument probe;
- ensure standard C# accepts the sample before the Neo compiler rejects the intended unsupported ref argument.

## Root cause

The probe declared `Span<int>` as an instance field of a normal class and accessed it from a static method. Standard C# rejected the sample with `CS8345` and `CS0120`, so the probe never reached the Neo-specific `ref values[1]` restriction it claimed to cover.

## Validation

- standard `net10.0` consumer build with warnings treated as errors: passed;
- direct `nccs` compilation: rejected `ref values[1]` with `NC2001` at the expected source location;
- complete syntax-probe suite: 139 passed;
- Release solution build: passed with no warnings or errors;
- Markdown lint baseline comparison: 21 existing findings before and after, no new findings;
- `git diff --check`: passed.

Part of #1841.
