### PR TITLE
Fix: validate all BigInteger constructor overloads

### DIFF
--- a/src/Neo.SmartContract.Analyzer/BigIntegerCreationAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/BigIntegerCreationAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Neo.SmartContract.Analyzer
         private static readonly DiagnosticDescriptor Rule = new(
             DiagnosticId,
             "Use of BigInteger constructor",
-            "Use of new BigInteger(int) is not allowed, please use BigInteger x = 0;",
+            "BigInteger constructor is not supported. Only BigInteger(byte[]) is supported; use BigInteger.Zero for zero or an implicit conversion for integral values.",
             "Usage",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
@@ -50,15 +50,30 @@ namespace Neo.SmartContract.Analyzer
         private void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
         {
             var objectCreationExpression = (ObjectCreationExpressionSyntax)context.Node;
-
-            // Check if it is a BigInteger creation
-            if (context.SemanticModel.GetTypeInfo(objectCreationExpression).Type?.ToString() == "System.Numerics.BigInteger" &&
-                objectCreationExpression.ArgumentList?.Arguments.Count == 1 &&
-                context.SemanticModel.GetTypeInfo(objectCreationExpression.ArgumentList.Arguments[0].Expression).Type?.SpecialType == SpecialType.System_Int32)
+            var constructor = context.SemanticModel
+                .GetSymbolInfo(objectCreationExpression, context.CancellationToken)
+                .Symbol as IMethodSymbol;
+            var bigIntegerType = context.Compilation.GetTypeByMetadataName("System.Numerics.BigInteger");
+            if (constructor is null ||
+                bigIntegerType is null ||
+                !SymbolEqualityComparer.Default.Equals(constructor.ContainingType, bigIntegerType) ||
+                IsSupportedByteArrayConstructor(constructor))
             {
-                var diagnostic = Diagnostic.Create(Rule, objectCreationExpression.GetLocation());
-                context.ReportDiagnostic(diagnostic);
+                return;
             }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, objectCreationExpression.GetLocation()));
+        }
+
+        private static bool IsSupportedByteArrayConstructor(IMethodSymbol constructor)
+        {
+            if (constructor.Parameters.Length != 1 ||
+                constructor.Parameters[0].Type is not IArrayTypeSymbol arrayType)
+            {
+                return false;
+            }
+
+            return arrayType.ElementType.SpecialType == SpecialType.System_Byte;
         }
     }
 
@@ -75,8 +90,8 @@ namespace Neo.SmartContract.Analyzer
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<ObjectCreationExpressionSyntax>().First();
-            if (declaration is null) return;
+            var declaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<ObjectCreationExpressionSyntax>().FirstOrDefault();
+            if (declaration is null || !await CanReplaceWithIntegralConversionAsync(context.Document, declaration, context.CancellationToken).ConfigureAwait(false)) return;
 
             context.RegisterCodeFix(
                 CodeAction.Create(
@@ -84,6 +99,26 @@ namespace Neo.SmartContract.Analyzer
                     createChangedDocument: c => ReplaceWithExplicitConversion(context.Document, declaration, c),
                     equivalenceKey: "Replace with explicit BigInteger conversion"),
                 diagnostic);
+        }
+
+        private static async Task<bool> CanReplaceWithIntegralConversionAsync(
+            Document document,
+            ObjectCreationExpressionSyntax objectCreation,
+            CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var constructor = semanticModel?.GetSymbolInfo(objectCreation, cancellationToken).Symbol as IMethodSymbol;
+            if (constructor is null || constructor.Parameters.Length != 1) return false;
+
+            var specialType = constructor.Parameters[0].Type.SpecialType;
+            return specialType is SpecialType.System_SByte or
+                SpecialType.System_Byte or
+                SpecialType.System_Int16 or
+                SpecialType.System_UInt16 or
+                SpecialType.System_Int32 or
+                SpecialType.System_UInt32 or
+                SpecialType.System_Int64 or
+                SpecialType.System_UInt64;
         }
 
         private static async Task<Document> ReplaceWithExplicitConversion(Document document, ObjectCreationExpressionSyntax objectCreation, CancellationToken cancellationToken)

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerCreationAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/BigIntegerCreationAnalyzerUnitTests.cs
@@ -36,7 +36,7 @@ class TestClass
 
             var expectedDiagnostic = VerifyCS.Diagnostic(BigIntegerCreationAnalyzer.DiagnosticId)
                 .WithLocation(8, 24)
-                .WithMessage("Use of new BigInteger(int) is not allowed, please use BigInteger x = 0;");
+                .WithMessage("BigInteger constructor is not supported. Only BigInteger(byte[]) is supported; use BigInteger.Zero for zero or an implicit conversion for integral values.");
 
             await VerifyCS.VerifyAnalyzerAsync(test, expectedDiagnostic);
         }
@@ -91,7 +91,7 @@ class TestClass
 
             var expectedDiagnostic = VerifyCS.Diagnostic(BigIntegerCreationAnalyzer.DiagnosticId)
                 .WithLocation(8, 24)
-                .WithMessage("Use of new BigInteger(int) is not allowed, please use BigInteger x = 0;");
+                .WithMessage("BigInteger constructor is not supported. Only BigInteger(byte[]) is supported; use BigInteger.Zero for zero or an implicit conversion for integral values.");
 
             await VerifyCS.VerifyCodeFixAsync(test, expectedDiagnostic, fixtest);
         }
@@ -197,6 +197,78 @@ class TestClass
                 .WithLocation(0);
 
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixedSource);
+        }
+
+        [DataTestMethod]
+        [DataRow("uint")]
+        [DataRow("long")]
+        [DataRow("ulong")]
+        public async Task UnsupportedIntegralConstructors_ShouldReportDiagnostic(string parameterType)
+        {
+            var test = $$"""
+                         using System.Numerics;
+
+                         class TestClass
+                         {
+                             BigInteger Create({{parameterType}} value) => {|#0:new BigInteger(value)|};
+                         }
+                         """;
+
+            var expected = VerifyCS.Diagnostic(BigIntegerCreationAnalyzer.DiagnosticId)
+                .WithLocation(0);
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task ParameterlessConstructor_ShouldReportDiagnostic()
+        {
+            var test = """
+                       using System.Numerics;
+
+                       class TestClass
+                       {
+                           BigInteger Create() => {|#0:new BigInteger()|};
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic(BigIntegerCreationAnalyzer.DiagnosticId)
+                .WithLocation(0);
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task ByteArrayConstructorWithFlags_ShouldReportDiagnostic()
+        {
+            var test = """
+                       using System.Numerics;
+
+                       class TestClass
+                       {
+                           BigInteger Create(byte[] value) => {|#0:new BigInteger(value, true, true)|};
+                       }
+                       """;
+
+            var expected = VerifyCS.Diagnostic(BigIntegerCreationAnalyzer.DiagnosticId)
+                .WithLocation(0);
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task ByteArrayConstructor_ShouldNotReportDiagnostic()
+        {
+            var test = """
+                       using System.Numerics;
+
+                       class TestClass
+                       {
+                           BigInteger Create(byte[] value) => new BigInteger(value);
+                       }
+                       """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
     }
 }


### PR DESCRIPTION
## Summary

- validate System.Numerics.BigInteger constructors by exact symbol
- allow only the byte-array constructor supported by the compiler
- limit the automatic conversion fix to integral constructor overloads

## Validation

- 315 analyzer tests passed
- 8 compiler constructor tests passed
- focused format verification passed
- `git diff --check` passed

Part of #1841.