### PR TITLE
Test: bind unsupported syntax probes to diagnostic IDs

### DIFF
--- a/tests/Neo.Compiler.CSharp.UnitTests/SyntaxProbes/Helper.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SyntaxProbes/Helper.cs
@@ -144,7 +144,8 @@ internal static class Helper
             expectSuccess,
             message,
             requireAnalyzerError: true,
-            allowCompilerErrors: CompilerFrontEndRejectedProbeIds.Contains(probe.Id));
+            allowCompilerErrors: CompilerFrontEndRejectedProbeIds.Contains(probe.Id),
+            expectedErrorIds: expectSuccess ? null : SyntaxProbeExpectedDiagnostics.Get(probe.Id));
     }
 
     private static void AssertCompilationResult(
@@ -152,7 +153,8 @@ internal static class Helper
         bool expectSuccess,
         string message,
         bool requireAnalyzerError = false,
-        bool allowCompilerErrors = true)
+        bool allowCompilerErrors = true,
+        IReadOnlyList<string>? expectedErrorIds = null)
     {
         var (compilerDiagnostics, analyzerDiagnostics) = AnalyzeSource(sourceCode);
         var compilerErrors = compilerDiagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -197,6 +199,24 @@ internal static class Helper
 
         if (!expectSuccess)
         {
+            if (expectedErrorIds is not null)
+            {
+                var actualErrorIds = compilerErrors
+                    .Concat(analyzerErrors)
+                    .Select(static diagnostic => diagnostic.Id)
+                    .ToHashSet(StringComparer.Ordinal);
+                var missingErrorIds = expectedErrorIds
+                    .Where(expectedId => !actualErrorIds.Contains(expectedId))
+                    .ToArray();
+                if (missingErrorIds.Length != 0)
+                {
+                    Assert.Fail(
+                        $"{message}{Environment.NewLine}" +
+                        $"Expected diagnostic IDs: {string.Join(", ", expectedErrorIds)}{Environment.NewLine}" +
+                        $"Actual diagnostic IDs: {string.Join(", ", actualErrorIds.OrderBy(static id => id, StringComparer.Ordinal))}");
+                }
+            }
+
             if (analyzerErrors.Length != 0)
             {
                 return;

--- a/tests/Neo.Compiler.CSharp.UnitTests/SyntaxProbes/SyntaxProbeExpectedDiagnostics.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SyntaxProbes/SyntaxProbeExpectedDiagnostics.cs
@@ -1,0 +1,71 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// SyntaxProbeExpectedDiagnostics.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System;
+using System.Collections.Generic;
+
+namespace Neo.Compiler.CSharp.UnitTests.Syntax;
+
+internal static class SyntaxProbeExpectedDiagnostics
+{
+    private static readonly IReadOnlyDictionary<string, string[]> ExpectedByProbe =
+        new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["unsafe_code"] = ["NC4033"],
+            ["numerics_bit_operations"] = ["NC4060"],
+            ["datetime_methods"] = ["NC4058"],
+            ["timespan_methods"] = ["NC4058"],
+            ["convert_methods"] = ["NC4058"],
+            ["anonymous_method"] = ["NC4034"],
+            ["iterator_block"] = ["NC4035"],
+            ["query_expression"] = ["NC4036"],
+            ["dynamic_binding"] = ["NC4037"],
+            ["async_method"] = ["NC4038"],
+            ["await_expression"] = ["NC4039"],
+            ["exception_filter"] = ["NC4040"],
+            ["local_function"] = ["NC4042"],
+            ["ref_return"] = ["NC4042"],
+            ["ref_argument_array_element"] = ["NC4010"],
+            ["ref_argument_span_element"] = ["NC4010"],
+            ["range_on_general_arrays"] = ["NC2010"],
+            ["using_declaration"] = ["NC4059"],
+            ["async_streams"] = ["NC4045"],
+            ["native_int"] = ["NC4046"],
+            ["top_level_statements"] = ["NC4047"],
+            ["function_pointer"] = ["NC4048"],
+            ["global_using"] = ["NC4049"],
+            ["extended_property_pattern"] = ["NC4061"],
+            ["list_patterns"] = ["NC4050"],
+            ["utf_8_string_literals"] = ["NC4051"],
+            ["file_local_types"] = ["NC4053"],
+            ["numeric_intptr_and_uintptr"] = ["NC4046"],
+            ["collection_expression_spread_elements"] = ["NC4062"],
+            ["ref_readonly_parameters"] = ["NC4054"],
+            ["interceptors"] = ["CS0246"],
+            ["new_lock_object"] = ["NC4015"],
+            ["ref_and_unsafe_in_iterators_and_async_methods"] = ["NC4038"],
+            ["extension_types"] = ["CS9283"],
+            ["shape_constraints"] = ["CS0246"],
+            ["discriminated_union_types"] = ["CS0246"],
+            ["lambda_default_parameters"] = ["CS1746"],
+            ["span_arraysegment_conversions"] = ["NC4013"],
+            ["lambda_parameter_modifiers"] = ["CS8171"],
+            ["partial_events_constructors"] = ["CS0079"],
+            ["user_defined_compound_assignment"] = ["CS0019"]
+        };
+
+    internal static IEnumerable<string> ProbeIds => ExpectedByProbe.Keys;
+
+    internal static IReadOnlyList<string> Get(string probeId) =>
+        ExpectedByProbe.TryGetValue(probeId, out var diagnostics)
+            ? diagnostics
+            : throw new InvalidOperationException($"Unsupported syntax probe '{probeId}' has no expected diagnostic ID.");
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/SyntaxProbes/SyntaxTests.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/SyntaxProbes/SyntaxTests.cs
@@ -51,6 +51,20 @@ public class SyntaxTests
     }
 
     [TestMethod]
+    public void EveryUnsupportedProbe_HasExpectedDiagnosticIds()
+    {
+        var unsupportedProbeIds = Probes
+            .Where(static probe => probe.Status == SyntaxSupportStatus.Unsupported)
+            .Select(static probe => probe.Id)
+            .ToArray();
+
+        CollectionAssert.AreEquivalent(
+            unsupportedProbeIds,
+            SyntaxProbeExpectedDiagnostics.ProbeIds.ToArray(),
+            "Expected diagnostic mappings must match unsupported syntax probes exactly.");
+    }
+
+    [TestMethod]
     public void Unsupported_Syntax_Summary_Is_UpToDate()
     {
         var unsupportedIds = Probes


### PR DESCRIPTION
## Summary

- record the expected diagnostic ID for all 41 unsupported syntax probes
- require those diagnostics during syntax probe validation
- fail when the unsupported probe inventory and diagnostic mappings drift

## Validation

- 140 syntax tests passed
- focused format verification passed
- `git diff --check` passed

Part of #1841.