### PR TITLE
Optimize - replace CONVERT with NZ for bool ^ bool expressions

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
@@ -123,9 +123,9 @@ internal partial class MethodConvert
         AddInstruction(opcode);
 
         // XOR of two booleans produces an integer (0 or 1).
-        // NZ (4 units = 120 datoshi) converts 0→false, nonzero→true,
+        // NZ (4 units = 120 datoshi) converts 0 -> false, nonzero -> true,
         // which is correct for boolean results and 2048× cheaper than
-        // CONVERT Boolean (8192 units = 245,760 datoshi).
+        // convert Boolean (8192 units = 245,760 datoshi).
         if (expression.OperatorToken.ValueText == "^" && type.GetStackItemType() == StackItemType.Boolean)
         {
             Nz();

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/BinaryExpression.cs
@@ -122,9 +122,13 @@ internal partial class MethodConvert
         }
         AddInstruction(opcode);
 
+        // XOR of two booleans produces an integer (0 or 1).
+        // NZ (4 units = 120 datoshi) converts 0→false, nonzero→true,
+        // which is correct for boolean results and 2048× cheaper than
+        // CONVERT Boolean (8192 units = 245,760 datoshi).
         if (expression.OperatorToken.ValueText == "^" && type.GetStackItemType() == StackItemType.Boolean)
         {
-            ChangeType(StackItemType.Boolean);
+            Nz();
         }
 
         if (checkResult)

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Logical.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Logical.cs
@@ -13,12 +13,12 @@ public abstract class Contract_Logical(Neo.SmartContract.Testing.SmartContractIn
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Logical"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testConditionalLogicalAnd"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testConditionalLogicalOr"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testLogicalExclusiveOr"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":20,""safe"":false},{""name"":""testLogicalAnd"",""parameters"":[{""name"":""x"",""type"":""Integer""},{""name"":""y"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":29,""safe"":false},{""name"":""testBoolAnd"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":36,""safe"":false},{""name"":""testBoolOr"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":43,""safe"":false},{""name"":""testLogicalOr"",""parameters"":[{""name"":""x"",""type"":""Integer""},{""name"":""y"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":50,""safe"":false},{""name"":""testLogicalNegation"",""parameters"":[{""name"":""x"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":57,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Logical"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testConditionalLogicalAnd"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""testConditionalLogicalOr"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":10,""safe"":false},{""name"":""testLogicalExclusiveOr"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":20,""safe"":false},{""name"":""testLogicalAnd"",""parameters"":[{""name"":""x"",""type"":""Integer""},{""name"":""y"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":28,""safe"":false},{""name"":""testBoolAnd"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":35,""safe"":false},{""name"":""testBoolOr"",""parameters"":[{""name"":""x"",""type"":""Boolean""},{""name"":""y"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":42,""safe"":false},{""name"":""testLogicalOr"",""parameters"":[{""name"":""x"",""type"":""Integer""},{""name"":""y"",""type"":""Integer""}],""returntype"":""Integer"",""offset"":49,""safe"":false},{""name"":""testLogicalNegation"",""parameters"":[{""name"":""x"",""type"":""Boolean""}],""returntype"":""Boolean"",""offset"":56,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9XAAJ4JAQJQHlAVwACeCYECEB5QFcAAnh5k9sgQFcAAnh5kUBXAAJ4eatAVwACeHmsQFcAAnh5kkBXAAF4qkAQ+sK8").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD5XAAJ4JAQJQHlAVwACeCYECEB5QFcAAnh5k7FAVwACeHmRQFcAAnh5q0BXAAJ4eaxAVwACeHmSQFcAAXiqQDyYz3U=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -102,12 +102,12 @@ public abstract class Contract_Logical(Neo.SmartContract.Testing.SmartContractIn
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwACeHmT2yBA
+    /// Script: VwACeHmTsUA=
     /// INITSLOT 0002 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// LDARG1 [2 datoshi]
     /// XOR [8 datoshi]
-    /// CONVERT 20 'Boolean' [8192 datoshi]
+    /// NZ [4 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
     [DisplayName("testLogicalExclusiveOr")]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
@@ -110,29 +110,6 @@ namespace Neo.Compiler.CSharp.UnitTests
         }
 
         /// <summary>
-        /// Verifies that the bool ^ bool optimization emits NZ (4 units = 120 datoshi)
-        /// instead of convert Boolean (8192 units = 245,760 datoshi) saving 245,640 datoshi per call.
-        /// Bytecode: XOR + NZ  vs old: XOR + CONVERT
-        /// </summary>
-        [TestMethod]
-        public void Test_BoolXor_GasSaving()
-        {
-            const long gasAfterOptimization = 1_047_480; // XOR + NZ (4u × 30)
-
-            Assert.IsFalse(Contract.TestLogicalExclusiveOr(false, false));
-            AssertGasConsumed(gasAfterOptimization);
-
-            Assert.IsTrue(Contract.TestLogicalExclusiveOr(false, true));
-            AssertGasConsumed(gasAfterOptimization);
-
-            Assert.IsTrue(Contract.TestLogicalExclusiveOr(true, false));
-            AssertGasConsumed(gasAfterOptimization);
-
-            Assert.IsFalse(Contract.TestLogicalExclusiveOr(true, true));
-            AssertGasConsumed(gasAfterOptimization);
-        }
-
-        /// <summary>
         /// Verifies semantic correctness of bool ^ bool for all input combinations.
         /// Ensures NZ produces the same truth table as XOR on booleans.
         /// </summary>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
