### PR TITLE
Fix: encode string constants as UTF-8

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/Expression.cs
@@ -61,6 +61,8 @@ internal partial class MethodConvert
             if (value == null)
                 return false;
 
+            bool isByteStringConstant = value is string && IsByteStringConstant(model, syntax);
+
             typeSymbol = GetTypeSymbol(syntaxNode, model);
 
             if (typeSymbol != null)
@@ -68,7 +70,10 @@ internal partial class MethodConvert
                 value = ConvertComplexConstantTypes(typeSymbol, value, syntax);
             }
 
-            Push(value);
+            if (isByteStringConstant && value is string byteString)
+                PushByteString(byteString);
+            else
+                Push(value);
             return true;
         }
         catch (CompilationException)
@@ -83,6 +88,19 @@ internal partial class MethodConvert
         {
             throw CompilationException.Unexpected("evaluating constant expression during conversion", e);
         }
+    }
+
+    private static bool IsByteStringConstant(SemanticModel model, ExpressionSyntax syntax)
+    {
+        var byteStringType = model.Compilation.GetTypeByMetadataName("Neo.SmartContract.Framework.ByteString");
+        if (byteStringType is null)
+            return false;
+
+        if (SymbolEqualityComparer.Default.Equals(model.GetTypeInfo(syntax).ConvertedType, byteStringType))
+            return true;
+
+        return syntax.Parent is CastExpressionSyntax cast
+            && SymbolEqualityComparer.Default.Equals(model.GetTypeInfo(cast.Type).Type, byteStringType);
     }
 
     private static void ThrowIfFloatingPointDefault(SemanticModel model, ExpressionSyntax syntax)

--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/StackHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/StackHelpers.cs
@@ -16,7 +16,7 @@ using Neo.VM;
 using scfx::Neo.SmartContract.Framework;
 using System;
 using System.Buffers.Binary;
-using System.IO;
+using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using OpCode = Neo.VM.OpCode;
@@ -132,29 +132,20 @@ internal partial class MethodConvert
         return instruction;
     }
 
