### PR TITLE
Test UTF-8 string offset semantics

### DIFF
--- a/docs/csharp-syntax/SemanticDifferences.md
+++ b/docs/csharp-syntax/SemanticDifferences.md
@@ -46,6 +46,8 @@ Examples:
 
 This keeps contract execution deterministic and avoids culture-dependent behavior.
 
+NeoVM stores contract strings as UTF-8 byte strings. As a result, string `Length`, indexing, and slicing use encoded byte offsets instead of the UTF-16 code-unit offsets used by .NET. For example, `"é".Length` evaluates to `2` on NeoVM instead of `1`, and `"é"[0]` returns the first encoded byte (`195`) instead of the .NET character value (`233`). Contracts that may process non-ASCII text should choose explicit byte-oriented behavior or constrain and validate their input.
+
 ## `typeof`
 
 `typeof(T)` does not produce a .NET `System.Type` object in Neo contract code. The compiler lowers the expression to the simple type name string, for example `typeof(int)` becomes `"Int32"`.

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Utf8StringSemantics.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Utf8StringSemantics.cs
@@ -1,0 +1,71 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UnitTest_Utf8StringSemantics.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_Utf8StringSemantics
+{
+    private const string Source = """
+        using Neo.SmartContract.Framework;
+        using System.ComponentModel;
+
+        public class Contract : SmartContract
+        {
+            [DisplayName("length")]
+            public static int Length(string value) => value.Length;
+
+            [DisplayName("first")]
+            public static int First(string value) => value[0];
+        }
+        """;
+
+    [TestMethod]
+    public void NonAsciiStringOffsets_ShouldUseDocumentedUtf8Semantics()
+    {
+        Assert.AreEqual(1, "é".Length);
+        Assert.AreEqual(2, "😀".Length);
+        Assert.AreEqual(233, "é"[0]);
+        Assert.AreEqual(55357, "😀"[0]);
+
+        var context = TestHelper.CompileSingleContract(Source);
+        Assert.IsTrue(
+            context.Success,
+            string.Join(Environment.NewLine, context.Diagnostics.Select(static item => item.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<Utf8StringContract>(
+            context.CreateExecutable(),
+            context.CreateManifest());
+
+        Assert.AreEqual(new BigInteger(2), contract.Length("é"));
+        Assert.AreEqual(new BigInteger(4), contract.Length("😀"));
+        Assert.AreEqual(new BigInteger(195), contract.First("é"));
+        Assert.AreEqual(new BigInteger(240), contract.First("😀"));
+    }
+
+    public abstract class Utf8StringContract(SmartContractInitialize initialize)
+        : SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("length")]
+        public abstract BigInteger? Length(string? value);
+
+        [DisplayName("first")]
+        public abstract BigInteger? First(string? value);
+    }
+}


### PR DESCRIPTION
## Summary
- document that NeoVM string length, indexing, and slicing use UTF-8 byte offsets
- add differential execution coverage for BMP and supplementary Unicode characters
- make the current semantic boundary explicit for contract developers

## Validation
- .NET control values: 1, 2, 233, and 55357
- NeoVM execution values: 2, 4, 195, and 240
- focused format verification passed

Part of #1841.
