### PR TITLE
Fix: diagnose qualified System.Linq usage

### DIFF
--- a/src/Neo.SmartContract.Analyzer/LinqUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/LinqUsageAnalyzer.cs
@@ -50,16 +50,46 @@ namespace Neo.SmartContract.Analyzer
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxNodeAction(AnalyzeUsingDirective, SyntaxKind.UsingDirective);
+            context.RegisterSyntaxNodeAction(AnalyzeMemberAccess, SyntaxKind.SimpleMemberAccessExpression);
         }
 
         private void AnalyzeUsingDirective(SyntaxNodeAnalysisContext context)
         {
             var usingDirective = (UsingDirectiveSyntax)context.Node;
-            if (usingDirective.Name!.ToString() == "System.Linq")
+            var symbol = context.SemanticModel.GetSymbolInfo(usingDirective.Name!, context.CancellationToken).Symbol;
+            if (!IsSystemLinqSymbol(symbol)) return;
+
+            var diagnostic = Diagnostic.Create(Rule, usingDirective.GetLocation(), usingDirective.Name);
+            context.ReportDiagnostic(diagnostic);
+        }
+
+        private void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
+        {
+            var memberAccess = (MemberAccessExpressionSyntax)context.Node;
+            if (context.SemanticModel.GetAliasInfo(memberAccess.Expression, context.CancellationToken) is not null)
+                return;
+
+            var receiver = context.SemanticModel.GetSymbolInfo(memberAccess.Expression, context.CancellationToken).Symbol;
+            if (!IsSystemLinqSymbol(receiver)) return;
+
+            var member = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
+            if (member is null or INamespaceSymbol or INamedTypeSymbol) return;
+
+            var diagnostic = Diagnostic.Create(Rule, memberAccess.Name.GetLocation(), member.ToDisplayString());
+            context.ReportDiagnostic(diagnostic);
+        }
+
+        private static bool IsSystemLinqSymbol(ISymbol? symbol)
+        {
+            var namespaceName = symbol switch
             {
-                var diagnostic = Diagnostic.Create(Rule, usingDirective.GetLocation(), usingDirective.Name);
-                context.ReportDiagnostic(diagnostic);
-            }
+                INamespaceSymbol namespaceSymbol => namespaceSymbol.ToDisplayString(),
+                INamedTypeSymbol typeSymbol => typeSymbol.ContainingNamespace.ToDisplayString(),
+                _ => null
+            };
+
+            return namespaceName == "System.Linq" ||
+                namespaceName?.StartsWith("System.Linq.", System.StringComparison.Ordinal) == true;
         }
     }
 
@@ -76,8 +106,9 @@ namespace Neo.SmartContract.Analyzer
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-            var usingDirective = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<UsingDirectiveSyntax>().First();
-            if (usingDirective != null)
+            var usingDirective = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<UsingDirectiveSyntax>().FirstOrDefault();
+            if (usingDirective is { Alias: null, StaticKeyword.RawKind: 0 } &&
+                usingDirective.Name?.ToString() == "System.Linq")
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/LinqUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/LinqUsageAnalyzerUnitTests.cs
@@ -64,6 +64,82 @@ namespace Neo.SmartContract.Framework.Linq
         }
 
         [TestMethod]
+        public async Task FullyQualifiedSystemLinqCall_ShouldReportDiagnostic()
+        {
+            var test = """
+                       class TestClass
+                       {
+                           public int[] Run(int[] values) => System.Linq.Enumerable.{|#0:ToArray|}(values);
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic(LinqUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("System.Linq.Enumerable.ToArray<int>(System.Collections.Generic.IEnumerable<int>)");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task AliasedSystemLinqType_ShouldReportDiagnosticAtUsing()
+        {
+            var test = """
+                       {|#0:using Linq = System.Linq.Enumerable;|}
+
+                       class TestClass
+                       {
+                           public int[] Run(int[] values) => Linq.ToArray(values);
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic(LinqUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("System.Linq.Enumerable");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task StaticSystemLinqUsing_ShouldReportDiagnostic()
+        {
+            var test = """
+                       {|#0:using static System.Linq.Enumerable;|}
+
+                       class TestClass
+                       {
+                           public System.Collections.Generic.IEnumerable<int> Run() => Range(0, 1);
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic(LinqUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("System.Linq.Enumerable");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task UserDefinedEnumerableType_ShouldNotReportDiagnostic()
+        {
+            var test = """
+                       namespace Example
+                       {
+                           public static class Enumerable
+                           {
+                               public static int Count(int[] values) => values.Length;
+                           }
+                       }
+
+                       class TestClass
+                       {
+                           public int Run(int[] values) => Example.Enumerable.Count(values);
+                       }
+                       """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
         public async Task QueryExpression_DoesNotSuggestFrameworkUsing()
         {
             var test = """


### PR DESCRIPTION
## Summary

- resolve System.Linq imports semantically, including alias and static imports
- diagnose fully qualified System.Linq member access without duplicate diagnostics
- offer the existing import replacement only for ordinary System.Linq imports

## Validation

- 313 analyzer tests passed
- focused format verification passed
- `git diff --check` passed

Part of #1841.