### PR TITLE
Bound Coverlet sequence point ranges

### DIFF
--- a/src/Neo.SmartContract.Testing/Coverage/Formats/CoverletJsonFormat.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/Formats/CoverletJsonFormat.cs
@@ -129,8 +129,13 @@ namespace Neo.SmartContract.Testing.Coverage.Formats
 
                     // Lines
 
-                    for (int line = debugPoint.Start.Line; line <= debugPoint.End.Line; line++)
+                    long lineCount = (long)debugPoint.End.Line - debugPoint.Start.Line + 1;
+                    if (lineCount <= 0 || lineCount > NeoDebugInfo.MaxSequencePointLineCount)
+                        throw new InvalidDataException("Invalid sequence point line range.");
+
+                    for (int offset = 0; offset < lineCount; offset++)
                     {
+                        int line = debugPoint.Start.Line + offset;
                         var hits = contract.TryGetLine(debugPoint.Address, out var hit) ? hit.Hits : 0;
 
                         if (!method.Lines.TryGetValue(line, out var hitLine))

--- a/src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs
+++ b/src/Neo.SmartContract.Testing/Coverage/NeoDebugInfo.cs
@@ -39,6 +39,7 @@ namespace Neo.SmartContract.Testing.Coverage
     public partial class NeoDebugInfo(UInt160 hash, string documentRoot, IReadOnlyList<string> documents, IReadOnlyList<NeoDebugInfo.Method> methods)
     {
         internal const int MaxDebugInfoJsonBytes = 16 * 1024 * 1024;
+        internal const int MaxSequencePointLineCount = 100_000;
         private const int CopyBufferSize = 81920;
 
         static readonly Regex spRegex = new(@"^(\d+)\[(-?\d+)\](\d+)\:(\d+)\-(\d+)\:(\d+)$");
@@ -356,6 +357,10 @@ namespace Neo.SmartContract.Testing.Coverage
             var document = int.Parse(match.Groups[2].Value);
             var start = (int.Parse(match.Groups[3].Value), int.Parse(match.Groups[4].Value));
             var end = (int.Parse(match.Groups[5].Value), int.Parse(match.Groups[6].Value));
+
+            long lineCount = (long)end.Item1 - start.Item1 + 1;
+            if (lineCount <= 0 || lineCount > MaxSequencePointLineCount)
+                throw new FormatException($"Invalid Sequence Point line range \"{sequence}\"");
 
             return new SequencePoint(address, document, start, end);
         }

--- a/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
@@ -68,6 +68,53 @@ namespace Neo.SmartContract.Testing.UnitTests.Coverage
             Assert.IsNull(debugInfo);
         }
 
+        [TestMethod]
+        public void NeoDebugInfoRejectsUnboundedSequencePointLineRanges()
+        {
+            string json = CreateDebugInfoJson("0[0]1:1-100001:1");
+
+            var exception = Assert.ThrowsException<FormatException>(() => NeoDebugInfo.FromDebugInfoJson(json));
+
+            StringAssert.Contains(exception.Message, "Invalid Sequence Point line range");
+        }
+
+        [TestMethod]
+        public void CoverletHandlesSequencePointAtMaximumLineNumber()
+        {
+            var debugInfo = NeoDebugInfo.FromDebugInfoJson(CreateDebugInfoJson($"0[0]{int.MaxValue}:1-{int.MaxValue}:1"));
+            var coverage = new CoveredContract(MethodDetectionMechanism.NextMethod, UInt160.Zero, null);
+            string? report = null;
+
+            new CoverletJsonFormat((coverage, debugInfo)).WriteReport((_, write) =>
+            {
+                using var stream = new MemoryStream();
+                write(stream);
+                report = Encoding.UTF8.GetString(stream.ToArray());
+            });
+
+            StringAssert.Contains(report, int.MaxValue.ToString());
+        }
+
+        private static string CreateDebugInfoJson(string sequencePoint)
+        {
+            return $$"""
+                {
+                  "hash": "0x0000000000000000000000000000000000000000",
+                  "document-root": "",
+                  "documents": ["Contract.cs"],
+                  "methods": [
+                    {
+                      "id": "0",
+                      "name": "Contract,main",
+                      "range": "0-0",
+                      "params": [],
+                      "sequence-points": ["{{sequencePoint}}"]
+                    }
+                  ]
+                }
+                """;
+        }
+
         private static byte[] CreateDebugInfoArchive(string json)
         {
             using var compressedFileStream = new MemoryStream();

--- a/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
+++ b/tests/Neo.SmartContract.Testing.UnitTests/Coverage/CoverageDataTests.cs
@@ -95,6 +95,19 @@ namespace Neo.SmartContract.Testing.UnitTests.Coverage
             StringAssert.Contains(report, int.MaxValue.ToString());
         }
 
+        [TestMethod]
+        public void CoverletRejectsProgrammaticReversedLineRange()
+        {
+            NeoDebugInfo.SequencePoint sequencePoint = new(0, 0, (2, 1), (1, 1));
+            NeoDebugInfo.Method method = new("0", "Contract", "main", (0, 0), [], [sequencePoint]);
+            NeoDebugInfo debugInfo = new(UInt160.Zero, "", ["Contract.cs"], [method]);
+            var coverage = new CoveredContract(MethodDetectionMechanism.NextMethod, UInt160.Zero, null);
+            var format = new CoverletJsonFormat((coverage, debugInfo));
+
+            Assert.ThrowsException<InvalidDataException>(() =>
+                format.WriteReport((_, write) => write(new MemoryStream())));
+        }
+
         private static string CreateDebugInfoJson(string sequencePoint)
         {
             return $$"""


### PR DESCRIPTION
Malformed debug information could make Coverlet enumerate an unbounded line range, and a sequence point ending at `int.MaxValue` could wrap the loop counter. This change validates line counts and uses a bounded offset loop in the formatter.

Validation:
- `CoverageDataTests`: 11/11 passed
- Release solution build passed
- `dotnet format` verification passed
