### PR TITLE
Cover Ownable2Step storage marker collisions

### DIFF
--- a/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
+++ b/src/Neo.SmartContract.Analyzer/StorageKeyCollisionAnalyzer.cs
@@ -45,7 +45,7 @@ namespace Neo.SmartContract.Analyzer
         private static readonly Dictionary<string, byte[]> ReservedBasePrefixes = new(StringComparer.Ordinal)
         {
             ["global::Neo.SmartContract.Framework.Ownable"] = [0xFF],
-            ["global::Neo.SmartContract.Framework.Ownable2Step"] = [0xFD, 0xFC],
+            ["global::Neo.SmartContract.Framework.Ownable2Step"] = [0xFD, 0xFC, 0xFB],
             ["global::Neo.SmartContract.Framework.Pausable"] = [0xFE],
             ["global::Neo.SmartContract.Framework.PausableOwnable"] = [0xFE],
             ["global::Neo.SmartContract.Framework.AccessControl"] = [0xFB],

--- a/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
+++ b/tests/Neo.SmartContract.Analyzer.UnitTests/StorageKeyCollisionAnalyzerUnitTests.cs
@@ -158,6 +158,24 @@ namespace Neo.SmartContract.Analyzer.UnitTests
         }
 
         [TestMethod]
+        public async Task InheritedOwnable2StepInitializedPrefix_ReportsDiagnostic()
+        {
+            var test = StorageStubs + BaseStubs + ExtendedBaseStubs + """
+                public class TokenG : Neo.SmartContract.Framework.Ownable2Step
+                {
+                    private static readonly Neo.SmartContract.Framework.Services.LocalStorageMap OwnerInitialized =
+                        new((byte)0xFB);
+                }
+                """;
+
+            var expected = VerifyCS.Diagnostic(StorageKeyCollisionAnalyzer.DiagnosticId)
+                .WithSpan(37, 82, 37, 98)
+                .WithArguments("FB", "OwnerInitialized", "the reserved prefix of base class Ownable2Step");
+
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
         public async Task InheritedAccessControlPrefix_ReportsDiagnostic()
         {
             var test = StorageStubs + BaseStubs + ExtendedBaseStubs + """


### PR DESCRIPTION
`Ownable2Step` uses `0xFB` for its owner-initialized marker, but the storage collision analyzer only reserved its `0xFD` and `0xFC` prefixes. This change adds the missing reserved prefix and a focused inherited-contract regression test.

Validation:
- `StorageKeyCollisionAnalyzerUnitTests`: 26/26 passed
- Release solution build passed
- `dotnet format` verification passed