### PR TITLE
Fix: require Framework SafeAttribute for call flags

### DIFF
--- a/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
+++ b/src/Neo.Compiler.CSharp/CompilationEngine/CompilationContext.cs
@@ -93,6 +93,7 @@ namespace Neo.Compiler
         /// <param name="nonDependencies">Classes that is not supposed to be compiled into current target contract.</param>
         private readonly bool _allowBaseName;
         internal INamedTypeSymbol TargetContract => _targetContract;
+        internal INamedTypeSymbol? FrameworkSafeAttribute => _frameworkSafeAttribute;
 
         internal CompilationContext(CompilationEngine engine, INamedTypeSymbol targetContract, System.Collections.Generic.List<INamedTypeSymbol>? nonDependencies = null, bool allowBaseName = true)
         {

--- a/src/Neo.Compiler.CSharp/MethodConvert/ExternConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ExternConvert.cs
@@ -115,13 +115,31 @@ internal partial class MethodConvert
         }
     }
 
-    private static bool IsSafeContractMethod(IMethodSymbol symbol)
+    private bool IsSafeContractMethod(IMethodSymbol symbol)
     {
-        if (symbol.GetAttributes().Any(p => p.AttributeClass?.Name == nameof(SafeAttribute)))
+        INamedTypeSymbol? safeAttribute = ResolveFrameworkSafeAttribute();
+        if (symbol.GetAttributes().Any(p => SymbolEqualityComparer.Default.Equals(p.AttributeClass, safeAttribute)))
             return true;
 
         return symbol.MethodKind == MethodKind.PropertyGet &&
             symbol.AssociatedSymbol is IPropertySymbol property &&
-            property.GetAttributes().Any(p => p.AttributeClass?.Name == nameof(SafeAttribute));
+            property.GetAttributes().Any(p => SymbolEqualityComparer.Default.Equals(p.AttributeClass, safeAttribute));
+    }
+
+    private INamedTypeSymbol? ResolveFrameworkSafeAttribute()
+    {
+        const string safeAttributeMetadataName = "Neo.SmartContract.Framework.Attributes.SafeAttribute";
+        INamedTypeSymbol smartContract = GetFrameworkSmartContractBase(_context.TargetContract);
+        return smartContract.ContainingAssembly.GetTypeByMetadataName(safeAttributeMetadataName);
+    }
+
+    private static INamedTypeSymbol GetFrameworkSmartContractBase(INamedTypeSymbol type)
+    {
+        const string smartContractMetadataName = "Neo.SmartContract.Framework.SmartContract";
+        INamedTypeSymbol baseType = type.BaseType!;
+        INamedTypeSymbol? smartContract = baseType.ContainingAssembly.GetTypeByMetadataName(smartContractMetadataName);
+        return SymbolEqualityComparer.Default.Equals(baseType, smartContract)
+            ? baseType
+            : GetFrameworkSmartContractBase(baseType);
     }
 }

--- a/src/Neo.Compiler.CSharp/MethodConvert/ExternConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/ExternConvert.cs
@@ -117,29 +117,12 @@ internal partial class MethodConvert
 
     private bool IsSafeContractMethod(IMethodSymbol symbol)
     {
-        INamedTypeSymbol? safeAttribute = ResolveFrameworkSafeAttribute();
+        INamedTypeSymbol? safeAttribute = _context.FrameworkSafeAttribute;
         if (symbol.GetAttributes().Any(p => SymbolEqualityComparer.Default.Equals(p.AttributeClass, safeAttribute)))
             return true;
 
         return symbol.MethodKind == MethodKind.PropertyGet &&
             symbol.AssociatedSymbol is IPropertySymbol property &&
             property.GetAttributes().Any(p => SymbolEqualityComparer.Default.Equals(p.AttributeClass, safeAttribute));
-    }
-
-    private INamedTypeSymbol? ResolveFrameworkSafeAttribute()
-    {
-        const string safeAttributeMetadataName = "Neo.SmartContract.Framework.Attributes.SafeAttribute";
-        INamedTypeSymbol smartContract = GetFrameworkSmartContractBase(_context.TargetContract);
-        return smartContract.ContainingAssembly.GetTypeByMetadataName(safeAttributeMetadataName);
-    }
-
-    private static INamedTypeSymbol GetFrameworkSmartContractBase(INamedTypeSymbol type)
-    {
-        const string smartContractMetadataName = "Neo.SmartContract.Framework.SmartContract";
-        INamedTypeSymbol baseType = type.BaseType!;
-        INamedTypeSymbol? smartContract = baseType.ContainingAssembly.GetTypeByMetadataName(smartContractMetadataName);
-        return SymbolEqualityComparer.Default.Equals(baseType, smartContract)
-            ? baseType
-            : GetFrameworkSmartContractBase(baseType);
     }
 }

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeMethodEnforcement.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeMethodEnforcement.cs
@@ -493,6 +493,51 @@ public static class SameFullyQualifiedNameSafeExternalContract
         }
 
         [TestMethod]
