### PR TITLE
Fix: the result consumed by JMPIF

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Char.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Char.cs
@@ -402,12 +402,17 @@ internal partial class MethodConvert
         JumpTarget endTarget = new();
         methodConvert.Dup();                                       // Duplicate character for digit check
         methodConvert.Within((ushort)'0', (ushort)'9');            // Check if within digit range
+        methodConvert.Dup();                                       // Dup the result, because JMPIF will pop the top of the stack
         methodConvert.JumpIfTrue(endTarget);                       // Jump if is digit
+        methodConvert.Drop();                                      // Drop the result if false
         methodConvert.Dup();                                       // Duplicate character for uppercase check
         methodConvert.Within((ushort)'A', (ushort)'Z');            // Check if within uppercase range
+        methodConvert.Dup();                                       // Dup the result, because JMPIF will pop the top of the stack
         methodConvert.JumpIfTrue(endTarget);                       // Jump if is uppercase
+        methodConvert.Drop();                                      // Drop the result if false
+        methodConvert.Dup();                                       // Duplicate character for lowercase check
         methodConvert.Within((ushort)'a', (ushort)'z');            // Check if within lowercase range
-        endTarget.Instruction = methodConvert.Nop();               // End target
+        endTarget.Instruction = methodConvert.Nip();               // Drop the input character to consume it
     }
 
     /// <summary>

--- a/tests/Neo.Compiler.CSharp.TestContracts/Contract_Char.cs
+++ b/tests/Neo.Compiler.CSharp.TestContracts/Contract_Char.cs
@@ -33,6 +33,12 @@ public class Contract_Char : SmartContract.Framework.SmartContract
         return char.IsLetterOrDigit(c);
     }
 
