### PR TITLE
Preserve lifted nullable unary semantics

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
@@ -48,27 +48,16 @@ internal partial class MethodConvert
                 break;
             case "-":
                 ConvertExpression(model, expression.Operand);
-                EmitNegativeInteger(model.GetTypeInfo(expression.Operand).Type);
+                var negativeType = model.GetTypeInfo(expression.Operand).Type;
+                EmitLiftedUnaryOperation(negativeType, () => EmitNegativeInteger(negativeType));
                 break;
             case "~":
                 ConvertExpression(model, expression.Operand);
-                AddInstruction(OpCode.INVERT);
-                // INVERT produces a signed result; unsigned complements retain their width even in checked code.
-                switch (GetNonNullableValueType(model.GetTypeInfo(expression).Type!).SpecialType)
-                {
-                    case SpecialType.System_UInt32:
-                        Push(uint.MaxValue);
-                        AddInstruction(OpCode.AND);
-                        break;
-                    case SpecialType.System_UInt64:
-                        Push(ulong.MaxValue);
-                        AddInstruction(OpCode.AND);
-                        break;
-                }
+                EmitLiftedUnaryOperation(model.GetTypeInfo(expression.Operand).Type, () => AddInstruction(OpCode.INVERT));
                 break;
             case "!":
                 ConvertExpression(model, expression.Operand);
-                AddInstruction(OpCode.NOT);
+                EmitLiftedUnaryOperation(model.GetTypeInfo(expression.Operand).Type, () => AddInstruction(OpCode.NOT));
                 break;
             case "++":
             case "--":
@@ -391,13 +380,32 @@ internal partial class MethodConvert
 
     private void EmitIncrementOrDecrement(SyntaxToken operatorToken, ITypeSymbol? typeSymbol)
     {
-        AddInstruction(operatorToken.ValueText switch
+        EmitLiftedUnaryOperation(typeSymbol, () =>
         {
-            "++" => OpCode.INC,
-            "--" => OpCode.DEC,
-            _ => throw CompilationException.UnsupportedSyntax(operatorToken, $"Invalid increment/decrement operator '{operatorToken.ValueText}'. Only '++' and '--' are supported.")
+            AddInstruction(operatorToken.ValueText switch
+            {
+                "++" => OpCode.INC,
+                "--" => OpCode.DEC,
+                _ => throw CompilationException.UnsupportedSyntax(operatorToken, $"Invalid increment/decrement operator '{operatorToken.ValueText}'. Only '++' and '--' are supported.")
+            });
+            if (typeSymbol != null) EnsureIntegerInRange(typeSymbol);
         });
-        if (typeSymbol != null) EnsureIntegerInRange(typeSymbol);
+    }
+
+    private void EmitLiftedUnaryOperation(ITypeSymbol? typeSymbol, Action emitOperation)
+    {
+        if (typeSymbol is not INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T })
+        {
+            emitOperation();
+            return;
+        }
+
+        var endTarget = new JumpTarget();
+        AddInstruction(OpCode.DUP);
+        AddInstruction(OpCode.ISNULL);
+        Jump(OpCode.JMPIF_L, endTarget);
+        emitOperation();
+        endTarget.Instruction = AddInstruction(OpCode.NOP);
     }
 
     private void EmitNegativeInteger(ITypeSymbol? typeSymbol)

--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PrefixUnary.cs
@@ -53,7 +53,23 @@ internal partial class MethodConvert
                 break;
             case "~":
                 ConvertExpression(model, expression.Operand);