+        public void ContractCallToken_SourceDefinedFrameworkBaseAndSafeAttributeRemainWriteCapable()
+        {
+            var context = TestHelper.CompileSingleContract("""
+                #pragma warning disable CS0436
+                namespace Neo.SmartContract.Framework
+                {
+                    public abstract class SmartContract
+                    {
+                        public static void _initialize()
+                        {
+                        }
+                    }
+                }
+
+                namespace Neo.SmartContract.Framework.Attributes
+                {
+                    [System.AttributeUsage(System.AttributeTargets.Method)]
+                    public sealed class SafeAttribute : System.Attribute
+                    {
+                    }
+                }
+
+                [Neo.SmartContract.Framework.Attributes.Contract("0xe7a98ee2c70b3024d5091d72c0a52bb71df4e322")]
+                public static class ExternalContract
+                {
+                #pragma warning disable CS0626
+                    [Neo.SmartContract.Framework.Attributes.Safe]
+                    public static extern object Read();
+                #pragma warning restore CS0626
+                }
+
+                public class Contract : Neo.SmartContract.Framework.SmartContract
+                {
+                    public static object Get() => ExternalContract.Read();
+                }
+                #pragma warning restore CS0436
+                """);
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, context.CreateExecutable().Tokens.Single().CallFlags,
+                "Source-defined Framework types must not narrow external call flags.");
+        }
+
+        [TestMethod]
         public void ContractCallToken_ResolvesSafeAttributeThroughIntermediateBase()
         {
             var context = TestHelper.CompileSingleContract("""

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeMethodEnforcement.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_SafeMethodEnforcement.cs
@@ -43,8 +43,74 @@ public static class ExternalContract
 
     [Safe]
     public static extern object Value { get; set; }
+
+    public static extern object SafeSetter
+    {
+        get;
+        [Safe]
+        set;
+    }
 #pragma warning restore CS0626
 }";
+
+        private const string CustomSafeExternalContractDeclaration = @"
+
+namespace User
+{
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property)]
+    public sealed class SafeAttribute : System.Attribute
+    {
+    }
+}
+
+[Contract(""0xe7a98ee2c70b3024d5091d72c0a52bb71df4e322"")]
+public static class CustomSafeExternalContract
+{
+#pragma warning disable CS0626
+    [User.Safe]
+    public static extern object Method();
+
+    public static extern object Getter
+    {
+        [User.Safe]
+        get;
+    }
+
+    [User.Safe]
+    public static extern object Property { get; }
+
+    public static extern object Setter
+    {
+        get;
+        [User.Safe]
+        set;
+    }
+#pragma warning restore CS0626
+}";
+
+        private const string SameFullyQualifiedNameSafeExternalContractDeclaration = @"
+
+#pragma warning disable CS0436
+namespace Neo.SmartContract.Framework.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property)]
+    public sealed class SafeAttribute : System.Attribute
+    {
+    }
+}
+
+[Contract(""0xe7a98ee2c70b3024d5091d72c0a52bb71df4e322"")]
+public static class SameFullyQualifiedNameSafeExternalContract
+{
+#pragma warning disable CS0626
+    [Neo.SmartContract.Framework.Attributes.Safe]
+    public static extern object Method();
+
+    [Neo.SmartContract.Framework.Attributes.Safe]
+    public static extern object Property { get; }
+#pragma warning restore CS0626
+}
+#pragma warning restore CS0436";
 
         private static string Compile(string body, string declarations = "") => Header + body + "\n}" + declarations;
 
@@ -191,6 +257,19 @@ public static class ExternalContract
             Assert.IsTrue(
                 context.Diagnostics.Any(d => d.Id == SafeWriteCapableCallDiagnosticId && d.Severity == DiagnosticSeverity.Error),
                 "Expected an NC3012 error for a write-capable CALLT.");
+        }
+
+        [TestMethod]
+        public void SafeMethod_FakeSafeCallToken_FailsCompilation()
+        {
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    [Safe]
+    public static object Get() => CustomSafeExternalContract.Method();", CustomSafeExternalContractDeclaration));
+
+            Assert.IsFalse(context.Success, "A fake [Safe] attribute must not suppress write-capable CALLT enforcement.");
+            Assert.IsTrue(
+                context.Diagnostics.Any(d => d.Id == SafeWriteCapableCallDiagnosticId && d.Severity == DiagnosticSeverity.Error),
+                "Expected an NC3012 error for a CALLT marked with a non-Framework SafeAttribute.");
         }
 
         [TestMethod]
@@ -357,6 +436,93 @@ public static class ExternalContract
                 "A [Safe] external property getter must use read-only flags.");
             Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "setValue").CallFlags,
                 "A setter must not inherit the getter's [Safe] flags.");
+        }
+
+        [TestMethod]
+        public void ContractCallToken_SafeSetterMethodIsReadOnly()
+        {
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    public static void Set(object value) => ExternalContract.SafeSetter = value;", ExternalContractDeclaration));
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            Assert.AreEqual(Neo.SmartContract.CallFlags.ReadOnly, context.CreateExecutable().Tokens.Single().CallFlags,
+                "A setter method with the Framework [Safe] attribute must use read-only flags.");
+        }
+
+        [TestMethod]
+        public void ContractCallToken_DifferentNamespaceSafeAttributesRemainWriteCapable()
+        {
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    public static object CallMethod() => CustomSafeExternalContract.Method();
+
+    public static object GetValue() => CustomSafeExternalContract.Getter;
+
+    public static object GetProperty() => CustomSafeExternalContract.Property;
+
+    public static void SetValue(object value) => CustomSafeExternalContract.Setter = value;", CustomSafeExternalContractDeclaration));
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            var tokens = context.CreateExecutable().Tokens;
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "method").CallFlags,
+                "A custom SafeAttribute on an extern method must not narrow its call flags.");
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "getter").CallFlags,
+                "A custom SafeAttribute on a getter must not narrow its call flags.");
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "property").CallFlags,
+                "A custom SafeAttribute on a property must not narrow its getter's call flags.");
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "setSetter").CallFlags,
+                "A custom SafeAttribute on a setter must not narrow its call flags.");
+        }
+
+        [TestMethod]
+        public void ContractCallToken_SourceDefinedFrameworkSafeAttributeRemainsWriteCapable()
+        {
+            var context = TestHelper.CompileSingleContract(Compile(@"
+    public static object CallMethod() => SameFullyQualifiedNameSafeExternalContract.Method();
+
+    public static object GetProperty() => SameFullyQualifiedNameSafeExternalContract.Property;", SameFullyQualifiedNameSafeExternalContractDeclaration));
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            var tokens = context.CreateExecutable().Tokens;
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "method").CallFlags,
+                "A source-defined SafeAttribute with the Framework metadata name must not narrow call flags.");
+            Assert.AreEqual(Neo.SmartContract.CallFlags.All, tokens.Single(t => t.Method == "property").CallFlags,
+                "A source-defined SafeAttribute with the Framework metadata name must not narrow a property's getter flags.");
+        }
+
+        [TestMethod]
+        public void ContractCallToken_ResolvesSafeAttributeThroughIntermediateBase()
+        {
+            var context = TestHelper.CompileSingleContract("""
+                using Neo;
+                using Neo.SmartContract.Framework;
+                using Neo.SmartContract.Framework.Attributes;
+
+                public abstract class BaseContract : SmartContract
+                {
+                }
+
+                [Contract("0xe7a98ee2c70b3024d5091d72c0a52bb71df4e322")]
+                public static class ExternalContract
+                {
+                #pragma warning disable CS0626
+                    [Safe]
+                    public static extern object Read();
+                #pragma warning restore CS0626
+                }
+
+                public class Contract : BaseContract
+                {
+                    public static object Get() => ExternalContract.Read();
+                }
+                """);
+
+            Assert.IsTrue(context.Success,
+                string.Join('\n', context.Diagnostics.Select(d => d.ToString())));
+            Assert.AreEqual(Neo.SmartContract.CallFlags.ReadOnly, context.CreateExecutable().Tokens.Single().CallFlags,
+                "An intermediate contract base must preserve Framework safety metadata.");
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

- resolve SafeAttribute from the Framework assembly that defines the target contract's SmartContract base
- compare external method and property attributes by their exact Roslyn type symbol
- keep custom and source-shadowing SafeAttribute declarations from narrowing CALLT flags
- preserve Framework method, getter, and explicitly attributed setter behavior

## Validation

- controlled master-n3 regression: 3 failures out of 27 related tests
- fixed branch: 27 related tests passed
- 1,418 compiler tests
- Release solution build
- focused format check

Progresses #1841