+    public static bool TestCharIsLetterOrDigitResult(char c)
+    {
+        object r = char.IsLetterOrDigit(c);
+        return r is bool;
+    }
+
     public static bool TestCharIsAsciiLetter(char c)
     {
         return char.IsAsciiLetter(c);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Char.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Char"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testCharIsDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testCharIsLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testCharIsWhiteSpace"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""testCharIsLetterOrDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testCharIsAsciiLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":68,""safe"":false},{""name"":""testCharIsLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":86,""safe"":false},{""name"":""testCharToLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":96,""safe"":false},{""name"":""testCharIsUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":112,""safe"":false},{""name"":""testCharToUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":122,""safe"":false},{""name"":""testCharToUpperInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":138,""safe"":false},{""name"":""testCharToLowerInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":154,""safe"":false},{""name"":""testCharGetNumericValue"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":170,""safe"":false},{""name"":""testCharIsPunctuation"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":189,""safe"":false},{""name"":""testCharIsSymbol"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":224,""safe"":false},{""name"":""testCharIsControl"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":259,""safe"":false},{""name"":""testCharIsSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":277,""safe"":false},{""name"":""testCharIsHighSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":307,""safe"":false},{""name"":""testCharIsLowSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":323,""safe"":false},{""name"":""testCharIsBetween"",""parameters"":[{""name"":""c"",""type"":""Integer""},{""name"":""lower"",""type"":""Integer""},{""name"":""upper"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":339,""safe"":false},{""name"":""testCharParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":358,""safe"":false},{""name"":""testCharTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Array"",""offset"":376,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":413,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Char"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testCharIsDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testCharIsLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testCharIsWhiteSpace"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""testCharIsLetterOrDigit"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testCharIsLetterOrDigitResult"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":74,""safe"":false},{""name"":""testCharIsAsciiLetter"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":110,""safe"":false},{""name"":""testCharIsLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":128,""safe"":false},{""name"":""testCharToLower"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":138,""safe"":false},{""name"":""testCharIsUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":154,""safe"":false},{""name"":""testCharToUpper"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":164,""safe"":false},{""name"":""testCharToUpperInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":180,""safe"":false},{""name"":""testCharToLowerInvariant"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":196,""safe"":false},{""name"":""testCharGetNumericValue"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":212,""safe"":false},{""name"":""testCharIsPunctuation"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":231,""safe"":false},{""name"":""testCharIsSymbol"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":266,""safe"":false},{""name"":""testCharIsControl"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":301,""safe"":false},{""name"":""testCharIsSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":319,""safe"":false},{""name"":""testCharIsHighSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":349,""safe"":false},{""name"":""testCharIsLowSurrogate"",""parameters"":[{""name"":""c"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":365,""safe"":false},{""name"":""testCharIsBetween"",""parameters"":[{""name"":""c"",""type"":""Integer""},{""name"":""lower"",""type"":""Integer""},{""name"":""upper"",""type"":""Integer""}],""returntype"":""Boolean"",""offset"":381,""safe"":false},{""name"":""testCharParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Integer"",""offset"":400,""safe"":false},{""name"":""testCharTryParse"",""parameters"":[{""name"":""value"",""type"":""String""}],""returntype"":""Array"",""offset"":418,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":455,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2gAVcAAXgAMAA6u0BXAAF4SgBBAFu7UABhAHu7rEBXAAF4Shkeu1AAILOsQFcAAXhKADAAOrskD0oAQQBbuyQHAGEAe7tAVwABeEoAQQBbu1AAYQB7u6xAVwABeABhAHu7QFcAAXhKAEEAW7smBQAgnkBXAAF4AEEAW7tAVwABeEoAYQB7uyYFACCfQFcAAXhKAGEAe7smBQAgn0BXAAF4SgBBAFu7JgUAIJ5AVwABeEoAMAA6uyQFRQ9AADCfQFcAAXhKAH8sGQQAAAAA7vcAjAEAALgAAAAoEVGokbFARQlAVwABeEoAfywZBAAAAAAQCABwAAAAQAEAAFARUaiRsUBFCUBXAAF4ShAAILtQAH8BoAC7rEBXAAF4SgIA2AAAAgDcAAC7UAIA3AAAAgDgAAC7rEBXAAF4AgDYAAACANwAALtAVwABeAIA3AAAAgDgAAC7QFcAA3p5eEpRuEomBlNFRUBFtUBXAAF4StgmAzpKyhEoAzoQzkBXAQEQSmF4UEVK2CQNSsoRKggQzmAIIgZFEGAJWGFwaFlQEr9AVgJAzqGC/g==").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP3KAVcAAXgAMAA6u0BXAAF4SgBBAFu7UABhAHu7rEBXAAF4Shkeu1AAILOsQFcAAXhKADAAOrtKJBNFSgBBAFu7SiQJRUoAYQB7u0ZAVwEBeEoAMAA6u0okE0VKAEEAW7tKJAlFSgBhAHu7RnBo2SBAVwABeEoAQQBbu1AAYQB7u6xAVwABeABhAHu7QFcAAXhKAEEAW7smBQAgnkBXAAF4AEEAW7tAVwABeEoAYQB7uyYFACCfQFcAAXhKAGEAe7smBQAgn0BXAAF4SgBBAFu7JgUAIJ5AVwABeEoAMAA6uyQFRQ9AADCfQFcAAXhKAH8sGQQAAAAA7vcAjAEAALgAAAAoEVGokbFARQlAVwABeEoAfywZBAAAAAAQCABwAAAAQAEAAFARUaiRsUBFCUBXAAF4ShAAILtQAH8BoAC7rEBXAAF4SgIA2AAAAgDcAAC7UAIA3AAAAgDgAAC7rEBXAAF4AgDYAAACANwAALtAVwABeAIA3AAAAgDgAAC7QFcAA3p5eEpRuEomBlNFRUBFtUBXAAF4StgmAzpKyhEoAzoQzkBXAQEQSmF4UEVK2CQNSsoRKggQzmAIIgZFEGAJWGFwaFlQEr9AVgJAMaO+hA==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -168,26 +168,66 @@ public abstract class Contract_Char(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeEoAMAA6uyQPSgBBAFu7JAcAYQB7u0A=
+    /// Script: VwABeEoAMAA6u0okE0VKAEEAW7tKJAlFSgBhAHu7RkA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// DUP [2 datoshi]
     /// PUSHINT8 30 [1 datoshi]
     /// PUSHINT8 3A [1 datoshi]
     /// WITHIN [8 datoshi]
-    /// JMPIF 0F [2 datoshi]
+    /// DUP [2 datoshi]
+    /// JMPIF 13 [2 datoshi]
+    /// DROP [2 datoshi]
     /// DUP [2 datoshi]
     /// PUSHINT8 41 [1 datoshi]
     /// PUSHINT8 5B [1 datoshi]
     /// WITHIN [8 datoshi]
-    /// JMPIF 07 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// JMPIF 09 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// DUP [2 datoshi]
     /// PUSHINT8 61 [1 datoshi]
     /// PUSHINT8 7B [1 datoshi]
     /// WITHIN [8 datoshi]
+    /// NIP [2 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testCharIsLetterOrDigit")]
     public abstract bool? TestCharIsLetterOrDigit(BigInteger? c);
+
+    /// <summary>
+    /// Unsafe method
+    /// </summary>
+    /// <remarks>
+    /// Script: VwEBeEoAMAA6u0okE0VKAEEAW7tKJAlFSgBhAHu7RnBo2SBA
+    /// INITSLOT 0101 [64 datoshi]
+    /// LDARG0 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT8 30 [1 datoshi]
+    /// PUSHINT8 3A [1 datoshi]
+    /// WITHIN [8 datoshi]
+    /// DUP [2 datoshi]
+    /// JMPIF 13 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT8 41 [1 datoshi]
+    /// PUSHINT8 5B [1 datoshi]
+    /// WITHIN [8 datoshi]
+    /// DUP [2 datoshi]
+    /// JMPIF 09 [2 datoshi]
+    /// DROP [2 datoshi]
+    /// DUP [2 datoshi]
+    /// PUSHINT8 61 [1 datoshi]
+    /// PUSHINT8 7B [1 datoshi]
+    /// WITHIN [8 datoshi]
+    /// NIP [2 datoshi]
+    /// STLOC0 [2 datoshi]
+    /// LDLOC0 [2 datoshi]
+    /// ISTYPE 20 'Boolean' [2 datoshi]
+    /// RET [0 datoshi]
+    /// </remarks>
+    [DisplayName("testCharIsLetterOrDigitResult")]
+    public abstract bool? TestCharIsLetterOrDigitResult(BigInteger? c);
 
     /// <summary>
     /// Unsafe method

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Char.cs
@@ -190,6 +190,11 @@ namespace Neo.Compiler.CSharp.UnitTests
             AssertGasConsumed(1047450);
             Assert.IsFalse(Contract.TestCharIsLetterOrDigit('$'));
             AssertGasConsumed(1048170);
+
+            Assert.IsTrue(Contract.TestCharIsLetterOrDigitResult('b'));
+            Assert.IsTrue(Contract.TestCharIsLetterOrDigitResult('B'));
+            Assert.IsTrue(Contract.TestCharIsLetterOrDigitResult('1'));
+            Assert.IsTrue(Contract.TestCharIsLetterOrDigitResult('\0'));
         }
 
         [TestMethod]


### PR DESCRIPTION

This PR is a fix for `char.IsLetterOrDigit`:
* Drop the input char in the end;
* Dup the result, because JMPIF will pop the top of the stack;