### PR TITLE
Fix: require framework SafeAttribute for ABI safety

### DIFF
--- a/src/Neo.Compiler.CSharp/ABI/AbiMethod.cs
+++ b/src/Neo.Compiler.CSharp/ABI/AbiMethod.cs
@@ -24,23 +24,26 @@ namespace Neo.Compiler.ABI
 
         public override IMethodSymbol Symbol { get; }
 
-        public AbiMethod(IMethodSymbol symbol)
+        public AbiMethod(IMethodSymbol symbol, INamedTypeSymbol? frameworkSafeAttribute)
             : base(symbol, symbol.GetDisplayName(true), symbol.Parameters.Select(p => p.ToAbiParameter()).ToArray())
         {
             Symbol = symbol;
-            Safe = GetSafeAttribute(symbol) != null;
+            Safe = GetSafeAttribute(symbol, frameworkSafeAttribute) != null;
             if (Safe && symbol.MethodKind == MethodKind.PropertySet)
                 throw new CompilationException(symbol, DiagnosticId.SafeSetter, "Safe setters are not allowed.");
             ReturnType = symbol.ReturnType.GetContractParameterType();
         }
 
-        private static AttributeData? GetSafeAttribute(IMethodSymbol symbol)
+        private static AttributeData? GetSafeAttribute(IMethodSymbol symbol, INamedTypeSymbol? frameworkSafeAttribute)
         {
-            AttributeData? attribute = symbol.GetAttributes().FirstOrDefault(p => p.AttributeClass!.Name == nameof(scfx::Neo.SmartContract.Framework.Attributes.SafeAttribute));
+            AttributeData? attribute = symbol.GetAttributes().FirstOrDefault(p => IsFrameworkSafeAttribute(p, frameworkSafeAttribute));
             if (attribute != null) return attribute;
             if (symbol.AssociatedSymbol is IPropertySymbol property)
-                return property.GetAttributes().FirstOrDefault(p => p.AttributeClass!.Name == nameof(scfx::Neo.SmartContract.Framework.Attributes.SafeAttribute));
+                return property.GetAttributes().FirstOrDefault(p => IsFrameworkSafeAttribute(p, frameworkSafeAttribute));
             return null;
         }
+
+        private static bool IsFrameworkSafeAttribute(AttributeData attribute, INamedTypeSymbol? frameworkSafeAttribute)
+            => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, frameworkSafeAttribute);
     }
 }

--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
@@ -38,6 +38,7 @@ namespace Neo.Compiler
     {
         private readonly CompilationEngine _engine;
         private readonly INamedTypeSymbol _targetContract;
+        private readonly INamedTypeSymbol? _frameworkSafeAttribute;
         private readonly System.Collections.Generic.List<INamedTypeSymbol>? _nonDependencies;
         internal CompilationOptions Options => _engine.Options;
         private string? _displayName, _className;
@@ -97,8 +98,18 @@ namespace Neo.Compiler
         {
             _engine = engine;
             _targetContract = targetContract;
+            _frameworkSafeAttribute = ResolveFrameworkSafeAttribute(engine);
             _nonDependencies = nonDependencies;
             _allowBaseName = allowBaseName;
+        }
+
+        private static INamedTypeSymbol? ResolveFrameworkSafeAttribute(CompilationEngine engine)
+        {
+            if (engine.Compilation is null || engine.FrameworkReference is null)
+                return null;
+
+            return (engine.Compilation.GetAssemblyOrModuleSymbol(engine.FrameworkReference) as IAssemblySymbol)?
+                .GetTypeByMetadataName(typeof(SafeAttribute).FullName!);
         }
 
         private void RemoveEmptyInitialize()
@@ -639,7 +650,7 @@ namespace Neo.Compiler
             }
             if (export)
             {
-                AbiMethod method = new(symbol);
+                AbiMethod method = new(symbol, _frameworkSafeAttribute);
                 ValidateExportedMethodName(method);
                 if (_methodsExported.Any(u => u.Name == method.Name && u.Parameters.Length == method.Parameters.Length))
                     throw new CompilationException(symbol, DiagnosticId.MethodNameConflict, $"Duplicate method key: {method.Name},{method.Parameters.Length}.");

--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationEngine.cs
@@ -33,8 +33,11 @@ namespace Neo.Compiler
     public class CompilationEngine(CompilationOptions options)
     {
         internal Compilation? Compilation;
+        internal MetadataReference? FrameworkReference;
         internal CompilationOptions Options { get; private set; } = options;
         private static readonly MetadataReference[] CommonReferences;
+        private static readonly Guid FrameworkModuleVersionId = typeof(scfx::Neo.SmartContract.Framework.Attributes.SafeAttribute).Assembly.ManifestModule.ModuleVersionId;
+        private const string FrameworkAssemblyName = "Neo.SmartContract.Framework";
         private static readonly StringComparison ProjectPathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         private readonly Dictionary<string, MetadataReference> MetaReferences = new();
         private string? PreparedProjectPath;
@@ -140,7 +143,9 @@ namespace Neo.Compiler
         {
             IEnumerable<SyntaxTree> syntaxTrees = sourceFiles.OrderBy(p => p).Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), options: Options.GetParseOptions(), path: p));
             CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, deterministic: true, nullableContextOptions: Options.Nullable, allowUnsafe: false);
