### PR TITLE
Warn about captured foreach variable semantics

### DIFF
--- a/docs/csharp-syntax/SemanticDifferences.md
+++ b/docs/csharp-syntax/SemanticDifferences.md
@@ -55,3 +55,9 @@ This behavior exists primarily so supported enum helpers such as `Enum.Parse(typ
 Guidance:
 - Do not use `typeof` for .NET reflection or `System.Type` behavior in contracts. Reflection is outside the supported contract surface.
 - Treat direct `typeof` results as Neo string semantics, not standard .NET type metadata.
+
+## Lambdas that capture `foreach` variables
+
+Neo currently stores captured local variables in shared contract fields. A lambda created inside a `foreach` loop therefore observes the most recently assigned iteration value when it is invoked after the loop. Standard C# creates a distinct captured variable for each iteration.
+
+The analyzer reports `NC4063` when a lambda references its enclosing `foreach` variable. Avoid retaining that lambda across iterations; compute the value eagerly or pass it explicitly instead.

--- a/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/Neo.SmartContract.Analyzer/AnalyzerReleases.Unshipped.md
@@ -2,6 +2,7 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|------------------------------------------------
+NC4063  | Usage    | Warning  | CapturedForeachVariableAnalyzer
 NC4060  | Method   | Error    | BitOperationsUsageAnalyzer
 NC2010  | Syntax   | Error    | ArrayRangeUsageAnalyzer
 

--- a/src/Neo.SmartContract.Analyzer/CapturedForeachVariableAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/CapturedForeachVariableAnalyzer.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CapturedForeachVariableAnalyzer.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Neo.SmartContract.Analyzer;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CapturedForeachVariableAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NC4063";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Captured foreach variables use Neo-specific semantics",
+        "Lambda captures foreach variable '{0}', whose value is shared across iterations on NeoVM",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Warns when a retained lambda can observe the last foreach value instead of C# per-iteration capture semantics.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            AnalyzeLambda,
+            SyntaxKind.SimpleLambdaExpression,
+            SyntaxKind.ParenthesizedLambdaExpression);
+    }
+
+    private static void AnalyzeLambda(SyntaxNodeAnalysisContext context)
+    {
+        var lambda = (LambdaExpressionSyntax)context.Node;
+        var foreachVariables = GetEnclosingForeachVariables(context, lambda);
+        if (foreachVariables.Count == 0)
+        {
+            return;
+        }
+
+        var reportedVariables = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        foreach (var identifier in lambda.Body
+            .DescendantNodesAndSelf(static node => node is not AnonymousFunctionExpressionSyntax)
+            .OfType<IdentifierNameSyntax>())
+        {
+            if (IsInsideNameof(identifier))
+            {
+                continue;
+            }
+
+            var symbol = context.SemanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol;
+            if (symbol is not ILocalSymbol local ||
+                !foreachVariables.Any(candidate => SymbolEqualityComparer.Default.Equals(candidate, local)) ||
+                !reportedVariables.Add(local))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, identifier.GetLocation(), local.Name));
+        }
+    }
+
+    private static List<ILocalSymbol> GetEnclosingForeachVariables(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda)
+    {
+        var variables = new List<ILocalSymbol>();
+        foreach (var statement in lambda.Ancestors().OfType<CommonForEachStatementSyntax>())
+        {
+            switch (statement)
+            {
+                case ForEachStatementSyntax simple
+                    when context.SemanticModel.GetDeclaredSymbol(simple, context.CancellationToken) is { } symbol:
+                    variables.Add(symbol);
+                    break;
+                case ForEachVariableStatementSyntax deconstruction:
+                    variables.AddRange(deconstruction.Variable
+                        .DescendantNodesAndSelf()
+                        .OfType<SingleVariableDesignationSyntax>()
+                        .Select(designation => context.SemanticModel.GetDeclaredSymbol(
+                            designation,
+                            context.CancellationToken))
+                        .OfType<ILocalSymbol>());
+                    break;
+            }
+        }
+
+        return variables;
+    }
+
+    private static bool IsInsideNameof(SyntaxNode node) =>
+        node.Ancestors().OfType<InvocationExpressionSyntax>().Any(static invocation =>
+            invocation.Expression is IdentifierNameSyntax { Identifier.ValueText: "nameof" });
+}

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Lambda.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Lambda.cs
@@ -87,6 +87,7 @@ namespace Neo.Compiler.CSharp.TestContracts
         /// </summary>
         /// <param name="array"></param>
         /// <returns></returns>
+#pragma warning disable NC4063 // Intentional NeoVM foreach-capture behavior under test.
         public static SmartContract.Framework.List<int> ForEachVar(int[] array)
         {
             var list = new SmartContract.Framework.List<Func<int>>();
@@ -102,6 +103,7 @@ namespace Neo.Compiler.CSharp.TestContracts
             }
             return result;
         }
+#pragma warning restore NC4063
 
         /// <summary>
         /// Use last value in for, different from C# behavior

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/CapturedForeachVariableAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/CapturedForeachVariableAnalyzerUnitTests.cs
@@ -1,0 +1,144 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// CapturedForeachVariableAnalyzerUnitTests.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.AnalyzerVerifier<
+    Neo.SmartContract.Analyzer.CapturedForeachVariableAnalyzer>;
+
+namespace Neo.SmartContract.Analyzer.UnitTests;
+
+[TestClass]
+public class CapturedForeachVariableAnalyzerUnitTests
+{
+    [TestMethod]
+    public async Task LambdaCapturingForeachVariable_ShouldReportDiagnostic()
+    {
+        var test = """
+                   using System;
+                   using System.Collections.Generic;
+
+                   class Test
+                   {
+                       List<Func<int>> Capture(int[] values)
+                       {
+                           var callbacks = new List<Func<int>>();
+                           foreach (int value in values)
+                           {
+                               callbacks.Add(() => {|#0:value|});
+                           }
+
+                           return callbacks;
+                       }
+                   }
+                   """;
+
+        var expected = VerifyCS.Diagnostic(CapturedForeachVariableAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task RepeatedReferences_ShouldReportOneDiagnosticPerLambda()
+    {
+        var test = """
+                   using System;
+                   using System.Collections.Generic;
+
+                   class Test
+                   {
+                       List<Func<int>> Capture(int[] values)
+                       {
+                           var callbacks = new List<Func<int>>();
+                           foreach (int value in values)
+                           {
+                               callbacks.Add(() => {|#0:value|} + value);
+                           }
+
+                           return callbacks;
+                       }
+                   }
+                   """;
+
+        var expected = VerifyCS.Diagnostic(CapturedForeachVariableAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("value");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task LambdaWithoutForeachCapture_ShouldNotReportDiagnostic()
+    {
+        var test = """
+                   using System;
+                   using System.Collections.Generic;
+
+                   class Test
+                   {
+                       List<Func<int>> Create(int[] values)
+                       {
+                           var callbacks = new List<Func<int>>();
+                           foreach (int value in values)
+                           {
+                               callbacks.Add(() => 42);
+                           }
+
+                           return callbacks;
+                       }
+                   }
+                   """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [TestMethod]
+    public async Task LambdaOutsideForeach_ShouldNotReportDiagnostic()
+    {
+        var test = """
+                   using System;
+
+                   class Test
+                   {
+                       Func<int> Capture(int value) => () => value;
+                   }
+                   """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [TestMethod]
+    public async Task NameofForeachVariable_ShouldNotReportDiagnostic()
+    {
+        var test = """
+                   using System;
+                   using System.Collections.Generic;
+
+                   class Test
+                   {
+                       List<Func<int>> Create(int[] values)
+                       {
+                           var callbacks = new List<Func<int>>();
+                           foreach (int value in values)
+                           {
+                               callbacks.Add(() => nameof(value).Length);
+                           }
+
+                           return callbacks;
+                       }
+                   }
+                   """;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
## Summary
- report NC4063 when a lambda captures an enclosing `foreach` variable
- emit one warning per captured variable and ignore compile-time `nameof` references
- document NeoVM's shared captured-slot behavior and practical guidance

## Validation
- 304 analyzer tests passed
- focused format verification passed
- `nccs` reports NC4063 while still producing the NEF and manifest

Part of #1841.
