### PR TITLE
Strengthen checked Int32 division overflow test

### DIFF
--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DivisionOverflow.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_DivisionOverflow.cs
@@ -42,10 +42,11 @@ namespace Neo.Compiler.CSharp.UnitTests
         [TestMethod]
         public void Test_DivideCheckedInt32_Overflow_ShouldThrow()
         {
-            Assert.ThrowsException<TestException>(() =>
+            var ex = Assert.ThrowsExactly<TestException>(() =>
             {
                 Contract.DivideCheckedInt32(int.MinValue, -1);
             });
+            Assert.Contains("Overflow", ex.Message);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- require the exact exception type for checked Int32 division overflow
- verify that the VM fault reason is `Overflow`