### PR TITLE
Fix: diagnose floating-point casts and literals

### DIFF
--- a/src/Neo.SmartContract.Analyzer/DecimalUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DecimalUsageAnalyzer.cs
@@ -40,6 +40,14 @@ namespace Neo.SmartContract.Analyzer
             context.EnableConcurrentExecution();
             context.RegisterOperationAction(AnalyzeOperation, OperationKind.VariableDeclaration);
             context.RegisterSyntaxNodeAction(
+                static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzeExpression(
+                    context,
+                    SpecialType.System_Decimal,
+                    Rule,
+                    static type => new object?[] { type.SpecialType.ToString(), type.ToString() }),
+                SyntaxKind.CastExpression,
+                SyntaxKind.NumericLiteralExpression);
+            context.RegisterSyntaxNodeAction(
                 static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzeMethodDeclaration(
                     context,
                     SpecialType.System_Decimal,

--- a/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/DoubleUsageAnalyzer.cs
@@ -40,6 +40,14 @@ namespace Neo.SmartContract.Analyzer
             context.EnableConcurrentExecution();
             context.RegisterOperationAction(AnalyzeOperation, OperationKind.VariableDeclaration);
             context.RegisterSyntaxNodeAction(
+                static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzeExpression(
+                    context,
+                    SpecialType.System_Double,
+                    Rule,
+                    static type => new object?[] { type.ToString() }),
+                SyntaxKind.CastExpression,
+                SyntaxKind.NumericLiteralExpression);
+            context.RegisterSyntaxNodeAction(
                 static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzeMethodDeclaration(
                     context,
                     SpecialType.System_Double,

--- a/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/FloatUsageAnalyzer.cs
@@ -40,6 +40,14 @@ namespace Neo.SmartContract.Analyzer
             context.EnableConcurrentExecution();
             context.RegisterOperationAction(AnalyzeOperation, OperationKind.VariableDeclaration);
             context.RegisterSyntaxNodeAction(
+                static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzeExpression(
+                    context,
+                    SpecialType.System_Single,
+                    Rule,
+                    static type => new object?[] { type.ToString() }),
+                SyntaxKind.CastExpression,
+                SyntaxKind.NumericLiteralExpression);
+            context.RegisterSyntaxNodeAction(
                 static context => UnsupportedTypeUsageAnalyzerHelpers.AnalyzeMethodDeclaration(
                     context,
                     SpecialType.System_Single,

--- a/src/Neo.SmartContract.Analyzer/UnsupportedTypeUsageAnalyzerHelpers.cs
+++ b/src/Neo.SmartContract.Analyzer/UnsupportedTypeUsageAnalyzerHelpers.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
@@ -115,6 +116,60 @@ internal static class UnsupportedTypeUsageAnalyzerHelpers
 
         var type = (context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken) as IPropertySymbol)?.Type;
         ReportIfUnsupportedType(context, propertyDeclaration.Type.GetLocation(), type, specialType, rule, getMessageArgs);
+    }
+
+    internal static void AnalyzeExpression(
+        SyntaxNodeAnalysisContext context,
+        SpecialType specialType,
+        DiagnosticDescriptor rule,
+        Func<ITypeSymbol, object?[]> getMessageArgs)
+    {
+        if (context.Node is not ExpressionSyntax expression) return;
+
+        var type = context.SemanticModel.GetTypeInfo(expression, context.CancellationToken).Type;
+        var matchedType = FindUnsupportedType(type, specialType);
+        if (matchedType is null || IsCoveredByDeclaration(context, expression, specialType)) return;
+
+        if (expression is LiteralExpressionSyntax &&
+            expression.Parent is CastExpressionSyntax castExpression &&
+            FindUnsupportedType(
+                context.SemanticModel.GetTypeInfo(castExpression, context.CancellationToken).Type,
+                specialType) is not null)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(rule, expression.GetLocation(), getMessageArgs(matchedType)));
+    }
+
+    private static bool IsCoveredByDeclaration(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax expression,
+        SpecialType specialType)
+    {
+        foreach (var ancestor in expression.Ancestors())
+        {
+            ITypeSymbol? declaredType = ancestor switch
+            {
+                VariableDeclarationSyntax variable =>
+                    context.SemanticModel.GetTypeInfo(variable.Type, context.CancellationToken).Type,
+                MethodDeclarationSyntax method =>
+                    context.SemanticModel.GetTypeInfo(method.ReturnType, context.CancellationToken).Type,
+                PropertyDeclarationSyntax property =>
+                    context.SemanticModel.GetTypeInfo(property.Type, context.CancellationToken).Type,
+                ParameterSyntax parameter when parameter.Type is not null =>
+                    context.SemanticModel.GetTypeInfo(parameter.Type, context.CancellationToken).Type,
+                _ => null
+            };
+
+            if (FindUnsupportedType(declaredType, specialType) is not null)
+                return true;
+
+            if (ancestor is StatementSyntax or MemberDeclarationSyntax)
+                break;
+        }
+
+        return false;
     }
 
     private static void ReportIfUnsupportedType(

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DecimalUsageAnalyzerUnitTests.cs
@@ -99,5 +99,29 @@ namespace Neo.SmartContract.Analyzer.UnitTests
 
             await VerifyCS.VerifyAnalyzerAsync(test, propertyDiagnostic);
         }
+
+        [TestMethod]
+        public async Task DecimalUsageAnalyzer_DirectExpressions_ShouldReportDiagnostics()
+        {
+            const string test = """
+                                public class TestClass
+                                {
+                                    private static object Consume(object value) => value;
+
+                                    public object FromCast(int value) => Consume({|#0:(decimal)value|});
+
+                                    public object FromLiteral() => Consume({|#1:1.5M|});
+                                }
+                                """;
+
+            var castDiagnostic = VerifyCS.Diagnostic(DecimalUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("System_Decimal", "decimal");
+            var literalDiagnostic = VerifyCS.Diagnostic(DecimalUsageAnalyzer.DiagnosticId)
+                .WithLocation(1)
+                .WithArguments("System_Decimal", "decimal");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, castDiagnostic, literalDiagnostic);
+        }
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/DoubleUsageAnalyzerUnitTest.cs
@@ -113,5 +113,29 @@ namespace Neo.SmartContract.Analyzer.UnitTests
 
             await Verifier.VerifyAnalyzerAsync(test, propertyDiagnostic).ConfigureAwait(false);
         }
+
+        [TestMethod]
+        public async Task DoubleUsageAnalyzer_DirectExpressions_ShouldReportDiagnostics()
+        {
+            const string test = """
+                                public class TestClass
+                                {
+                                    private static object Consume(object value) => value;
+
+                                    public object FromCast(int value) => Consume({|#0:(double)value|});
+
+                                    public object FromLiteral() => Consume({|#1:1.5D|});
+                                }
+                                """;
+
+            var castDiagnostic = Verifier.Diagnostic(DoubleUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("double");
+            var literalDiagnostic = Verifier.Diagnostic(DoubleUsageAnalyzer.DiagnosticId)
+                .WithLocation(1)
+                .WithArguments("double");
+
+            await Verifier.VerifyAnalyzerAsync(test, castDiagnostic, literalDiagnostic).ConfigureAwait(false);
+        }
     }
 }

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/FloatUsageAnalyzerUnitTest.cs
@@ -113,5 +113,29 @@ namespace Neo.SmartContract.Analyzer.UnitTests
 
             await Verifier.VerifyAnalyzerAsync(test, propertyDiagnostic).ConfigureAwait(false);
         }
+
+        [TestMethod]
+        public async Task FloatUsageAnalyzer_DirectExpressions_ShouldReportDiagnostics()
+        {
+            const string test = """
+                                public class TestClass
+                                {
+                                    private static object Consume(object value) => value;
+
+                                    public object FromCast(int value) => Consume({|#0:(float)value|});
+
+                                    public object FromLiteral() => Consume({|#1:1.5F|});
+                                }
+                                """;
+
+            var castDiagnostic = Verifier.Diagnostic(FloatUsageAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("float");
+            var literalDiagnostic = Verifier.Diagnostic(FloatUsageAnalyzer.DiagnosticId)
+                .WithLocation(1)
+                .WithArguments("float");
+
+            await Verifier.VerifyAnalyzerAsync(test, castDiagnostic, literalDiagnostic).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- diagnose float, double, and decimal casts and literals outside typed declarations
- avoid duplicate diagnostics when declaration analysis already covers the root cause
- preserve the existing diagnostic IDs and guidance

## Validation

- 312 analyzer tests passed
- focused format verification passed
- `git diff --check` passed

Part of #1841.