### PR TITLE
Analyze unsupported extended property patterns

### DIFF
--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -4,6 +4,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|------------------------------------------------
 NC4060  | Method   | Error    | BitOperationsUsageAnalyzer
 NC2010  | Syntax   | Error    | ArrayRangeUsageAnalyzer
+NC4061  | Syntax   | Error    | ExtendedPropertyPatternAnalyzer
 
 ### Removed Rules
 

--- a/src/Neo.SmartContract.Analyzer/ExtendedPropertyPatternAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/ExtendedPropertyPatternAnalyzer.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExtendedPropertyPatternAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Neo.SmartContract.Analyzer;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ExtendedPropertyPatternAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NC4061";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Extended property patterns are not supported",
+        "Extended property pattern '{0}' is not supported; use nested property patterns instead",
+        "Syntax",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Reports dotted property names in recursive patterns before they reach unsupported Neo compiler lowering.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeSubpattern, SyntaxKind.Subpattern);
+    }
+
+    private static void AnalyzeSubpattern(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not SubpatternSyntax
+            {
+                ExpressionColon: { Expression: MemberAccessExpressionSyntax expression }
+            })
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, expression.GetLocation(), expression.ToString()));
+    }
+}

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/ExtendedPropertyPatternAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/ExtendedPropertyPatternAnalyzerUnitTests.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// ExtendedPropertyPatternAnalyzerUnitTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.ExtendedPropertyPatternAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests;
+
+[TestClass]
+public class ExtendedPropertyPatternAnalyzerUnitTests
+{
+    [TestMethod]
+    public async Task ExtendedPropertyPattern_ShouldReportDiagnostic()
+    {
+        var test = """
+                   class Inner { public int Value { get; set; } }
+                   class Holder { public Inner Inner { get; set; } = new(); }
+
+                   class Test
+                   {
+                       bool Match(Holder holder) => holder is { {|#0:Inner.Value|}: 5 };
+                   }
+                   """;
+
+        var expected = VerifyCS.Diagnostic(ExtendedPropertyPatternAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Inner.Value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task NestedPropertyPattern_ShouldNotReportDiagnostic()
+    {
+        var test = """
+                   class Inner { public int Value { get; set; } }
+                   class Holder { public Inner Inner { get; set; } = new(); }
+
+                   class Test
+                   {
+                       bool Match(Holder holder) => holder is { Inner: { Value: 5 } };
+                   }
+                   """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
## Summary
- report NC4061 for unsupported extended property patterns
- point the diagnostic at the dotted property path
- keep nested property patterns available as the supported replacement

## Validation
- 301 analyzer tests passed
- focused format verification passed
- `nccs` reports NC4061 for `{ Inner.Value: 5 }`

Part of #1841.