-            Compilation = CSharpCompilation.Create(null, syntaxTrees, references, compilationOptions);
+            MetadataReference[] referenceArray = references.ToArray();
+            FrameworkReference = referenceArray.FirstOrDefault(IsTrustedFrameworkReference);
+            Compilation = CSharpCompilation.Create(null, syntaxTrees, referenceArray, compilationOptions);
             return CompileProjectContracts(Compilation);
         }
 
@@ -210,6 +215,7 @@ namespace Neo.Compiler
 
             ResetProjectState();
             Compilation = GetCompilation(projectPath);
+            FrameworkReference = ResolveProjectFrameworkReference(Compilation);
             ProjectPath = projectPath;
             return Compilation;
         }
@@ -217,6 +223,7 @@ namespace Neo.Compiler
         private void ResetProjectState()
         {
             Compilation = null;
+            FrameworkReference = null;
             MetaReferences.Clear();
             PreparedProjectPath = null;
             ProjectPath = null;
@@ -224,6 +231,37 @@ namespace Neo.Compiler
             ProjectVersionPrefix = null;
             ProjectVersionSuffix = null;
             Contexts.Clear();
+        }
+
+        private MetadataReference? ResolveProjectFrameworkReference(Compilation compilation)
+        {
+            return MetaReferences
+                .Where(pair => IsFrameworkLibrary(pair.Key))
+                .Select(pair => pair.Value)
+                .FirstOrDefault(reference => compilation.References.Contains(reference));
+        }
+
+        private static bool IsFrameworkLibrary(string libraryName)
+        {
+            int separator = libraryName.IndexOf('/');
+            ReadOnlySpan<char> packageName = separator < 0 ? libraryName.AsSpan() : libraryName.AsSpan(0, separator);
+            return packageName.Equals(FrameworkAssemblyName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool IsTrustedFrameworkReference(MetadataReference reference)
+        {
+            if (reference is not PortableExecutableReference portableReference)
+                return false;
+
+            try
+            {
+                return portableReference.GetMetadata() is AssemblyMetadata assemblyMetadata &&
+                    assemblyMetadata.GetModules().Any(module => module.GetModuleVersionId() == FrameworkModuleVersionId);
+            }
+            catch (Exception exception) when (exception is BadImageFormatException or IOException)
+            {
+                return false;
+            }
         }
 
         public List<CompilationContext> CompileProject(string csproj, List<INamedTypeSymbol> sortedClasses, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> classDependencies, List<INamedTypeSymbol?> allClassSymbols, string? targetContractName = null)

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeAttributeIdentity.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeAttributeIdentity.cs
@@ -1,0 +1,282 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_SafeAttributeIdentity.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+extern alias scfx;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_SafeAttributeIdentity
+{
+    [TestMethod]
+    public void OnlyFrameworkSafeAttributeMarksAbiMembersSafe()
+    {
+        const string source = """
+            using Neo.SmartContract.Framework;
+            using System;
+
+            namespace User
+            {
+                [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+                public sealed class SafeAttribute : Attribute
+                {
+                }
+            }
+
+            public class Contract : SmartContract
+            {
+                [User.Safe]
+                public static int CustomMethod() => 1;
+
+                [User.Safe]
+                public static int CustomProperty => 2;
+
+                [User.Safe]
+                public static int CustomWritableProperty { get; set; }
+
+                [Neo.SmartContract.Framework.Attributes.Safe]
+                public static int FrameworkMethod() => 3;
+
+                [Neo.SmartContract.Framework.Attributes.Safe]
+                public static int FrameworkProperty => 4;
+            }
+            """;
+
+        var context = TestHelper.CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics));
+
+        var methods = context.CreateManifest().Abi.Methods;
+        Assert.IsFalse(methods.Single(method => method.Name == "customMethod").Safe);
+        Assert.IsFalse(methods.Single(method => method.Name == "customProperty").Safe);
+        var customWritableAccessors = methods.Where(method => method.Name == "customWritableProperty").ToArray();
+        Assert.AreEqual(1, customWritableAccessors.Length);
+        Assert.IsTrue(customWritableAccessors.All(method => !method.Safe));
+        Assert.IsTrue(methods.Single(method => method.Name == "frameworkMethod").Safe);
+        Assert.IsTrue(methods.Single(method => method.Name == "frameworkProperty").Safe);
+    }
+
+    [TestMethod]
+    public void SourceDefinedFrameworkSafeAttributeDoesNotMarkAbiMembersSafe()
+    {
+        var context = TestHelper.CompileSingleContract("""
+            using Neo.SmartContract.Framework;
+            using System;
+
+            namespace Neo.SmartContract.Framework.Attributes
+            {
+                [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+                public sealed class SafeAttribute : Attribute
+                {
+                }
+            }
+
+            public class Contract : SmartContract
+            {
+                [Neo.SmartContract.Framework.Attributes.Safe]
+                public static int ShadowedMethod() => 1;
+
+                [Neo.SmartContract.Framework.Attributes.Safe]
+                public static int ShadowedProperty => 2;
+            }
+            """);
+
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics));
+        var methods = context.CreateManifest().Abi.Methods;
+        Assert.IsFalse(methods.Single(method => method.Name == "shadowedMethod").Safe);
+        Assert.IsFalse(methods.Single(method => method.Name == "shadowedProperty").Safe);
+    }
+
+    [TestMethod]
+    public void MetadataAssemblyWithFrameworkNameDoesNotMarkAbiMembersSafe()
+    {
+        var sourceFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(sourceFile, """
+            extern alias spoof;
+
+            using Neo.SmartContract.Framework;
+
+            public class Contract : SmartContract
+            {
+                [spoof::Neo.SmartContract.Framework.Attributes.Safe]
+                public static int SpoofedMethod() => 1;
+
+                [Neo.SmartContract.Framework.Attributes.Safe]
+                public static int FrameworkMethod() => 2;
+            }
+            """);
+
+        try
+        {
+            MetadataReference spoofFramework = CreateSpoofFrameworkReference("spoof");
+            MetadataReference trustedFramework = MetadataReference.CreateFromFile(
+                typeof(scfx::Neo.SmartContract.Framework.Attributes.SafeAttribute).Assembly.Location);
+            MetadataReference[] references =
+            [
+                spoofFramework,
+                .. CreatePlatformReferences(),
+                trustedFramework
+            ];
+
+            var engine = new CompilationEngine(TestHelper.CreateDefaultOptions());
+            var context = engine.Compile([sourceFile], references).Single();
+
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics));
+            var methods = context.CreateManifest().Abi.Methods;
+            var spoofedMethod = context.TargetContract.GetMembers("SpoofedMethod").OfType<IMethodSymbol>().Single();
+            var frameworkMethod = context.TargetContract.GetMembers("FrameworkMethod").OfType<IMethodSymbol>().Single();
+            Assert.IsFalse(methods.Single(method => method.Name == "spoofedMethod").Safe,
+                $"Base: {context.TargetContract.BaseType?.ContainingAssembly.Identity}; " +
+                $"spoof: {spoofedMethod.GetAttributes().Single().AttributeClass?.ContainingAssembly.Identity}; " +
+                $"framework: {frameworkMethod.GetAttributes().Single().AttributeClass?.ContainingAssembly.Identity}");
+            Assert.IsTrue(methods.Single(method => method.Name == "frameworkMethod").Safe);
+        }
+        finally
+        {
+            File.Delete(sourceFile);
+        }
+    }
+
+    [TestMethod]
+    public void SpoofFrameworkContractBaseDoesNotEstablishSafeAttributeIdentity()
+    {
+        var sourceFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+        File.WriteAllText(sourceFile, """
+            using Neo.SmartContract.Framework;
+            using Neo.SmartContract.Framework.Attributes;
+
+            public class Contract : SmartContract
+            {
+                [Safe]
+                public static int SpoofedMethod() => 1;
+            }
+            """);
+
+        try
+        {
+            MetadataReference[] references =
+            [
+                CreateSpoofFrameworkReference(),
+                .. CreatePlatformReferences()
+            ];
+
+            var engine = new CompilationEngine(TestHelper.CreateDefaultOptions());
+            var context = engine.Compile([sourceFile], references).Single();
+
+            Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics));
+            Assert.IsFalse(context.CreateManifest().Abi.Methods.Single(method => method.Name == "spoofedMethod").Safe);
+        }
+        finally
+        {
+            File.Delete(sourceFile);
+        }
+    }
+
+    [TestMethod]
+    public void FrameworkReferenceIdentityRejectsUntrustedMetadata()
+    {
+        MetadataReference compilationReference = CSharpCompilation.Create(
+            assemblyName: "Unrelated",
+            references: CreatePlatformReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .ToMetadataReference();
+        using var moduleStream = new MemoryStream();
+        var moduleResult = CSharpCompilation.Create(
+            assemblyName: "Unrelated.netmodule",
+            references: CreatePlatformReferences(),
+            options: new CSharpCompilationOptions(OutputKind.NetModule))
+            .Emit(moduleStream);
+        Assert.IsTrue(moduleResult.Success, string.Join(Environment.NewLine, moduleResult.Diagnostics));
+        MetadataReference moduleReference = MetadataReference.CreateFromImage(
+            moduleStream.ToArray(), MetadataReferenceProperties.Module);
+        MetadataReference malformedReference = MetadataReference.CreateFromImage([0]);
+        MetadataReference trustedReference = MetadataReference.CreateFromFile(
+            typeof(scfx::Neo.SmartContract.Framework.Attributes.SafeAttribute).Assembly.Location);
+
+        Assert.IsFalse(CompilationEngine.IsTrustedFrameworkReference(compilationReference));
+        Assert.IsFalse(CompilationEngine.IsTrustedFrameworkReference(moduleReference));
+        Assert.IsFalse(CompilationEngine.IsTrustedFrameworkReference(malformedReference));
+        Assert.IsTrue(CompilationEngine.IsTrustedFrameworkReference(trustedReference));
+    }
+
+    private static MetadataReference CreateSpoofFrameworkReference(params string[] aliases)
+    {
+        byte[]? publicKey = typeof(object).Assembly.GetName().GetPublicKey();
+        Assert.IsNotNull(publicKey);
+
+        CSharpCompilation spoofCompilation = CSharpCompilation.Create(
+            assemblyName: "Neo.SmartContract.Framework",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText("""
+                    using System;
+                    using System.Reflection;
+                    using System.Runtime.CompilerServices;
+
+                    [assembly: AssemblyVersion("99.0.0.0")]
+
+                    namespace Neo.SmartContract.Framework
+                    {
+                        public abstract class SmartContract
+                        {
+                            [MethodImpl(MethodImplOptions.InternalCall)]
+                            public extern static void _initialize();
+                        }
+                    }
+
+                    namespace Neo.SmartContract.Framework.Attributes
+                    {
+                        [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+                        public sealed class SafeAttribute : Attribute
+                        {
+                        }
+                    }
+                    """)
+            ],
+            references: CreatePlatformReferences(),
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                cryptoPublicKey: ImmutableArray.Create(publicKey),
+                delaySign: true));
+
+        using var stream = new MemoryStream();
+        var result = spoofCompilation.Emit(stream);
+        Assert.IsTrue(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        MetadataReferenceProperties properties = aliases.Length == 0
+            ? MetadataReferenceProperties.Assembly
+            : MetadataReferenceProperties.Assembly.WithAliases(aliases);
+        return MetadataReference.CreateFromImage(stream.ToArray(), properties);
+    }
+
+    private static MetadataReference[] CreatePlatformReferences()
+    {
+        var trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(trustedPlatformAssemblies));
+        return trustedPlatformAssemblies!
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Where(path => !string.Equals(
+                Path.GetFileNameWithoutExtension(path),
+                "Neo.SmartContract.Framework",
+                StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

- retain the exact Framework metadata reference selected for project compilation
- recognize the compiler's canonical Framework PE reference by module identity in direct compilation
- compare ABI safety attributes by exact Roslyn type symbol
- ignore custom, source-shadowed, and same-named metadata attributes

## Rationale

The previous implementation selected the first referenced assembly with the Framework simple name. Reference order could therefore select a different same-named assembly and use its `SafeAttribute` symbol. ABI safety now follows the exact Framework reference used by the compilation.

## Validation

- 5 focused ABI attribute identity tests
- custom and same-namespace source attribute regressions
- same-named metadata assembly ordering regression
- same-named contract-base assembly regression
- compilation, module, and malformed metadata reference rejection
- actual package-reference `nccs` compilation with the Framework attribute preserved as `safe: true`
- full compiler test suite: 1,423 passed
- combined Release solution build
- combined full solution test run: 2,117 passed
- GitHub Action and Codecov project/patch checks passed
- focused format and diff checks

Part of #1841.