-                EmitLiftedUnaryOperation(model.GetTypeInfo(expression.Operand).Type, () => AddInstruction(OpCode.INVERT));
+                var complementType = model.GetTypeInfo(expression).Type;
+                EmitLiftedUnaryOperation(model.GetTypeInfo(expression.Operand).Type, () =>
+                {
+                    AddInstruction(OpCode.INVERT);
+                    // INVERT produces a signed result; unsigned complements retain their width even in checked code.
+                    switch (GetNonNullableValueType(complementType!).SpecialType)
+                    {
+                        case SpecialType.System_UInt32:
+                            Push(uint.MaxValue);
+                            AddInstruction(OpCode.AND);
+                            break;
+                        case SpecialType.System_UInt64:
+                            Push(ulong.MaxValue);
+                            AddInstruction(OpCode.AND);
+                            break;
+                    }
+                });
                 break;
             case "!":
                 ConvertExpression(model, expression.Operand);

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_NULL.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_NULL.cs
@@ -13,12 +13,12 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_NULL"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""isNull"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""equalNullA"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":8,""safe"":false},{""name"":""equalNullB"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":15,""safe"":false},{""name"":""equalNotNullA"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":21,""safe"":false},{""name"":""equalNotNullB"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""nullCoalescing"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""String"",""offset"":35,""safe"":false},{""name"":""nullCollation"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""String"",""offset"":51,""safe"":false},{""name"":""nullPropertyGT"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":70,""safe"":false},{""name"":""nullPropertyLT"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":82,""safe"":false},{""name"":""nullPropertyGE"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":94,""safe"":false},{""name"":""nullPropertyLE"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":106,""safe"":false},{""name"":""nullProperty"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":118,""safe"":false},{""name"":""ifNull"",""parameters"":[{""name"":""obj"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":130,""safe"":false},{""name"":""nullCollationAndCollation"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""Any"",""offset"":140,""safe"":false},{""name"":""nullCollationAndCollation2"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""Any"",""offset"":165,""safe"":false},{""name"":""nullType"",""parameters"":[],""returntype"":""Void"",""offset"":202,""safe"":false},{""name"":""nullCoalescingAssignment"",""parameters"":[{""name"":""nullableArg"",""type"":""Integer""}],""returntype"":""Void"",""offset"":215,""safe"":false},{""name"":""staticNullableCoalesceAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":467,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":608,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_NULL"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""isNull"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":0,""safe"":false},{""name"":""equalNullA"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":8,""safe"":false},{""name"":""equalNullB"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":15,""safe"":false},{""name"":""equalNotNullA"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":21,""safe"":false},{""name"":""equalNotNullB"",""parameters"":[{""name"":""value"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":28,""safe"":false},{""name"":""nullCoalescing"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""String"",""offset"":35,""safe"":false},{""name"":""nullCollation"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""String"",""offset"":51,""safe"":false},{""name"":""nullPropertyGT"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":70,""safe"":false},{""name"":""nullPropertyLT"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":82,""safe"":false},{""name"":""nullPropertyGE"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":94,""safe"":false},{""name"":""nullPropertyLE"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":106,""safe"":false},{""name"":""nullProperty"",""parameters"":[{""name"":""a"",""type"":""String""}],""returntype"":""Boolean"",""offset"":118,""safe"":false},{""name"":""ifNull"",""parameters"":[{""name"":""obj"",""type"":""Any""}],""returntype"":""Boolean"",""offset"":130,""safe"":false},{""name"":""nullCollationAndCollation"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""Any"",""offset"":140,""safe"":false},{""name"":""nullCollationAndCollation2"",""parameters"":[{""name"":""code"",""type"":""String""}],""returntype"":""Any"",""offset"":165,""safe"":false},{""name"":""nullType"",""parameters"":[],""returntype"":""Void"",""offset"":202,""safe"":false},{""name"":""nullCoalescingAssignment"",""parameters"":[{""name"":""nullableArg"",""type"":""Integer""}],""returntype"":""Void"",""offset"":215,""safe"":false},{""name"":""staticNullableCoalesceAssignment"",""parameters"":[],""returntype"":""Void"",""offset"":471,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":620,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP1nAlcBAXhwaNhAVwABC3iXQFcAAXjYQFcAAQt4mEBXAAF42KpAVwEBeErYJAcREozbKHBoQFcBAXhK2CYKRQwFbGludXhwaEBXAAF4StgkA8oQt0BXAAF4StgkA8oQtUBXAAF4StgkA8oQuEBXAAF4StgkA8oQtkBXAAF4StgkA8oQmEBXAAF4JgQIQAlAVwEBQZv2Z85weGhBkl3oMUrYJgZFDAF7QFcBAUGb9mfOcAwDMTExeGhB5j8YhHhoQZJd6DFK2CYGRQwBe0BXAQALcGhK2CQDQEVAVwEBeNgkBXgiBRFKgEV4C1ASwHBoEM4RlzloEAvQaBHO2DloShHOStgkBUYiE0UQCxITaBDOFVUVwE5QEVHQRQsRwGg1kgAAAEVoEc4Qzmg1mQAAAEVoEM4QlzloEEtLztgkBc4iC2gRzhHOSlRT0EVoEM4QlzloEc4RS0vO2CQFziIHEUpUU9BFaBHOEc4RlzloEc4RS0vO2CQFziIHEkpUU9BFaBHOEc4RlzloEc4RS0vOSlRTnAH/AJHQRWgRzhHOEpc5aAsRwFARUdBoEc4Qztg5QFcAAngRzkrYJgpFeHlOUBFR0EBXAAJ4EEtLztgkBM5AeUpUU9BAWNgkBVgiBQtKYEVYCJc5C2BY2CQFWCIFCUpgCZc5WUrYJgZFC0phRVkQlzkLYVlK2CYGRRFKYRGXOVlKnErKFDIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn2FFWRKXOVmdSsoUMh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfYVkRlzlAVgIIYBBhQANuk1g=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP1zAlcBAXhwaNhAVwABC3iXQFcAAXjYQFcAAQt4mEBXAAF42KpAVwEBeErYJAcREozbKHBoQFcBAXhK2CYKRQwFbGludXhwaEBXAAF4StgkA8oQt0BXAAF4StgkA8oQtUBXAAF4StgkA8oQuEBXAAF4StgkA8oQtkBXAAF4StgkA8oQmEBXAAF4JgQIQAlAVwEBQZv2Z85weGhBkl3oMUrYJgZFDAF7QFcBAUGb9mfOcAwDMTExeGhB5j8YhHhoQZJd6DFK2CYGRQwBe0BXAQALcGhK2CQDQEVAVwEBeNgkBXgiBRFKgEV4C1ASwHBoEM4RlzloEAvQaBHO2DloShHOStgkBUYiE0UQCxITaBDOFVUVwE5QEVHQRQsRwGg1lgAAAEVoEc4Qzmg1nQAAAEVoEM4QlzloEEtLztgkBc4iC2gRzhHOSlRT0EVoEM4QlzloEc4RS0vO2CQFziIHEUpUU9BFaBHOEc4RlzloEc4RS0vO2CQFziIHEkpUU9BFaBHOEc4RlzloEc4RS0vOSlRTStgkB5wB/wCR0EVoEc4RzhKXOWgLEcBQEVHQaBHOEM7YOUBXAAJ4Ec5K2CYKRXh5TlARUdBAVwACeBBLS87YJATOQHlKVFPQQFjYJAVYIgULSmBFWAiXOQtgWNgkBVgiBQlKYAmXOVlK2CYGRQtKYUVZEJc5C2FZStgmBkURSmERlzlZSkrYJCScSsoUMh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfYUVZEpc5WUrYJCSdSsoUMh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfYVkRlzlAVgIIYBBhQIUrBgQ=").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -135,7 +135,7 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwEBeNgkBXgiBRFKgEV4C1ASwHBoEM4RlzloEAvQaBHO2DloShHOStgkBUYiE0UQCxITaBDOFVUVwE5QEVHQRQsRwGg1kgAAAEVoEc4Qzmg1mQAAAEVoEM4QlzloEEtLztgkBc4iC2gRzhHOSlRT0EVoEM4QlzloEc4RS0vO2CQFziIHEUpUU9BFaBHOEc4RlzloEc4RS0vO2CQFziIHEkpUU9BFaBHOEc4RlzloEc4RS0vOSlRTnAH/AJHQRWgRzhHOEpc5aAsRwFARUdBoEc4Qztg5QA==
+    /// Script: VwEBeNgkBXgiBRFKgEV4C1ASwHBoEM4RlzloEAvQaBHO2DloShHOStgkBUYiE0UQCxITaBDOFVUVwE5QEVHQRQsRwGg1lgAAAEVoEc4Qzmg1nQAAAEVoEM4QlzloEEtLztgkBc4iC2gRzhHOSlRT0EVoEM4QlzloEc4RS0vO2CQFziIHEUpUU9BFaBHOEc4RlzloEc4RS0vO2CQFziIHEkpUU9BFaBHOEc4RlzloEc4RS0vOSlRTStgkB5wB/wCR0EVoEc4RzhKXOWgLEcBQEVHQaBHOEM7YOUA=
     /// INITSLOT 0101 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// ISNULL [2 datoshi]
@@ -198,7 +198,7 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// PUSH1 [1 datoshi]
     /// PACK [2048 datoshi]
     /// LDLOC0 [2 datoshi]
-    /// CALL_L 92000000 [512 datoshi]
+    /// CALL_L 96000000 [512 datoshi]
     /// DROP [2 datoshi]
     /// LDLOC0 [2 datoshi]
     /// PUSH1 [1 datoshi]
@@ -206,7 +206,7 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// PUSH0 [1 datoshi]
     /// PICKITEM [64 datoshi]
     /// LDLOC0 [2 datoshi]
-    /// CALL_L 99000000 [512 datoshi]
+    /// CALL_L 9D000000 [512 datoshi]
     /// DROP [2 datoshi]
     /// LDLOC0 [2 datoshi]
     /// PUSH0 [1 datoshi]
@@ -299,6 +299,9 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// DUP [2 datoshi]
     /// REVERSE4 [2 datoshi]
     /// REVERSE3 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIF 07 [2 datoshi]
     /// INC [4 datoshi]
     /// PUSHINT16 FF00 [1 datoshi]
     /// AND [8 datoshi]
@@ -510,7 +513,7 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: WNgkBVgiBQtKYEVYCJc5C2BY2CQFWCIFCUpgCZc5WUrYJgZFC0phRVkQlzkLYVlK2CYGRRFKYRGXOVlKnErKFDIeA/////8AAAAAkUoC////fzIMAwAAAAABAAAAn2FFWRKXOVmdSsoUMh4D/////wAAAACRSgL///9/MgwDAAAAAAEAAACfYVkRlzlA
+    /// Script: WNgkBVgiBQtKYEVYCJc5C2BY2CQFWCIFCUpgCZc5WUrYJgZFC0phRVkQlzkLYVlK2CYGRRFKYRGXOVlKStgkJJxKyhQyHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9hRVkSlzlZStgkJJ1KyhQyHgP/////AAAAAJFKAv///38yDAMAAAAAAQAAAJ9hWRGXOUA=
     /// LDSFLD0 [2 datoshi]
     /// ISNULL [2 datoshi]
     /// JMPIF 05 [2 datoshi]
@@ -565,6 +568,9 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// ASSERT [1 datoshi]
     /// LDSFLD1 [2 datoshi]
     /// DUP [2 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIF 24 [2 datoshi]
     /// INC [4 datoshi]
     /// DUP [2 datoshi]
     /// SIZE [4 datoshi]
@@ -584,6 +590,9 @@ public abstract class Contract_NULL(Neo.SmartContract.Testing.SmartContractIniti
     /// EQUAL [32 datoshi]
     /// ASSERT [1 datoshi]
     /// LDSFLD1 [2 datoshi]
+    /// DUP [2 datoshi]
+    /// ISNULL [2 datoshi]
+    /// JMPIF 24 [2 datoshi]
     /// DEC [4 datoshi]
     /// DUP [2 datoshi]
     /// SIZE [4 datoshi]

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_LiftedNullableUnary.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_LiftedNullableUnary.cs
@@ -1,0 +1,123 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.SmartContract.Testing;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
+
+namespace Neo.Compiler.CSharp.UnitTests;
+
+[TestClass]
+public class UnitTest_LiftedNullableUnary
+{
+    [TestMethod]
+    public void LiftedUnaryOperatorsPropagateNullAndPreserveValues()
+    {
+        const string source = """
+using Neo.SmartContract.Framework;
+using System.ComponentModel;
+
+public class Contract : SmartContract
+{
+    private static int? _value;
+
+    [DisplayName("not")]
+    public static bool? Not(bool? value) => !value;
+
+    [DisplayName("negate")]
+    public static int? Negate(int? value) => -value;
+
+    [DisplayName("complement")]
+    public static int? Complement(int? value) => ~value;
+
+    [DisplayName("preIncrement")]
+    public static int? PreIncrement(int? value) => ++value;
+
+    [DisplayName("preDecrement")]
+    public static int? PreDecrement(int? value) => --value;
+
+    [DisplayName("postIncrement")]
+    public static int? PostIncrement(int? value) => value++;
+
+    [DisplayName("postIncrementStored")]
+    public static int? PostIncrementStored(int? value)
+    {
+        value++;
+        return value;
+    }
+
+    [DisplayName("preIncrementField")]
+    public static int? PreIncrementField(int? value)
+    {
+        _value = value;
+        return ++_value;
+    }
+
+    [DisplayName("postIncrementArrayStored")]
+    public static int? PostIncrementArrayStored(int? value)
+    {
+        int?[] values = [value];
+        values[0]++;
+        return values[0];
+    }
+}
+""";
+
+        var context = TestHelper.CompileSingleContract(source);
+        Assert.IsTrue(context.Success, string.Join(Environment.NewLine, context.Diagnostics.Select(p => p.ToString())));
+
+        var engine = new TestEngine(true);
+        var contract = engine.Deploy<NullableUnaryContract>(context.CreateExecutable(), context.CreateManifest());
+
+        Assert.IsNull(contract.Not(null));
+        Assert.IsNull(contract.Negate(null));
+        Assert.IsNull(contract.Complement(null));
+        Assert.IsNull(contract.PreIncrement(null));
+        Assert.IsNull(contract.PreDecrement(null));
+        Assert.IsNull(contract.PostIncrement(null));
+        Assert.IsNull(contract.PostIncrementStored(null));
+        Assert.IsNull(contract.PreIncrementField(null));
+        Assert.IsNull(contract.PostIncrementArrayStored(null));
+
+        Assert.AreEqual(false, contract.Not(true));
+        Assert.AreEqual(new BigInteger(-5), contract.Negate(5));
+        Assert.AreEqual(new BigInteger(~5), contract.Complement(5));
+        Assert.AreEqual(new BigInteger(6), contract.PreIncrement(5));
+        Assert.AreEqual(new BigInteger(4), contract.PreDecrement(5));
+        Assert.AreEqual(new BigInteger(5), contract.PostIncrement(5));
+        Assert.AreEqual(new BigInteger(6), contract.PostIncrementStored(5));
+        Assert.AreEqual(new BigInteger(6), contract.PreIncrementField(5));
+        Assert.AreEqual(new BigInteger(6), contract.PostIncrementArrayStored(5));
+    }
+
+    public abstract class NullableUnaryContract(SmartContractInitialize initialize)
+        : Neo.SmartContract.Testing.SmartContract(initialize)
+    {
+        [DisplayName("not")]
+        public abstract bool? Not(bool? value);
+
+        [DisplayName("negate")]
+        public abstract BigInteger? Negate(BigInteger? value);
+
+        [DisplayName("complement")]
+        public abstract BigInteger? Complement(BigInteger? value);
+
+        [DisplayName("preIncrement")]
+        public abstract BigInteger? PreIncrement(BigInteger? value);
+
+        [DisplayName("preDecrement")]
+        public abstract BigInteger? PreDecrement(BigInteger? value);
+
+        [DisplayName("postIncrement")]
+        public abstract BigInteger? PostIncrement(BigInteger? value);
+
+        [DisplayName("postIncrementStored")]
+        public abstract BigInteger? PostIncrementStored(BigInteger? value);
+
+        [DisplayName("preIncrementField")]
+        public abstract BigInteger? PreIncrementField(BigInteger? value);
+
+        [DisplayName("postIncrementArrayStored")]
+        public abstract BigInteger? PostIncrementArrayStored(BigInteger? value);
+    }
+}

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NULL.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_NULL.cs
@@ -205,14 +205,14 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void NullCoalescingAssignment()
         {
             Contract.NullCoalescingAssignment(null);
-            AssertGasConsumed(2867610);
+            AssertGasConsumed(2867790);
         }
 
         [TestMethod]
         public void StaticNullableCoalesceAssignment()
         {
             Contract.StaticNullableCoalesceAssignment();
-            AssertGasConsumed(993810);
+            AssertGasConsumed(994170);
         }
     }
 }


### PR DESCRIPTION
## Summary

- preserve null through lifted boolean negation, unary negation, complement, and nullable increment/decrement
- keep non-null behavior and checked range handling unchanged
- refresh the existing nullable contract artifact and exact gas expectations

## Validation

- 64 nullable-focused compiler tests
- 1,559 compiler unit tests
- Release solution build
- targeted format verification and git diff check