### PR TITLE
Fix nuget restore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         path: ${{ env.NUGET_PACKAGES }}
         key: ${{ runner.os }}-dotnet-${{ env.DOTNET_VERSION }}-nuget-${{ hashFiles('NuGet.Config', 'src/Directory.Build.props', 'tests/Directory.Build.props', '**/*.csproj') }}
     - name: Add package coverlet.msbuild
-      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --source https://api.nuget.org/v3/index.json
+      run: find tests -path '*UnitTests/*.csproj' | xargs -I % dotnet add % package coverlet.msbuild --version 6.0.4
     - name: Build Solution
       run: dotnet build ./neo-devpack-dotnet.sln
     - name: Check format


### PR DESCRIPTION
The "Add package coverlet.msbuild" step was failing with NU1100 errors because the --source https://api.nuget.org/v3/index.json flag overrode the repo's NuGet.Config breaking the Package Source Mapping that resolves Neo.* packages. This caused the job to exit with code 123 before any tests could run.