### PR TITLE
Fix positional index

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Helpers/SlotHelpers.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Helpers/SlotHelpers.cs
@@ -399,13 +399,22 @@ internal partial class MethodConvert
             {
                 case ArgumentSyntax argument:
                     expression = argument.Expression;
-                    targetParameter = argument.NameColon is null
-                        ? symbol.Parameters.ElementAtOrDefault(positionalIndex++)
-                        : symbol.Parameters.FirstOrDefault(p => p.Name == argument.NameColon.Name.Identifier.ValueText);
+                    if (argument.NameColon is null)
+                    {
+                        targetParameter = symbol.Parameters.ElementAtOrDefault(positionalIndex);
+                        positionalIndex++;
+                    }
+                    else
+                    {
+                        targetParameter = symbol.Parameters.FirstOrDefault(p => p.Name == argument.NameColon.Name.Identifier.ValueText);
+                        if (targetParameter is not null)
+                            positionalIndex = Math.Max(positionalIndex, targetParameter.Ordinal + 1);
+                    }
                     break;
                 case ExpressionSyntax exp:
                     expression = exp;
-                    targetParameter = symbol.Parameters.ElementAtOrDefault(positionalIndex++);
+                    targetParameter = symbol.Parameters.ElementAtOrDefault(positionalIndex);
+                    positionalIndex++;
                     break;
                 default:
                     continue;
@@ -482,15 +491,24 @@ internal partial class MethodConvert
             {
                 case ArgumentSyntax syntax:
                     expression = syntax.Expression;
-                    parameter = syntax.NameColon is null
-                        ? symbol.Parameters.ElementAtOrDefault(Math.Min(positionalIndex, paramsParameter.Ordinal))
-                        : symbol.Parameters.FirstOrDefault(p => p.Name == syntax.NameColon.Name.Identifier.ValueText);
-                    if (syntax.NameColon is not null && parameter is not null)
-                        positionalIndex = Math.Max(positionalIndex, parameter.Ordinal + 1);
+                    if (syntax.NameColon is null)
+                    {
+                        parameter = symbol.Parameters.ElementAtOrDefault(Math.Min(positionalIndex, paramsParameter.Ordinal));
+                        if (parameter is not null && !parameter.IsParams)
+                            positionalIndex++;
+                    }
+                    else
+                    {
+                        parameter = symbol.Parameters.FirstOrDefault(p => p.Name == syntax.NameColon.Name.Identifier.ValueText);
+                        if (parameter is not null)
+                            positionalIndex = Math.Max(positionalIndex, parameter.Ordinal + 1);
+                    }
                     break;
                 case ExpressionSyntax syntax:
                     expression = syntax;
                     parameter = symbol.Parameters.ElementAtOrDefault(Math.Min(positionalIndex, paramsParameter.Ordinal));
+                    if (parameter is not null && !parameter.IsParams)
+                        positionalIndex++;
                     break;
                 default:
                     return false;
@@ -508,9 +526,6 @@ internal partial class MethodConvert
                 paramsSlots.Add((expression, slot));
             else
                 regularSlots[parameter] = slot;
-
-            if (!parameter.IsParams)
-                positionalIndex++;
         }
 
         foreach (IParameterSymbol parameter in DetermineParameterOrder(symbol, callingConvention))

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ArgumentEvaluationOrder.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_ArgumentEvaluationOrder.cs
@@ -204,6 +204,46 @@ public class UnitTest_ArgumentEvaluationOrder
         Assert.AreEqual(new BigInteger(12), contract.ReceiverBeforeArgument());
     }
 
+    [TestMethod]
+    public void NamedArgumentBeforeExpandedParamsBindsToCorrectParameter()
+    {
+        const string source = """
+        using Neo.SmartContract.Framework;
+        using System.ComponentModel;
+
+        public class Contract : SmartContract
+        {
+            [DisplayName("namedThenPositional")]
+            public static int NamedThenPositional()
+            {
+                // "a" is named but occupies its correct positional slot (ordinal 0),
+                // followed by plain positional arguments for "b" and the params array.
+                // Equivalent to calling Combine(1, 2, 3).
+                return Combine(a: 1, 2, 3);
+            }
+
+            private static int Combine(int a, int b, params int[] c)
+            {
+                // Expected: a=1, b=2, c=[3] => 1*1000 + 2*100 + (c.Length > 0 ? c[0] : 0) = 1203
+                return a * 1000 + b * 100 + (c.Length > 0 ? c[0] : 0);
+            }
+        }
+        """;
+
+        var context = TestHelper.CompileSingleContract(source);
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<NamedThenPositionalContract>(context.CreateExecutable(), context.CreateManifest());
+
+        Assert.AreEqual(new BigInteger(1203), contract.NamedThenPositional());
+    }
+
+    public abstract class NamedThenPositionalContract(SmartContractInitialize initialize)
+        : SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("namedThenPositional")]
+        public abstract BigInteger? NamedThenPositional();
+    }
+
     public abstract class ArgumentOrderContract(SmartContractInitialize initialize)
         : SmartContract.Testing.SmartContract(initialize)
     {


### PR DESCRIPTION
When calling a method with a named argument that occupies its correct positional slot followed by positional arguments and a params parameter (e.g. Combine(a: 1, 2, 3) with Combine(int a, int b, params int[] c)) the result is incorrect.

Expected: a=1, b=2, c=[3]. Actual: a=1, b=3, c=[3] (the value 2 is lost, and b incorrectly takes the last positional argument instead).

Related to #1964 