### PR TITLE
Preserve lifted nullable shift semantics

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
@@ -71,6 +71,15 @@ internal partial class MethodConvert
         IMethodSymbol? symbol = (IMethodSymbol?)model.GetSymbolInfo(expression).Symbol;
         if (symbol is not null && TryProcessSystemOperators(model, symbol, expression.Left, expression.Right))
             return;
+
+        if ((expression.IsKind(SyntaxKind.LeftShiftExpression) ||
+             expression.IsKind(SyntaxKind.RightShiftExpression)) &&
+            HasNullableOperand(model, expression))
+        {
+            ConvertLiftedShiftExpression(model, expression);
+            return;
+        }
+
         ConvertExpression(model, expression.Left);
         ConvertExpression(model, expression.Right);
 
@@ -125,6 +134,77 @@ internal partial class MethodConvert
             else
                 EnsureIntegerInRange(type);
         }
+    }
+
+    private static bool HasNullableOperand(SemanticModel model, BinaryExpressionSyntax expression) =>
+        IsNullableValueType(model.GetTypeInfo(expression.Left).Type) ||
+        IsNullableValueType(model.GetTypeInfo(expression.Right).Type);
+
+    private static bool IsNullableValueType(ITypeSymbol? type) =>
+        type is INamedTypeSymbol
+        {
+            OriginalDefinition.SpecialType: SpecialType.System_Nullable_T
+        };
+
+    /// <summary>
+    /// Emits a lifted shift while preserving C# null propagation and operand evaluation order.
+    /// </summary>
+    private void ConvertLiftedShiftExpression(SemanticModel model, BinaryExpressionSyntax expression)
+    {
+        ITypeSymbol? leftType = model.GetTypeInfo(expression.Left).Type;
+        ITypeSymbol? rightType = model.GetTypeInfo(expression.Right).Type;
+        ITypeSymbol resultType = model.GetTypeInfo(expression).Type!;
+        bool leftNullable = IsNullableValueType(leftType);
+        bool rightNullable = IsNullableValueType(rightType);
+
+        JumpTarget? leftNullTarget = leftNullable ? new JumpTarget() : null;
+        JumpTarget? rightNullTarget = rightNullable ? new JumpTarget() : null;
+        var endTarget = new JumpTarget();
+
+        ConvertExpression(model, expression.Left);
+        if (leftNullTarget is not null)
+        {
+            Dup();
+            IsNull();
+            JumpIfTrue(leftNullTarget);
+        }
+
+        ConvertExpression(model, expression.Right);
+        if (rightNullTarget is not null)
+        {
+            Dup();
+            IsNull();
+            JumpIfTrue(rightNullTarget);
+        }
+
+        if (expression.IsKind(SyntaxKind.LeftShiftExpression))
+        {
+            if (!MaskFixedWidthShiftCount(leftType))
+                CheckLeftShiftOverflow(model, leftType, expression.Right, true);
+            AddInstruction(OpCode.SHL);
+            NormalizeShiftResult(resultType);
+        }
+        else
+        {
+            MaskFixedWidthShiftCount(leftType);
+            AddInstruction(OpCode.SHR);
+        }
+        Jump(OpCode.JMP_L, endTarget);
+
+        if (rightNullTarget is not null)
+        {
+            rightNullTarget.Instruction = Nip();
+            Jump(OpCode.JMP_L, endTarget);
+        }
+
+        if (leftNullTarget is not null)
+        {
+            leftNullTarget.Instruction = Nop();
+            ConvertExpression(model, expression.Right);
+            Drop();
+        }
+
+        endTarget.Instruction = Nop();
     }
 
     /// <summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ShiftCountMasking.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ShiftCountMasking.cs