@@ -105,7 +105,51 @@ namespace Neo.Compiler.CSharp.UnitTests
                 {
                     var result = Contract.TestLogicalExclusiveOr(x, y);
                     Assert.AreEqual(x ^ y, result);
-                    AssertGasConsumed(1293120);
+                    AssertGasConsumed(1047480);
+                }
+        }
+
+        /// <summary>
+        /// Verifies that the bool ^ bool optimization emits NZ (4 units = 120 datoshi)
+        /// instead of CONVERT Boolean (8192 units = 245,760 datoshi), saving 245,640 datoshi per call.
+        /// Bytecode: XOR + NZ  vs old: XOR + CONVERT
+        /// </summary>
+        [TestMethod]
+        public void Test_BoolXor_GasSaving()
+        {
+            const long gasBeforeOptimization = 1_293_120; // XOR + CONVERT Boolean (8192u × 30)
+            const long gasAfterOptimization  = 1_047_480; // XOR + NZ              (4u × 30)
+            const long expectedSaving        = gasBeforeOptimization - gasAfterOptimization;
+
+            Assert.AreEqual(expectedSaving, 245_640L, "Expected saving must be 245,640 datoshi (8188 units × 30): CONVERT=8192u vs NZ=4u.");
+
+            // Execute and confirm optimized gas is consumed for all four boolean combinations
+            Assert.IsFalse(Contract.TestLogicalExclusiveOr(false, false));
+            AssertGasConsumed(gasAfterOptimization);
+
+            Assert.IsTrue(Contract.TestLogicalExclusiveOr(false, true));
+            AssertGasConsumed(gasAfterOptimization);
+
+            Assert.IsTrue(Contract.TestLogicalExclusiveOr(true,  false));
+            AssertGasConsumed(gasAfterOptimization);
+
+            Assert.IsFalse(Contract.TestLogicalExclusiveOr(true,  true));
+            AssertGasConsumed(gasAfterOptimization);
+        }
+
+        /// <summary>
+        /// Verifies semantic correctness of bool ^ bool for all input combinations.
+        /// Ensures NZ produces the same truth table as XOR on booleans.
+        /// </summary>
+        [TestMethod]
+        public void Test_BoolXor_Correctness()
+        {
+            foreach (var x in new[] { false, true })
+                foreach (var y in new[] { false, true })
+                {
+                    bool expected = x ^ y;
+                    bool? actual = Contract.TestLogicalExclusiveOr(x, y);
+                    Assert.AreEqual(expected, actual, $"bool ^ bool correctness failed: {x} ^ {y} should be {expected} but was {actual}");
                 }
         }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
@@ -117,7 +117,7 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_BoolXor_GasSaving()
         {
-            const long gasAfterOptimization  = 1_047_480; // XOR + NZ (4u × 30)
+            const long gasAfterOptimization = 1_047_480; // XOR + NZ (4u × 30)
 
             Assert.IsFalse(Contract.TestLogicalExclusiveOr(false, false));
             AssertGasConsumed(gasAfterOptimization);
@@ -125,10 +125,10 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.IsTrue(Contract.TestLogicalExclusiveOr(false, true));
             AssertGasConsumed(gasAfterOptimization);
 
-            Assert.IsTrue(Contract.TestLogicalExclusiveOr(true,  false));
+            Assert.IsTrue(Contract.TestLogicalExclusiveOr(true, false));
             AssertGasConsumed(gasAfterOptimization);
 
-            Assert.IsFalse(Contract.TestLogicalExclusiveOr(true,  true));
+            Assert.IsFalse(Contract.TestLogicalExclusiveOr(true, true));
             AssertGasConsumed(gasAfterOptimization);
         }
 

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_Logical.cs
@@ -111,19 +111,14 @@ namespace Neo.Compiler.CSharp.UnitTests
 
         /// <summary>
         /// Verifies that the bool ^ bool optimization emits NZ (4 units = 120 datoshi)
-        /// instead of CONVERT Boolean (8192 units = 245,760 datoshi), saving 245,640 datoshi per call.
+        /// instead of convert Boolean (8192 units = 245,760 datoshi) saving 245,640 datoshi per call.
         /// Bytecode: XOR + NZ  vs old: XOR + CONVERT
         /// </summary>
         [TestMethod]
         public void Test_BoolXor_GasSaving()
         {
-            const long gasBeforeOptimization = 1_293_120; // XOR + CONVERT Boolean (8192u × 30)
-            const long gasAfterOptimization  = 1_047_480; // XOR + NZ              (4u × 30)
-            const long expectedSaving        = gasBeforeOptimization - gasAfterOptimization;
+            const long gasAfterOptimization  = 1_047_480; // XOR + NZ (4u × 30)
 
-            Assert.AreEqual(expectedSaving, 245_640L, "Expected saving must be 245,640 datoshi (8188 units × 30): CONVERT=8192u vs NZ=4u.");
-
-            // Execute and confirm optimized gas is consumed for all four boolean combinations
             Assert.IsFalse(Contract.TestLogicalExclusiveOr(false, false));
             AssertGasConsumed(gasAfterOptimization);
 


### PR DESCRIPTION
bool ^ bool expressions were emitting XOR + CONVERT Boolean to produce a proper boolean stack item. CONVERT costs 8192 execution units (245760 datoshi) making it the most expensive opcode in the Neo VM.

Since XOR on two booleans always produces 0 or 1. NZ is semantically equivalent and costs only 4 units (120 datoshi) a 2048× reduction.