### PR TITLE
CI: restore coverlet with configured package sources

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         path: ${{ env.NUGET_PACKAGES }}
         key: ${{ runner.os }}-dotnet-${{ env.DOTNET_VERSION }}-nuget-${{ hashFiles('NuGet.Config', 'src/Directory.Build.props', 'tests/Directory.Build.props', '**/*.csproj') }}
     - name: Add package coverlet.msbuild
-      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --source https://api.nuget.org/v3/index.json
+      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --source https://api.nuget.org/v3/index.json --no-restore
     - name: Build Solution
       run: dotnet build ./neo-devpack-dotnet.sln
     - name: Check format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         path: ${{ env.NUGET_PACKAGES }}
         key: ${{ runner.os }}-dotnet-${{ env.DOTNET_VERSION }}-nuget-${{ hashFiles('NuGet.Config', 'src/Directory.Build.props', 'tests/Directory.Build.props', '**/*.csproj') }}
     - name: Add package coverlet.msbuild
-      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --source https://api.nuget.org/v3/index.json --no-restore
+      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --version 6.0.4 --no-restore
     - name: Build Solution
       run: dotnet build ./neo-devpack-dotnet.sln
     - name: Check format


### PR DESCRIPTION
## Summary

- add coverlet.msbuild references without restoring each test project
- let the following solution build restore dependencies through NuGet.Config

## Problem

The current command restricts restore to NuGet.org before the solution has been restored. With an empty cache, package source mapping requires Neo.* dependencies from MyGet, so the CI job fails with NU1100.

## Validation

- verified the updated command adds the package reference to all five unit-test projects without restoring
- verified the workflow diff remains limited to the coverlet setup command