@@ -30,6 +30,8 @@ public class UnitTest_ShiftCountMasking
 
         public class Contract : SmartContract
         {
+            private static int _evaluations;
+
             [DisplayName("intLeftChecked")]
             public static int IntLeftChecked(int value, int count) => checked(value << count);
 
@@ -50,6 +52,23 @@ public class UnitTest_ShiftCountMasking
 
             [DisplayName("nullableLongRightChecked")]
             public static long? NullableLongRightChecked(long? value, int count) => checked(value >> count);
+
+            [DisplayName("nullableBothLeft")]
+            public static int? NullableBothLeft(int? value, int? count) => value << count;
+
+            [DisplayName("nullableBothRight")]
+            public static int? NullableBothRight(int? value, int? count) => value >> count;
+
+            [DisplayName("nullLeftEvaluationCount")]
+            public static int NullLeftEvaluationCount()
+            {
+                _evaluations = 0;
+                int? value = null;
+                _ = value << Evaluate();
+                return _evaluations;
+            }
+
+            private static int Evaluate() => ++_evaluations;
 
             [DisplayName("compoundInt")]
             public static int CompoundInt(int value, int count)
@@ -107,6 +126,15 @@ public class UnitTest_ShiftCountMasking
         Assert.AreEqual(new BigInteger(2), contract.IntLeftUnchecked(1, 33), optimization.ToString());
         Assert.AreEqual(new BigInteger(2), contract.NullableIntLeftChecked(1, 33), optimization.ToString());
         Assert.AreEqual(new BigInteger(-4), contract.NullableLongRightChecked(-8, 65), optimization.ToString());
+        Assert.IsNull(contract.NullableIntLeftChecked(null, 33), optimization.ToString());
+        Assert.IsNull(contract.NullableLongRightChecked(null, 65), optimization.ToString());
+        Assert.AreEqual(new BigInteger(2), contract.NullableBothLeft(1, 33), optimization.ToString());
+        Assert.IsNull(contract.NullableBothLeft(1, null), optimization.ToString());
+        Assert.IsNull(contract.NullableBothLeft(null, null), optimization.ToString());
+        Assert.AreEqual(new BigInteger(-4), contract.NullableBothRight(-8, 33), optimization.ToString());
+        Assert.IsNull(contract.NullableBothRight(-8, null), optimization.ToString());
+        Assert.IsNull(contract.NullableBothRight(null, 33), optimization.ToString());
+        Assert.AreEqual(BigInteger.One, contract.NullLeftEvaluationCount(), optimization.ToString());
         Assert.AreEqual(new BigInteger(2), contract.CompoundInt(1, 33), optimization.ToString());
         Assert.AreEqual(BigInteger.Zero, contract.CompoundByte(0, 8), optimization.ToString());
         Assert.AreEqual(new BigInteger(2), contract.CompoundByte(1, 33), optimization.ToString());
@@ -139,6 +167,15 @@ public class UnitTest_ShiftCountMasking
 
         [DisplayName("nullableLongRightChecked")]
         public abstract BigInteger? NullableLongRightChecked(BigInteger? value, BigInteger? count);
+
+        [DisplayName("nullableBothLeft")]
+        public abstract BigInteger? NullableBothLeft(BigInteger? value, BigInteger? count);
+
+        [DisplayName("nullableBothRight")]
+        public abstract BigInteger? NullableBothRight(BigInteger? value, BigInteger? count);
+
+        [DisplayName("nullLeftEvaluationCount")]
+        public abstract BigInteger? NullLeftEvaluationCount();
 
         [DisplayName("compoundInt")]
         public abstract BigInteger? CompoundInt(BigInteger? value, BigInteger? count);


### PR DESCRIPTION
## Summary

- return null when either operand of a lifted shift is null
- preserve left-to-right, exactly-once operand evaluation
- retain fixed-width shift masking and normalization for non-null values

## Validation

- 1,497 compiler tests passed
- focused tests passed under None, Basic, and All optimization modes
- covered left and right shifts, nullable counts, null propagation, and side effects
- format verification passed

Related to #1841.