### PR TITLE
Analyze unsupported collection spread elements

### DIFF
--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -3,6 +3,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|------------------------------------------------
 NC4060  | Method   | Error    | BitOperationsUsageAnalyzer
+NC4062  | Syntax   | Error    | CollectionSpreadUsageAnalyzer
 NC2010  | Syntax   | Error    | ArrayRangeUsageAnalyzer
 NC4061  | Syntax   | Error    | ExtendedPropertyPatternAnalyzer
 

--- a/src/Neo.SmartContract.Analyzer/CollectionSpreadUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/CollectionSpreadUsageAnalyzer.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CollectionSpreadUsageAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Neo.SmartContract.Analyzer;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CollectionSpreadUsageAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NC4062";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Collection spread elements are not supported",
+        "Collection spread element '{0}' is not supported; construct the collection explicitly",
+        "Syntax",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Reports collection-expression spread elements before they reach unsupported Neo compiler lowering.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeSpreadElement, SyntaxKind.SpreadElement);
+    }
+
+    private static void AnalyzeSpreadElement(SyntaxNodeAnalysisContext context)
+    {
+        var spread = (SpreadElementSyntax)context.Node;
+        context.ReportDiagnostic(Diagnostic.Create(Rule, spread.GetLocation(), spread.ToString()));
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/CollectionSpreadUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/CollectionSpreadUsageAnalyzerUnitTests.cs
@@ -1,0 +1,51 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CollectionSpreadUsageAnalyzerUnitTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.CollectionSpreadUsageAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests;
+
+[TestClass]
+public class CollectionSpreadUsageAnalyzerUnitTests
+{
+    [TestMethod]
+    public async Task SpreadElement_ShouldReportDiagnostic()
+    {
+        var test = """
+                   class Test
+                   {
+                       int[] Clone(int[] values) => [{|#0:..values|}];
+                   }
+                   """;
+
+        var expected = VerifyCS.Diagnostic(CollectionSpreadUsageAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("..values");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task ExplicitCollectionElements_ShouldNotReportDiagnostic()
+    {
+        var test = """
+                   class Test
+                   {
+                       int[] Create(int first, int second) => [first, second];
+                   }
+                   """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
## Summary
- report NC4062 for collection-expression spread elements
- stop valid C# spread syntax before unsupported compiler lowering
- keep explicit collection elements supported

## Validation
- 301 analyzer tests passed
- focused format verification passed
- `nccs` reports NC4062 for `[..values]`

Part of #1841.
