### PR TITLE
Less opcodes and GAS for `NumericParse`

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Numeric.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/System/SystemCall.Numeric.cs
@@ -57,6 +57,7 @@ internal partial class MethodConvert
         }
         return method;
     }
+
     private static void HandleNumericParse(NumericTypeDescriptor descriptor, MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)
     {
         if (instanceExpression is not null)
@@ -65,14 +66,23 @@ internal partial class MethodConvert
             methodConvert.PrepareArgumentsForMethod(model, symbol, arguments);
 
         methodConvert.CallContractMethod(NativeContract.StdLib.Hash, "atoi", 1, true);
-        methodConvert.EmitIf(
-            () =>
-            {
-                methodConvert.Dup();
-                methodConvert.Within(descriptor.MinValue, descriptor.MaxValue);
-                methodConvert.Not();
-            },
-            () => { methodConvert.Throw(); });
+
+        var endTarget = new JumpTarget();
+        methodConvert.Dup();
+        if (descriptor.MinValue < 0) // signed integer
+        {
+            methodConvert.Size();
+            methodConvert.Push(descriptor.BitSize / 8);
+            methodConvert.JumpIfLessOrEqual(endTarget);
+        }
+        else
+        {
+            methodConvert.Within(descriptor.MinValue, descriptor.MaxValue);
+            methodConvert.JumpIfTrue(endTarget);
+        }
+
+        methodConvert.Throw(); // throw the overflowed value.
+        endTarget.Instruction = methodConvert.Nop();
     }
 
     private static void HandleNumericLeadingZeroCount(NumericTypeDescriptor descriptor, MethodConvert methodConvert, SemanticModel model, IMethodSymbol symbol, ExpressionSyntax? instanceExpression, IReadOnlyList<SyntaxNode>? arguments)

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_IntegerParse.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_IntegerParse.cs
@@ -13,12 +13,12 @@ public abstract class Contract_IntegerParse(Neo.SmartContract.Testing.SmartContr
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_IntegerParse"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testSbyteparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testByteparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":18,""safe"":false},{""name"":""testUshortparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":35,""safe"":false},{""name"":""testShortparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":54,""safe"":false},{""name"":""testUlongparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":75,""safe"":false},{""name"":""testLongparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":106,""safe"":false},{""name"":""testUintparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":145,""safe"":false},{""name"":""testIntparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":168,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""atoi""]}],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_IntegerParse"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""testSbyteparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":0,""safe"":false},{""name"":""testByteparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":14,""safe"":false},{""name"":""testUshortparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":31,""safe"":false},{""name"":""testShortparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":50,""safe"":false},{""name"":""testUlongparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":64,""safe"":false},{""name"":""testLongparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":95,""safe"":false},{""name"":""testUintparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":109,""safe"":false},{""name"":""testIntparse"",""parameters"":[{""name"":""s"",""type"":""String""}],""returntype"":""Integer"",""offset"":132,""safe"":false}],""events"":[]},""permissions"":[{""contract"":""0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"",""methods"":[""atoi""]}],""trusts"":[],""extra"":{""Version"":""3.10.1"",""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARhdG9pAQABBQAAw1cAAXg3AABKAIABgAC7JAM6QFcAAXg3AABKEAEAAbskAzpAVwABeDcAAEoQAgAAAQC7JAM6QFcAAXg3AABKAQCAAgCAAAC7JAM6QFcAAXg3AABKEAQAAAAAAAAAAAEAAAAAAAAAuyQDOkBXAAF4NwAASgMAAAAAAAAAgAQAAAAAAAAAgAAAAAAAAAAAuyQDOkBXAAF4NwAAShADAAAAAAEAAAC7JAM6QFcAAXg3AABKAgAAAIADAAAAgAAAAAC7JAM6QH/++ww=").AsSerializable<Neo.SmartContract.NefFile>();
+    public static Neo.SmartContract.NefFile Nef => Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHA7znO4OTpJcbCoGp54UQN2G/OrARhdG9pAQABBQAAklcAAXg3AABKyhEyAzpAVwABeDcAAEoQAQABuyQDOkBXAAF4NwAAShACAAABALskAzpAVwABeDcAAErKEjIDOkBXAAF4NwAAShAEAAAAAAAAAAABAAAAAAAAALskAzpAVwABeDcAAErKGDIDOkBXAAF4NwAAShADAAAAAAEAAAC7JAM6QFcAAXg3AABKyhQyAzpALTZc8A==").AsSerializable<Neo.SmartContract.NefFile>();
 
     #endregion
 
@@ -47,15 +47,14 @@ public abstract class Contract_IntegerParse(Neo.SmartContract.Testing.SmartContr
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeDcAAEoCAAAAgAMAAACAAAAAALskAzpA
+    /// Script: VwABeDcAAErKFDIDOkA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// CALLT 0000 [32768 datoshi]
     /// DUP [2 datoshi]
-    /// PUSHINT32 00000080 [1 datoshi]
-    /// PUSHINT64 0000008000000000 [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 03 [2 datoshi]
+    /// SIZE [4 datoshi]
+    /// PUSH4 [1 datoshi]
+    /// JMPLE 03 [2 datoshi]
     /// THROW [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
@@ -66,15 +65,14 @@ public abstract class Contract_IntegerParse(Neo.SmartContract.Testing.SmartContr
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeDcAAEoDAAAAAAAAAIAEAAAAAAAAAIAAAAAAAAAAALskAzpA
+    /// Script: VwABeDcAAErKGDIDOkA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// CALLT 0000 [32768 datoshi]
     /// DUP [2 datoshi]
-    /// PUSHINT64 0000000000000080 [1 datoshi]
-    /// PUSHINT128 00000000000000800000000000000000 [4 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 03 [2 datoshi]
+    /// SIZE [4 datoshi]
+    /// PUSH8 [1 datoshi]
+    /// JMPLE 03 [2 datoshi]
     /// THROW [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
@@ -85,15 +83,14 @@ public abstract class Contract_IntegerParse(Neo.SmartContract.Testing.SmartContr
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeDcAAEoAgAGAALskAzpA
+    /// Script: VwABeDcAAErKETIDOkA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// CALLT 0000 [32768 datoshi]
     /// DUP [2 datoshi]
-    /// PUSHINT8 80 [1 datoshi]
-    /// PUSHINT16 8000 [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 03 [2 datoshi]
+    /// SIZE [4 datoshi]
+    /// PUSH1 [1 datoshi]
+    /// JMPLE 03 [2 datoshi]
     /// THROW [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>
@@ -104,15 +101,14 @@ public abstract class Contract_IntegerParse(Neo.SmartContract.Testing.SmartContr
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: VwABeDcAAEoBAIACAIAAALskAzpA
+    /// Script: VwABeDcAAErKEjIDOkA=
     /// INITSLOT 0001 [64 datoshi]
     /// LDARG0 [2 datoshi]
     /// CALLT 0000 [32768 datoshi]
     /// DUP [2 datoshi]
-    /// PUSHINT16 0080 [1 datoshi]
-    /// PUSHINT32 00800000 [1 datoshi]
-    /// WITHIN [8 datoshi]
-    /// JMPIF 03 [2 datoshi]
+    /// SIZE [4 datoshi]
+    /// PUSH2 [1 datoshi]
+    /// JMPLE 03 [2 datoshi]
     /// THROW [512 datoshi]
     /// RET [0 datoshi]
     /// </remarks>

--- a/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_IntegerParse.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/UnitTest_IntegerParse.cs
@@ -23,9 +23,9 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void SByteParse_Test()
         {
             Assert.AreEqual(new BigInteger(sbyte.MaxValue), Contract.TestSbyteparse("127"));
-            AssertGasConsumed(2032650);
+            AssertGasConsumed(2032500);
             Assert.AreEqual(new BigInteger(sbyte.MinValue), Contract.TestSbyteparse("-128"));
-            AssertGasConsumed(2032650);
+            AssertGasConsumed(2032500);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("20 "));
@@ -33,9 +33,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse(" 20 "));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("128"));
-            AssertGasConsumed(2048010);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("-129"));
-            AssertGasConsumed(2048010);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse(""));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestSbyteparse("abc"));
@@ -98,9 +98,9 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void ShortParse_Test()
         {
             Assert.AreEqual(new BigInteger(short.MinValue), Contract.TestShortparse("-32768"));
-            AssertGasConsumed(2032650);
+            AssertGasConsumed(2032500);
             Assert.AreEqual(new BigInteger(short.MaxValue), Contract.TestShortparse("32767"));
-            AssertGasConsumed(2032650);
+            AssertGasConsumed(2032500);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("20 "));
@@ -108,9 +108,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse(" 20 "));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("-32769"));
-            AssertGasConsumed(2048010);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("32768"));
-            AssertGasConsumed(2048010);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse(""));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestShortparse("abc"));
@@ -148,9 +148,9 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void LongParse_Test()
         {
             Assert.AreEqual(new BigInteger(long.MinValue), Contract.TestLongparse("-9223372036854775808"));
-            AssertGasConsumed(2032740);
+            AssertGasConsumed(2032500);
             Assert.AreEqual(new BigInteger(long.MaxValue), Contract.TestLongparse("9223372036854775807"));
-            AssertGasConsumed(2032740);
+            AssertGasConsumed(2032500);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("20 "));
@@ -158,9 +158,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse(" 20 "));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("-9223372036854775809"));
-            AssertGasConsumed(2048100);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("9223372036854775808"));
-            AssertGasConsumed(2048100);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse(""));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestLongparse("abc"));
@@ -198,9 +198,9 @@ namespace Neo.Compiler.CSharp.UnitTests
         public void IntParse_Test()
         {
             Assert.AreEqual(new BigInteger(int.MinValue), Contract.TestIntparse("-2147483648"));
-            AssertGasConsumed(2032650);
+            AssertGasConsumed(2032500);
             Assert.AreEqual(new BigInteger(int.MaxValue), Contract.TestIntparse("2147483647"));
-            AssertGasConsumed(2032650);
+            AssertGasConsumed(2032500);
 
             //test backspace trip
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("20 "));
@@ -208,9 +208,9 @@ namespace Neo.Compiler.CSharp.UnitTests
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse(" 20 "));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("-2147483649"));
-            AssertGasConsumed(2048010);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("2147483648"));
-            AssertGasConsumed(2048010);
+            AssertGasConsumed(2047860);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse(""));
             AssertGasConsumed(2032230);
             Assert.ThrowsException<TestException>(() => Contract.TestIntparse("abc"));


### PR DESCRIPTION

Less opcodes and GAS implementation for `NumericParse`.