-    /// <summary>
-    /// If all char in the input is no greater than byte.MaxValue == 255, get the byte for each char
-    /// If any char in the input is greater than byte.MaxValue == 255, encode in UTF8
-    /// This ensures "a\xff\x80\x79\x00" accurately translated to 0x61 0xff 0x80 0x79 0x00
-    /// </summary>
-    /// <param name="s">String value to push</param>
-    /// <returns>Instruction</returns>
     private Instruction Push(string s)
     {
-        try
-        {// Handle byte-like "\xff\x80\x79\x00..."
-         // fails on non-ascii char (> byte.MaxValue == 255) like "悪い文字"
-         // fails on long \x, e.g. \x123, \x1234
-         // does not fail on ascii chars
-            MemoryStream pushed = new();
-            BinaryWriter writer = new(pushed);
-            foreach (char c in s)
-                writer.Write(System.Convert.ToByte(c));
-            return Push(pushed.ToArray());
-        }
-        catch { }
         return Push(Utility.StrictUTF8.GetBytes(s));
-        // \xff (and each byte >= \x80) will be decoded to 2 bytes (0xc3 0xbf for \xff) by UTF8 decoder
+    }
+
+    /// <summary>
+    /// Preserves byte-like ByteString constants while encoding constants containing wider characters as UTF-8.
+    /// </summary>
+    private Instruction PushByteString(string s)
+    {
+        if (s.All(static character => character <= byte.MaxValue))
+            return Push(s.Select(static character => (byte)character).ToArray());
+
+        return Push(Utility.StrictUTF8.GetBytes(s));
     }
 
     private Instruction Push(byte[] data)

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestSources/Contract_UnicodeStringConstantEncoding.cs.txt
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestSources/Contract_UnicodeStringConstantEncoding.cs.txt
@@ -1,0 +1,74 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// Contract_UnicodeStringConstantEncoding.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.SmartContract.Framework;
+
+namespace Neo.Compiler.CSharp.UnitTests.TestSources;
+
+public class Contract_UnicodeStringConstantEncoding : SmartContract.Framework.SmartContract
+{
+    private const string Latin1 = "\u00E9";
+    private const string Cjk = "\u4F60\u597D";
+    private const string Mixed = "Neo-\u00E9-\u4F60\u597D-\U0001F642";
+    private const string RawBytes =
+        "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f" +
+        "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f" +
+        "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f" +
+        "\x30\x31\x32\x33\x34\x35\x36\x37\x38\x39\x3a\x3b\x3c\x3d\x3e\x3f" +
+        "\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f" +
+        "\x50\x51\x52\x53\x54\x55\x56\x57\x58\x59\x5a\x5b\x5c\x5d\x5e\x5f" +
+        "\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f" +
+        "\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7a\x7b\x7c\x7d\x7e\x7f" +
+        "\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f" +
+        "\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f" +
+        "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf" +
+        "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf" +
+        "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf" +
+        "\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf" +
+        "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef" +
+        "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff";
+
+    public static string Latin1Literal() => Latin1;
+
+    public static string CjkLiteral() => Cjk;
+
+    public static string MixedLiteral() => Mixed;
+
+    public static bool ContainsLatin1(string value) => value.Contains(Latin1);
+
+    public static bool ContainsCjk(string value) => value.Contains(Cjk);
+
+    public static bool ContainsMixed(string value) => value.Contains(Mixed);
+
+    public static bool EqualsLatin1(string value) => value == Latin1;
+
+    public static bool EqualsCjk(string value) => value == Cjk;
+
+    public static bool EqualsMixed(string value) => value == Mixed;
+
+    public static ByteString RawByteStringReturn() => RawBytes;
+
+    public static ByteString RawByteStringLocal()
+    {
+        ByteString value = RawBytes;
+        return value;
+    }
+
+    public static ByteString RawByteStringArgument() => Echo(RawBytes);
+
+    public static ByteString RawByteStringExplicit() => (ByteString)RawBytes;
+
+    public static ByteString RawByteStringParenthesizedCast() => (ByteString)((RawBytes));
+
+    public static ByteString RawLatin1ByteString() => Latin1;
+
+    private static ByteString Echo(ByteString value) => value;
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_UnicodeStringConstantEncoding.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_UnicodeStringConstantEncoding.cs
@@ -1,0 +1,154 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_UnicodeStringConstantEncoding.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.Compiler.CSharp.UnitTests.Syntax;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Testing;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_UnicodeStringConstantEncoding
+{
+    private const string Latin1 = "\u00E9";
+    private const string Cjk = "\u4F60\u597D";
+    private const string Mixed = "Neo-\u00E9-\u4F60\u597D-\U0001F642";
+    private static readonly Lazy<(NefFile Nef, ContractManifest Manifest)> CompiledContract = new(CompileContract);
+
+    [TestMethod]
+    public void StringLiterals_MatchDotNetValues()
+    {
+        var contract = DeployContract();
+
+        Assert.AreEqual(Latin1, contract.Latin1Literal());
+        Assert.AreEqual(Cjk, contract.CjkLiteral());
+        Assert.AreEqual(Mixed, contract.MixedLiteral());
+    }
+
+    [TestMethod]
+    public void StringSearchAndEquality_MatchDotNetOrdinalResults()
+    {
+        var contract = DeployContract();
+
+        AssertContainsMatchesDotNet(Latin1, $"before-{Latin1}-after", contract.ContainsLatin1);
+        AssertContainsMatchesDotNet(Cjk, $"before-{Cjk}-after", contract.ContainsCjk);
+        AssertContainsMatchesDotNet(Mixed, $"before-{Mixed}-after", contract.ContainsMixed);
+
+        AssertEqualityMatchesDotNet(Latin1, Latin1, contract.EqualsLatin1);
+        AssertEqualityMatchesDotNet(Cjk, Cjk, contract.EqualsCjk);
+        AssertEqualityMatchesDotNet(Mixed, Mixed, contract.EqualsMixed);
+
+        AssertContainsMatchesDotNet(Latin1, "missing", contract.ContainsLatin1);
+        AssertEqualityMatchesDotNet(Mixed, "different", contract.EqualsMixed);
+    }
+
+    [TestMethod]
+    public void ByteStringConstants_PreserveRawBytesAcrossContexts()
+    {
+        var contract = DeployContract();
+        byte[] expected = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+        CollectionAssert.AreEqual(expected, contract.RawByteStringReturn());
+        CollectionAssert.AreEqual(expected, contract.RawByteStringLocal());
+        CollectionAssert.AreEqual(expected, contract.RawByteStringArgument());
+        CollectionAssert.AreEqual(expected, contract.RawByteStringExplicit());
+        CollectionAssert.AreEqual(expected, contract.RawByteStringParenthesizedCast());
+        CollectionAssert.AreEqual(new byte[] { 0xE9 }, contract.RawLatin1ByteString());
+    }
+
+    private static void AssertContainsMatchesDotNet(string search, string value, Func<string, bool?> neoVmContains)
+    {
+        bool expected = value.Contains(search, StringComparison.Ordinal);
+        Assert.AreEqual(expected, neoVmContains(value));
+    }
+
+    private static void AssertEqualityMatchesDotNet(string expectedValue, string value, Func<string, bool?> neoVmEquals)
+    {
+        bool expected = string.Equals(value, expectedValue, StringComparison.Ordinal);
+        Assert.AreEqual(expected, neoVmEquals(value));
+    }
+
+    private static UnicodeStringConstantContract DeployContract()
+    {
+        var (nef, manifest) = CompiledContract.Value;
+        var engine = new TestEngine(true);
+        return engine.Deploy<UnicodeStringConstantContract>(nef, manifest);
+    }
+
+    private static (NefFile Nef, ContractManifest Manifest) CompileContract()
+    {
+        string path = Path.Combine(
+            SyntaxProbeLoader.GetRepositoryRoot(),
+            "tests",
+            "Neo.Compiler.CSharp.UnitTests",
+            "TestSources",
+            "Contract_UnicodeStringConstantEncoding.cs.txt");
+        var context = TestHelper.CompileSingleContract(File.ReadAllText(path));
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+        return (context.CreateExecutable(), context.CreateManifest());
+    }
+
+    public abstract class UnicodeStringConstantContract(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("latin1Literal")]
+        public abstract string? Latin1Literal();
+
+        [DisplayName("cjkLiteral")]
+        public abstract string? CjkLiteral();
+
+        [DisplayName("mixedLiteral")]
+        public abstract string? MixedLiteral();
+
+        [DisplayName("containsLatin1")]
+        public abstract bool? ContainsLatin1(string value);
+
+        [DisplayName("containsCjk")]
+        public abstract bool? ContainsCjk(string value);
+
+        [DisplayName("containsMixed")]
+        public abstract bool? ContainsMixed(string value);
+
+        [DisplayName("equalsLatin1")]
+        public abstract bool? EqualsLatin1(string value);
+
+        [DisplayName("equalsCjk")]
+        public abstract bool? EqualsCjk(string value);
+
+        [DisplayName("equalsMixed")]
+        public abstract bool? EqualsMixed(string value);
+
+        [DisplayName("rawByteStringReturn")]
+        public abstract byte[]? RawByteStringReturn();
+
+        [DisplayName("rawByteStringLocal")]
+        public abstract byte[]? RawByteStringLocal();
+
+        [DisplayName("rawByteStringArgument")]
+        public abstract byte[]? RawByteStringArgument();
+
+        [DisplayName("rawByteStringExplicit")]
+        public abstract byte[]? RawByteStringExplicit();
+
+        [DisplayName("rawByteStringParenthesizedCast")]
+        public abstract byte[]? RawByteStringParenthesizedCast();
+
+        [DisplayName("rawLatin1ByteString")]
+        public abstract byte[]? RawLatin1ByteString();
+    }
+}


### PR DESCRIPTION
## Summary

- encode ordinary C# string constants with strict UTF-8
- preserve raw one-byte values for constants converted to `ByteString`
- recognize `ByteString` conversions semantically across return, local, argument, and explicit-cast contexts

## Why

The shared string push path treated every character up to `0xff` as a raw byte. A normal string literal such as `"\u00e9"` therefore emitted invalid UTF-8 and could fail decoding or produce incorrect string search and equality results in NeoVM. Raw `ByteString` constants intentionally rely on the existing byte-preserving behavior, so that path remains compatible.

## Validation

- Unicode string constant tests: 3 passed against a deployed NeoVM contract
- related string and byte-string tests: 76 passed
- full compiler test suite: 1416 passed
- Release solution build: 0 errors
- focused `dotnet format --verify-no-changes`: passed
